### PR TITLE
[mypy] fix cascade.executor,scheduler types 

### DIFF
--- a/src/cascade/executors/dask_utils/daskcontextgraph.py
+++ b/src/cascade/executors/dask_utils/daskcontextgraph.py
@@ -11,6 +11,7 @@ from cascade.contextgraph import ContextGraph
 
 class NetworkBenchmark:
 
+    @staticmethod
     async def benchmark_send(target, size):
         comm = await connect(target)
         start = time.time()
@@ -18,6 +19,7 @@ class NetworkBenchmark:
         comm.close()
         return start
 
+    @staticmethod
     def register_handler(size):
         worker = get_worker()
         worker._benchmark_event = asyncio.Event()
@@ -28,6 +30,7 @@ class NetworkBenchmark:
 
         worker.handlers["on_benchmark"] = on_benchmark
 
+    @staticmethod
     async def benchmark_recv():
         worker = get_worker()
         await worker._benchmark_event.wait()
@@ -36,6 +39,7 @@ class NetworkBenchmark:
         del worker._benchmark_event
         return end
 
+    @staticmethod
     def run(dask_client, sender, receiver, size):
 
         reg = dask_client.submit(

--- a/src/cascade/executors/dask_utils/report.py
+++ b/src/cascade/executors/dask_utils/report.py
@@ -93,7 +93,7 @@ class TaskStream:
         duration_index = columns.index("duration")
         worker_thread_index = columns.index("worker_thread")
 
-        self._stream = {}
+        self._stream: dict[str, list["TaskStream.Task"]] = {}
         for index, worker in enumerate(key_items[columns.index("worker")][1]):
             self._stream.setdefault(worker, [])
             name = key_items[name_index][1][index]
@@ -143,7 +143,7 @@ class TaskStream:
     def task_info(
         self, exclude_transfer: bool = True
     ) -> dict[str, list["TaskStream.Task"]]:
-        tasks = {}
+        tasks: dict[str, list["TaskStream.Task"]] = {}
         for task_stats in self._stream.values():
             for task in task_stats:
                 if exclude_transfer and task.is_transfer():
@@ -178,7 +178,7 @@ class TaskStream:
         """
         worker_stats = {}
         for worker, tasks in self._stream.items():
-            idle = 0
+            idle = 0.0
             for index, current_info in enumerate(tasks):
 
                 if index == 0:
@@ -222,8 +222,8 @@ class TaskStream:
         """
         worker_stats = {}
         for worker, tasks in self._stream.items():
-            blocking_time = 0
-            total_time = 0
+            blocking_time = 0.0
+            total_time = 0.0
             for index, task in enumerate(tasks):
                 if task.is_transfer():
                     if self.is_enclosed(worker, task):

--- a/src/cascade/schedulers/schedule.py
+++ b/src/cascade/schedulers/schedule.py
@@ -1,7 +1,7 @@
-from typing import Iterator, cast
+from typing import Iterable, Iterator, cast
 
 from cascade.contextgraph import ContextGraph
-from cascade.graph import Graph, Node, Source, copy_graph
+from cascade.graph import Graph, Node, Sink, Source, copy_graph
 
 
 class Schedule(Graph):
@@ -43,13 +43,13 @@ class Schedule(Graph):
                 return processor
         raise RuntimeError(f"Task {task_name} not in schedule {self.task_allocation}")
 
-    def processors(self) -> Iterator[str]:
+    def processors(self) -> Iterable[str]:
         """
         Iterator over all processor names in the schedule
 
         Returns
         -------
-        Iterator[str]
+        Iterable[str]
         """
         return self.task_allocation.keys()
 
@@ -91,7 +91,7 @@ class Schedule(Graph):
                     while f"input{index}" in next_task.inputs:
                         index += 1
                     if current_task in new_graph.sinks:
-                        new_graph.sinks.remove(current_task)
+                        new_graph.sinks.remove(cast(Sink, current_task))
                         current_task.outputs = [Node.DEFAULT_OUTPUT]
                     next_task.inputs[f"input{index}"] = current_task.get_output()
                     # Check number of nodes as disconnected components may have been introduced
@@ -154,5 +154,5 @@ class Schedule(Graph):
         tasks = self.task_allocation[task_worker]
         previous = tasks.index(node.name) - 1
         if previous > 0:
-            predecessors["allocation"].append(self.get_node(tasks[next]))
+            predecessors["allocation"].append(self.get_node(tasks[next]))  # type: ignore # no idea what this should do
         return predecessors

--- a/src/cascade/taskgraph.py
+++ b/src/cascade/taskgraph.py
@@ -103,7 +103,7 @@ class TaskGraph(Graph):
             for input in node.inputs.values():
                 yield input.parent, node
 
-    def accumulated_duration(self, task: Task) -> float:
+    def accumulated_duration(self, task: Node) -> float:
         """
         Calculate the accumulated duration of a task, using the duration of all its
         predecessors.


### PR DESCRIPTION
Fixing cascade.executor,scheduler types

There are a few glitches which I just suppressed:
 - processor/communicator don't declare the `state` attribute, it's patched in there over time -- proper solution would require some refactoring to avoid circular imports and the like
 - at multiple places it seems only processor is supported, not communicator. We'll need to add some fine graining there
 - the distinction between task and node is at times blurry, I mostly just downcasted when encountered, probably fine
 - at places it seems that graph is expected -- not sure if schedule would be valid in that context or not

There are two things which I believe are genuine bugs, not just annotations:
1. NetworkBenchmark is lacking `@staticmethod`, I think it would crash at runtime due to `not instance of self: arg1`
2. `get_processor` was called on an instance of `Schedule`, but there's only `processor` method it seems to me. Could have been copypaste bug
so I fix both here