### PR TITLE
Add options to benchmarking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "dill",
     "multiprocess",
     "memray",
+    "code-meters",
+    "filelock>=3.12.0"
 ]
 
 [project.optional-dependencies]

--- a/src/cascade/cascade.py
+++ b/src/cascade/cascade.py
@@ -72,8 +72,21 @@ class Cascade:
             input = self._graph
         return self.executor.execute(input, report="report.html")
 
-    def benchmark(self, base_path: os.PathLike):
-        results, self._graph = profile(self._graph, base_path, self.executor)
+    def benchmark(
+        self,
+        base_path: os.PathLike,
+        memray_native_traces: bool = False,
+        memory: str = "memray",
+        duration: str = "meters",
+    ):
+        results, self._graph = profile(
+            self._graph,
+            base_path,
+            self.executor,
+            memray_native_traces,
+            memory,
+            duration,
+        )
         return results
 
     def __add__(self, other: "Cascade") -> "Cascade":

--- a/src/cascade/executors/dask.py
+++ b/src/cascade/executors/dask.py
@@ -110,7 +110,9 @@ def execute(
 
             for fut in seq:
                 if fut.status != "finished":
-                    print(f"Task {fut.key} failed with exception: {fut.exception()}")
+                    print(
+                        f"Task {fut.key}, completed with status {fut.status} and exception: {fut.exception()}"
+                    )
                     errored_tasks += 1
                 results[fut.key] = fut.result()
 

--- a/src/cascade/profiler.py
+++ b/src/cascade/profiler.py
@@ -1,18 +1,21 @@
 import functools
 import os
 import pathlib
+import re
 import warnings
 
+import filelock
 from memray import FileDestination, FileReader, Tracker
+from meters import metered
 
 from .executors.executor import Executor
 from .fluent import Node
 from .graph import Graph, Transformer
 from .schedulers.schedule import Schedule
-from .taskgraph import Task, TaskGraph
+from .taskgraph import Resources, Task, TaskGraph
 
 
-def _wrap_task(node: Node, path: pathlib.Path, native_traces: bool) -> Node:
+def _memray_wrap_task(node: Node, path: pathlib.Path, native_traces: bool) -> Node:
     assert isinstance(node.payload, tuple)
     assert len(node.payload) == 3
     func = node.payload[0]
@@ -29,14 +32,14 @@ def _wrap_task(node: Node, path: pathlib.Path, native_traces: bool) -> Node:
     return wrapped
 
 
-class _AddProfiler(Transformer):
+class _AddMemrayProfiler(Transformer):
     def __init__(self, base_path: pathlib.Path, native_traces: bool = False):
         self.base_path = base_path
         self.native_traces = native_traces
 
     def node(self, node: Node, **inputs: Node.Output) -> Node:
         path = self.base_path / (node.name + ".bin")
-        wrapped = _wrap_task(node, path, self.native_traces)
+        wrapped = _memray_wrap_task(node, path, self.native_traces)
         wrapped.inputs = inputs
         return wrapped
 
@@ -44,9 +47,13 @@ class _AddProfiler(Transformer):
         return graph.__class__(sinks)
 
 
-class _ReadProfiles(Transformer):
-    def __init__(self, base_path: pathlib.Path):
+class _ReadMemrayProfiles(Transformer):
+    def __init__(
+        self, base_path: pathlib.Path, memory: bool = True, duration: bool = True
+    ):
         self.base_path = base_path
+        self.memory = memory
+        self.duration = duration
 
     def node(self, node: Node, **inputs: Node.Output) -> Task:
         task = Task(node.name, node.outputs.copy(), node.payload, **inputs)
@@ -57,31 +64,158 @@ class _ReadProfiles(Transformer):
             warnings.warn(f"Could not read {path!r}: {e!s}", RuntimeWarning)
             return task
         with reader:
-            task.duration = (
-                reader.metadata.end_time - reader.metadata.start_time
-            ).total_seconds()
-            task.memory = reader.metadata.peak_memory / (1024**2)  # Convert to MiB
+            if self.duration:
+                task.duration = (
+                    reader.metadata.end_time - reader.metadata.start_time
+                ).total_seconds()
+            if self.memory:
+                task.memory = reader.metadata.peak_memory / (1024**2)  # Convert to MiB
         return task
 
     def graph(self, graph: Graph, sinks: list[Node]) -> Graph:
         return graph.__class__(sinks)
 
 
-def profile(
+def _meters_wrap_task(node: Node, path: str) -> Node:
+    assert isinstance(node.payload, tuple)
+    assert len(node.payload) == 3
+    func = node.payload[0]
+    name = node.name
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        meter, result = metered(name, return_meter=True)(func)(*args, **kwargs)
+        with filelock.FileLock(f"{path}.lock"):
+            with open(path, "a") as f:
+                f.write(f"{meter}\n")
+        return result
+
+    wrapped = node.copy()
+    wrapped.payload = (wrapper,) + node.payload[1:]
+    return wrapped
+
+
+class _AddMetersProfiler(Transformer):
+    def __init__(self, logfile: str):
+        self.logfile = logfile
+
+    def node(self, node: Node, **inputs: Node.Output) -> Node:
+        wrapped = _meters_wrap_task(node, self.logfile)
+        wrapped.inputs = inputs
+        return wrapped
+
+    def graph(self, graph: Graph, sinks: list[Node]) -> Graph:
+        return graph.__class__(sinks)
+
+
+def parse_metered_logfile(
+    logfile: str, memory: bool = True, duration: bool = True
+) -> dict[str, float]:
+    resources = {}
+    with open(logfile, "r") as file:
+        for line in file:
+            log_bytes = float(re.search("memory: (.+?) bytes", line).group(1))
+            log_time = float(re.search("wall time: (.+?) s", line).group(1))
+            resources[":".join(line.split(":")[0:2])] = Resources(
+                log_time, log_bytes / (1024**2)
+            )
+    return resources
+
+
+class _ReadMetersProfiles(Transformer):
+    def __init__(self, logfile: str, memory: bool = True, duration: bool = True):
+        self.resources = parse_metered_logfile(logfile, memory, duration)
+        self.memory = memory
+        self.duration = duration
+
+    def node(self, node: Node, **inputs: Node.Output) -> Task:
+        task = Task(node.name, node.outputs.copy(), node.payload, **inputs)
+        resources = self.resources[node.name]
+        if self.duration:
+            task.duration = resources.duration
+        if self.memory:
+            task.memory = resources.memory
+        return task
+
+    def graph(self, graph: Graph, sinks: list[Node]) -> Graph:
+        return graph.__class__(sinks)
+
+
+def memray_profile(
     graph: Graph | Schedule,
     base_path: os.PathLike,
     executor: Executor,
     native_traces: bool = False,
+    memory: bool = True,
+    duration: bool = True,
 ) -> tuple[object, Graph]:
     base_path = pathlib.Path(base_path)
     base_path.mkdir(parents=True, exist_ok=True)
     task_graph = TaskGraph(graph.sinks) if isinstance(graph, Schedule) else graph
-    wrapped_graph = _AddProfiler(base_path, native_traces).transform(task_graph)
+    wrapped_graph = _AddMemrayProfiler(base_path, native_traces).transform(task_graph)
     execution_graph = (
         Schedule(wrapped_graph, graph.context_graph, graph.task_allocation)
         if isinstance(graph, Schedule)
         else wrapped_graph
     )
     result = executor.execute(execution_graph)
-    annotated_graph = _ReadProfiles(base_path).transform(task_graph)
+    annotated_graph = _ReadMemrayProfiles(base_path, memory, duration).transform(
+        task_graph
+    )
     return result, annotated_graph
+
+
+def meters_profile(
+    graph: Graph | Schedule,
+    logfile: str,
+    executor: Executor,
+    memory: bool = True,
+    duration: bool = True,
+) -> tuple[object, Graph]:
+    if os.path.exists(logfile):
+        os.remove(logfile)
+    task_graph = TaskGraph(graph.sinks) if isinstance(graph, Schedule) else graph
+    wrapped_graph = _AddMetersProfiler(logfile).transform(task_graph)
+    execution_graph = (
+        Schedule(wrapped_graph, graph.context_graph, graph.task_allocation)
+        if isinstance(graph, Schedule)
+        else wrapped_graph
+    )
+    result = executor.execute(execution_graph)
+    annotated_graph = _ReadMetersProfiles(logfile, memory, duration).transform(
+        task_graph
+    )
+    return result, annotated_graph
+
+
+def profile(
+    graph: Graph | Schedule,
+    base_path: str,
+    executor: Executor,
+    memray_native_traces: bool = False,
+    memory: str = "memray",
+    duration: str = "meters",
+) -> tuple[object, Graph]:
+    if memory == duration == "memray":
+        return memray_profile(graph, base_path, executor, memray_native_traces)
+    if memory == duration == "meters":
+        return meters_profile(
+            graph,
+            f"{base_path}/meters_log.txt",
+            executor,
+        )
+    _, memray_graph = memray_profile(
+        graph,
+        base_path,
+        executor,
+        memray_native_traces,
+        memory=(memory == "memray"),
+        duration=(duration == "memray"),
+    )
+    return meters_profile(
+        memray_graph,
+        f"{base_path}/meters_log.txt",
+        executor,
+        memory=(memory == "meters"),
+        duration=(duration == "meters"),
+    )

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,18 +1,31 @@
 import pytest
 
 from cascade.executors.dask import DaskLocalExecutor
-from cascade.profiler import profile
+from cascade.profiler import memray_profile, meters_profile
 from cascade.schedulers.depthfirst import DepthFirstScheduler
 
 
 @pytest.mark.parametrize("schedule", [False, True])
-def test_profiler(tmpdir, task_graph, schedule):
+def test_memray_profiler(tmpdir, task_graph, schedule):
     executor = DaskLocalExecutor(n_workers=2)
     if schedule:
         task_graph = DepthFirstScheduler().schedule(
             task_graph, executor.create_context_graph()
         )
-    _, annotated_graph = profile(task_graph, tmpdir, executor)
+    _, annotated_graph = memray_profile(task_graph, tmpdir, executor)
+    nodes = list(annotated_graph.nodes())
+    assert not all([node.duration == 0 for node in nodes])
+    assert not all([node.memory == 0 for node in nodes])
+
+
+@pytest.mark.parametrize("schedule", [False, True])
+def test_meters_profiler(tmpdir, task_graph, schedule):
+    executor = DaskLocalExecutor(n_workers=2)
+    if schedule:
+        task_graph = DepthFirstScheduler().schedule(
+            task_graph, executor.create_context_graph()
+        )
+    _, annotated_graph = meters_profile(task_graph, f"{tmpdir}/meters_log", executor)
     nodes = list(annotated_graph.nodes())
     assert not all([node.duration == 0 for node in nodes])
     assert not all([node.memory == 0 for node in nodes])
@@ -20,5 +33,5 @@ def test_profiler(tmpdir, task_graph, schedule):
 
 def test_overwrite_existing_files(tmpdir, task_graph):
     executor = DaskLocalExecutor(n_workers=2)
-    profile(task_graph, tmpdir, executor)
-    profile(task_graph, tmpdir, executor)
+    memray_profile(task_graph, tmpdir, executor)
+    memray_profile(task_graph, tmpdir, executor)


### PR DESCRIPTION
- Make enabling native traces in memray optional, as it can result in a large overhead
- Options to use a different code-meters instead of memory for memory and task timings, or a combination of both. In the latter case, the task graph is executed twice.