### PR TITLE
[mypy] fix cascade.graph types

### DIFF
--- a/src/cascade/graph/deduplicate.py
+++ b/src/cascade/graph/deduplicate.py
@@ -1,6 +1,6 @@
-from typing import Callable
+from typing import Callable, cast
 
-from .graph import Graph, Node
+from .graph import Graph, Node, Sink
 from .transform import Transformer
 
 PredicateType = Callable[[Node, Node], bool]
@@ -49,7 +49,7 @@ class _DedupTransformer(Transformer):
             ref = self.__find_node(sink)
             assert ref is not None
             new_sinks.add(ref)
-        return Graph(list(new_sinks))
+        return Graph(cast(list[Sink], list(new_sinks)))
 
 
 def same_payload(a: Node, b: Node):

--- a/src/cascade/graph/export.py
+++ b/src/cascade/graph/export.py
@@ -60,17 +60,17 @@ def deserialise(data: dict, node_factory: NodeFactory = default_node_factory) ->
     bare `Source`, `Processor` and `Sink` objects, depending on the presence of
     inputs and outputs.
     """
-    deps = {}
-    for name, node in data.items():
-        deps[name] = []
-        for inp in node.get("inputs", {}).values():
-            if isinstance(inp, str):
-                deps[name].append(inp)
-            else:
-                deps[name].append(inp[0])
+    deps = {
+        name: [
+            inp if isinstance(inp, str) else inp[0]
+            for inp in node.get("inputs", {}).values()
+        ]
+        for name, node in data.items()
+    }
+
     ts = graphlib.TopologicalSorter(deps)
-    nodes = {}
-    sinks = []
+    nodes: dict[str, Any] = {}
+    sinks: list = []
     for name in ts.static_order():
         node_data = data[name]
         node_inputs = {}

--- a/src/cascade/graph/graph.py
+++ b/src/cascade/graph/graph.py
@@ -115,20 +115,21 @@ class Graph:
         The result is a dict where keys are the given node's input names, and
         values are node outputs, encoded as either the node itself (default
         output), or (parent, output name) tuples."""
-        pred = {}
-        for iname, isrc in node.inputs.items():
-            if isrc.name == Node.DEFAULT_OUTPUT:
-                pred[iname] = isrc.parent
-            else:
-                pred[iname] = (isrc.parent, isrc.name)
-        return pred
+        return {
+            iname: (
+                isrc.parent
+                if isrc.name == Node.DEFAULT_OUTPUT
+                else (isrc.parent, isrc.name)
+            )
+            for iname, isrc in node.inputs.items()
+        }
 
     def get_successors(self, node: Node) -> dict[str, list[tuple[Node, str]]]:
         """Get the successors (children) of a node
 
         The result is a dict where keys are the given node's output names, and
         values are lists of (child, input name) tuples."""
-        succ = {}
+        succ: dict[str, list[tuple[Node, str]]] = {}
         for other in self.nodes():
             for iname, isrc in other.inputs.items():
                 if isrc.parent is node:

--- a/src/cascade/graph/nodes.py
+++ b/src/cascade/graph/nodes.py
@@ -98,13 +98,13 @@ class Node:
     def _make_output(self, name: str) -> Output:
         return Node.Output(self, name)
 
-    def serialise(self) -> dict:
+    def serialise(self) -> dict[str, Any]:
         """Convert the node to a serialisable value
 
         If the payload object has a ``serialise`` method, it is called without
         arguments to get its serialised form, otherwise the payload is assumed
         to be serialisable as is."""
-        res = {}
+        res: dict[str, Any] = {}
         res["outputs"] = self.outputs.copy()
         res["inputs"] = {name: src.serialise() for name, src in self.inputs.items()}
         if self.payload is not None:

--- a/src/cascade/graph/rename.py
+++ b/src/cascade/graph/rename.py
@@ -1,9 +1,9 @@
 from functools import reduce
 from operator import add
-from typing import Callable
+from typing import Callable, cast
 
 from .graph import Graph
-from .nodes import Node
+from .nodes import Node, Sink
 from .transform import Transformer
 
 RenamerFunc = Callable[[str], str]
@@ -21,7 +21,7 @@ class _Renamer(Transformer):
         return n
 
     def graph(self, g: Graph, sinks: list[Node]) -> Graph:
-        return Graph(sinks)
+        return Graph(cast(list[Sink], sinks))
 
 
 def rename_nodes(func: RenamerFunc, graph: Graph) -> Graph:


### PR DESCRIPTION
Fixing types in the cascade.graph package, first of the multiple ones to follow

Two opinions:
 - we should get rid of the Source, Sink, Processor classes, and just retain them as factory methods / property checks of the Node class. It's really a dynamic property (as observed by the need to override the isinstance method), so it only confuses the type system
 - we should introduce more classes (ideally lightweight as dataclasses), eg to represent outputs like `str | tuple[str, Node.Output]`, or some of the `dict[str, ...]` which are likely to change over time and are currently used an many places -> danger.

Neither is about typing anymore :), so I'm not doing them until some consensus / quorum