### PR TITLE
[mypy] fix types in backends

### DIFF
--- a/src/cascade/backends/__init__.py
+++ b/src/cascade/backends/__init__.py
@@ -1,5 +1,6 @@
 import functools
 import warnings
+from typing import Callable
 
 import xarray as xr
 
@@ -32,7 +33,7 @@ def array_module(*arrays):
     return backend
 
 
-def __getattr__(name: str) -> callable:
+def __getattr__(name: str) -> Callable:
     if not hasattr(Backend, name):
 
         def f(*args, **kwargs):
@@ -60,7 +61,7 @@ def num_args(expect: int, accept_nested: bool = True):
     accept_nested: bool, whether to unpack
     """
 
-    def decorator(func: callable) -> callable:
+    def decorator(func: Callable) -> Callable:
         @functools.wraps(func)
         def check_num_args(*args, **kwargs):
             if accept_nested and len(args) == 1:
@@ -75,14 +76,14 @@ def num_args(expect: int, accept_nested: bool = True):
     return decorator
 
 
-def batchable(func: callable) -> callable:
+def batchable(func: Callable) -> Callable:
     """
     Decorator to mark a function as batchable. A method is batchable if
     it can be computed sequentially trivially by applying the same function
     to each batch and to aggregate the batches. Examples of batchable
     functions are sum, prod, min and non-batchable are mean and std.
     """
-    func.batchable = True
+    func.batchable = True  # type: ignore # monkeypatching...
     return func
 
 

--- a/src/cascade/backends/xarray.py
+++ b/src/cascade/backends/xarray.py
@@ -3,8 +3,9 @@ import xarray as xr
 
 
 class XArrayBackend:
+    @staticmethod
     def multi_arg_function(
-        name: str, *arrays: list[xr.DataArray | xr.Dataset], **method_kwargs
+        name: str, *arrays: xr.DataArray | xr.Dataset, **method_kwargs
     ) -> xr.DataArray | xr.Dataset:
         """
         Apply named function on DataArrays or Datasets. If only a single
@@ -31,9 +32,10 @@ class XArrayBackend:
 
         return getattr(arg, name)(**method_kwargs)
 
+    @staticmethod
     def two_arg_function(
         name: str,
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         keep_attrs: bool | str = False,
         **method_kwargs,
     ) -> xr.DataArray | xr.Dataset:
@@ -58,50 +60,58 @@ class XArrayBackend:
         with xr.set_options(keep_attrs=keep_attrs):
             return getattr(np, name)(arrays[0], arrays[1], **method_kwargs)
 
+    @staticmethod
     def mean(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         **method_kwargs,
     ) -> xr.DataArray | xr.Dataset:
         return XArrayBackend.multi_arg_function("mean", *arrays, **method_kwargs)
 
+    @staticmethod
     def std(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         **method_kwargs,
     ) -> xr.DataArray | xr.Dataset:
         return XArrayBackend.multi_arg_function("std", *arrays, **method_kwargs)
 
+    @staticmethod
     def min(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         **method_kwargs,
     ) -> xr.DataArray | xr.Dataset:
         return XArrayBackend.multi_arg_function("min", *arrays, **method_kwargs)
 
+    @staticmethod
     def max(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         **method_kwargs,
     ) -> xr.DataArray | xr.Dataset:
         return XArrayBackend.multi_arg_function("max", *arrays, **method_kwargs)
 
+    @staticmethod
     def sum(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         **method_kwargs,
     ) -> xr.DataArray | xr.Dataset:
         return XArrayBackend.multi_arg_function("sum", *arrays, **method_kwargs)
 
+    @staticmethod
     def prod(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         **method_kwargs,
     ) -> xr.DataArray | xr.Dataset:
         return XArrayBackend.multi_arg_function("prod", *arrays, **method_kwargs)
 
+    @staticmethod
     def var(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         **method_kwargs,
     ) -> xr.DataArray | xr.Dataset:
         return XArrayBackend.multi_arg_function("var", *arrays, **method_kwargs)
 
+    @staticmethod
     def concat(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         dim: str,
         **method_kwargs: dict,
     ) -> xr.DataArray | xr.Dataset:
@@ -109,10 +119,11 @@ class XArrayBackend:
             raise ValueError(
                 "Concat must be used on existing dimensions only. Try stack instead."
             )
-        return xr.concat(arrays, dim=dim, **method_kwargs)
+        return xr.concat(arrays, dim=dim, **method_kwargs)  # type: ignore # xr/mypy dont coop
 
+    @staticmethod
     def stack(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         dim: str,
         axis: int | None = None,
         **method_kwargs: dict,
@@ -122,14 +133,15 @@ class XArrayBackend:
                 "Stack must be used on non-existing dimensions only. Try concat instead."
             )
 
-        ret = xr.concat(arrays, dim=dim, **method_kwargs)
+        ret = xr.concat(arrays, dim=dim, **method_kwargs)  # type: ignore # xr/mypy dont coop
         if axis is not None and axis != 0:
             dims = list(ret.sizes.keys())
             ret = ret.transpose(*dims[1:axis], dim, *dims[axis:])
         return ret
 
+    @staticmethod
     def add(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         keep_attrs: bool | str = False,
         **method_kwargs,
     ):
@@ -137,8 +149,9 @@ class XArrayBackend:
             "add", *arrays, keep_attrs=keep_attrs, **method_kwargs
         )
 
+    @staticmethod
     def subtract(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         keep_attrs: bool | str = False,
         **method_kwargs,
     ):
@@ -146,8 +159,9 @@ class XArrayBackend:
             "subtract", *arrays, keep_attrs=keep_attrs, **method_kwargs
         )
 
+    @staticmethod
     def multiply(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         keep_attrs: bool | str = False,
         **method_kwargs,
     ):
@@ -155,8 +169,9 @@ class XArrayBackend:
             "multiply", *arrays, keep_attrs=keep_attrs, **method_kwargs
         )
 
+    @staticmethod
     def pow(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         keep_attrs: bool | str = False,
         **method_kwargs,
     ):
@@ -164,8 +179,9 @@ class XArrayBackend:
             "power", *arrays, keep_attrs=keep_attrs, **method_kwargs
         )
 
+    @staticmethod
     def divide(
-        *arrays: list[xr.DataArray | xr.Dataset],
+        *arrays: xr.DataArray | xr.Dataset,
         keep_attrs: bool | str = False,
         **method_kwargs,
     ):
@@ -173,6 +189,7 @@ class XArrayBackend:
             "divide", *arrays, keep_attrs=keep_attrs, **method_kwargs
         )
 
+    @staticmethod
     def take(
         array,
         indices,


### PR DESCRIPTION
Fixing types in backends, mostly caused by missing `@staticmethod` decorator (which would cause a runtime error) and wrong annotation on the varargs