### PR TITLE
Fix failing test and pep8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,10 @@
 [flake8]
-max-line-length = 120
-
-# E731: lambdas are legit, E741: nothing wrong with `l` variable name, E203: whitespace before : fights with black
-extend-ignore = E731, E741, E203
+max-line-length = 210
+# E731: lambdas are legit
+# E741: nothing wrong with `l` variable name
+# E203: whitespace before : fights with black
+# E722: bare except is ok
+# E266: ## is ok
+# E228: no ws around modulo is ok
+extend-ignore = E731, E741, E203, E722, E266, E228
+exclude = ["docs"] # zounds! Doesnt seem to work at all, even as cli `--exclude`... its even claimed to be the default settings

--- a/docs/benchmarking/run1/analysis.py
+++ b/docs/benchmarking/run1/analysis.py
@@ -65,7 +65,7 @@ def fixMode(df):
 
 def ensureColumns(df, columns):
     for column in columns:
-        if not column in df.columns:
+        if column not in df.columns:
             df = df.assign(**{column: np.nan})
     return df
 
@@ -206,7 +206,7 @@ taskCompareF1F4.sort_values(by="dif")[-10:]
 # ## Task Takeaways:
 # * There is a big difference between f1 and f4 in pure runtimes of tasks, 17e9 vs 28e9, suggesting some contention happening
 #   * Comparing individual tasks, we see only small relative/abs differences in concats and disk-accessing retrieves, but big in compute intensive sot or efi, suggesting there is some CPU contention
-#   * The difference is also visible for m scenarios -- m1_4 is expectedly like f4, but m2_2 and m4_1 are 20e9 being thus closer to f1. It could be that there is less overlap in those scenarios, as the scheduling is more gappy due to interleaved http comms?
+#   * The difference is also visible for m scenarios -- m1_4 is expectedly like f4, but m2_2 and m4_1 are 20e9 being thus closer to f1. It could be that there is less overlap in those scenarios, as the scheduling is more gappy due to interleaved http comms? # noqa:E501
 # * Queue delay exhibits no real difference over f/m scenarios
 # * Comm delays are 1e7 for f scenarios, 1e8 for m4_1, and 1e9 for m2_2 and m1_4 -- m4_1 being midway looks more like a glitch
 # * m2_2 is showing a slight disbalance of one worker being less utilised than the others, all others look balanced

--- a/docs/benchmarking/run2/analysis.py
+++ b/docs/benchmarking/run2/analysis.py
@@ -2,11 +2,11 @@
 # coding: utf-8
 
 # ### Novel observations
-# * Controller reports available as well, showing that a lot of time is spent in the `act` phase of sending (sequentially!) the commands to the hosts. I realize now that the `act` is blocking, so the transmit are effectively serialized at the controller!
-# * Redundant local transports mostly vanished -- there are times when the planner decides in a single step that a dataset is needed at two workers on a host so issues two transmit commands. We could thus replace the redundant sent by idle time, to save network etc. It happens only 3 times out of 55 in the 2,2 scenario
+# * Controller reports available as well, showing that a lot of time is spent in the `act` phase of sending (sequentially!) the commands to the hosts. I realize now that the `act` is blocking, so the transmit are effectively serialized at the controller! # noqa: E501
+# * Redundant local transports mostly vanished -- there are times when the planner decides in a single step that a dataset is needed at two workers on a host so issues two transmit commands. We could thus replace the redundant sent by idle time, to save network etc. It happens only 3 times out of 55 in the 2,2 scenario # noqa: E501
 #
 # The `lA` logs here represent the code/measurements _before_ transmits were reworked to happen async, the `lB` the _after_.
-# The `act` phase duration has shortened considerably, but the overall duration has increased -- possibly due to increased contention, due to introduction of locks, etc. But the overall amount of transmits has stayed roughly the same (even dripped a tiny bit). In particular, duration of the longest transmit has increased 4 times in the 2-host 2-worker scenario, **from 1 second to 4 seconds**. During that time, both sides of the transmit were doing other things as well (transmitting other datasets, computing tasks, etc).
+# The `act` phase duration has shortened considerably, but the overall duration has increased -- possibly due to increased contention, due to introduction of locks, etc. But the overall amount of transmits has stayed roughly the same (even dripped a tiny bit). In particular, duration of the longest transmit has increased 4 times in the 2-host 2-worker scenario, **from 1 second to 4 seconds**. During that time, both sides of the transmit were doing other things as well (transmitting other datasets, computing tasks, etc). # noqa: E501
 #
 # ### Next steps
 # * Rework the client to send asynchronously
@@ -76,7 +76,7 @@ def fmn(n):  # TODO set some central
 
 def ensureColumns(df, columns):
     for column in columns:
-        if not column in df.columns:
+        if column not in df.columns:
             df = df.assign(**{column: np.nan})
     return df
 

--- a/docs/benchmarking/run3/prototype_allocationviz.py
+++ b/docs/benchmarking/run3/prototype_allocationviz.py
@@ -27,7 +27,7 @@ def add_inputs(g, l: str):
 
 
 # cat l1ctrl.txt  | grep 'action=taskPlanned' | sed 's/.*task=\([^;]*\).*worker=\([^;]*\).*/\1;\2/' > g1_task_host.csv
-# cat l1*.txt  | grep 'about to start subgraph' | sed 's/.*name=.\(.*\).,.*wirings=\[\([^]]*\)\].*/\1;\2/' | sed "s/'Any')/@/g" | sed "s/@, /@;/g" | sed "s/Variable[^@]*task='\([^']*\)'[^@]*@/\1/g" > g1_task_inputs.csv
+# cat l1*.txt  | grep 'about to start subgraph' | sed 's/.*name=.\(.*\).,.*wirings=\[\([^]]*\)\].*/\1;\2/' | sed "s/'Any')/@/g" | sed "s/@, /@;/g" | sed "s/Variable[^@]*task='\([^']*\)'[^@]*@/\1/g" > g1_task_inputs.csv # noqa: E501
 
 
 def vizLogs(pref: str):

--- a/docs/benchmarking/run3/tasklanes.py
+++ b/docs/benchmarking/run3/tasklanes.py
@@ -4,7 +4,6 @@
 # In[1]:
 
 
-import pandas as pd
 from bokeh.io import curdoc, output_notebook, show
 from bokeh.models import ColumnDataSource, Grid, HBar, LinearAxis, Plot, VSpan
 

--- a/src/cascade/benchmarks/__main__.py
+++ b/src/cascade/benchmarks/__main__.py
@@ -90,7 +90,6 @@ def run_locally(job: JobInstance, hosts: int, workers: int, portBase: int = 1234
     c = f"tcp://localhost:{portBase}"
     m = f"tcp://localhost:{portBase+1}"
     ps = []
-    spawn = perf_counter_ns()
     for i, executor in enumerate(range(hosts)):
         if i == 0:
             try:
@@ -123,7 +122,7 @@ def run_locally(job: JobInstance, hosts: int, workers: int, portBase: int = 1234
         print(
             f"compute took {(end-start)/1e9:.3f}s, including startup {(end-launch)/1e9:.3f}s"
         )
-    except Exception as e:
+    except:
         for p in ps:
             if p.is_alive():
                 callback(m, ExecutorShutdown())

--- a/src/cascade/benchmarks/anemoi.py
+++ b/src/cascade/benchmarks/anemoi.py
@@ -1,5 +1,4 @@
 from cascade import Cascade
-from cascade.graph import serialise
 
 
 def get_graph(lead_time, ensemble_members, CKPT=None, date="2024-12-02T00:00"):

--- a/src/cascade/benchmarks/job1.py
+++ b/src/cascade/benchmarks/job1.py
@@ -7,17 +7,12 @@ Controlled by env var params: JOB1_{DATA_ROOT, GRID, ...}, see below
 """
 
 import os
-from pathlib import Path
 
 import earthkit.data
 from ppcascade.fluent import from_source
-from ppcascade.utils.request import Request
 from ppcascade.utils.window import Range
 
-from cascade.cascade import Cascade
 from cascade.fluent import Payload
-from cascade.fluent import from_source as c_from_source
-from cascade.graph import Graph, deduplicate_nodes
 
 # *** PARAMS ***
 

--- a/src/cascade/benchmarks/plotting.py
+++ b/src/cascade/benchmarks/plotting.py
@@ -6,7 +6,6 @@ Run `dirTaskLane(<path-to-your-logs-directory>)`
 
 import os
 
-import pandas as pd
 from bokeh.io import curdoc, output_notebook, show
 from bokeh.models import ColumnDataSource, Grid, HBar, LinearAxis, Plot, VSpan
 

--- a/src/cascade/benchmarks/reporting.py
+++ b/src/cascade/benchmarks/reporting.py
@@ -25,17 +25,6 @@ def taskDurations(tasks: pd.DataFrame) -> pd.DataFrame:
     durations = tasks.pivot(index=["task", "worker"], columns=["action"], values=["at"])
     durations = durations.reset_index()
     durations.columns = ["task", "worker"] + [e[1] for e in durations.columns[2:]]  # type: ignore
-    planned = "task_planned"  # controller planned the task to run at a worker
-    enqueued = (
-        "task_enqueued"  # worker received the task and put into its internal queue
-    )
-    started = "task_started"  # a process executing this task is ready and imported
-    loaded = "task_loaded"  # all task's inputs are in process memory and deserialized
-    computed = "task_computed"  # the task callable itself has finished
-    published = (
-        "task_published"  # the results have been serialized and put to shared memory
-    )
-    completed = "task_completed"  # the controller marked this task as completed
 
     durations = durations.assign(total_e2e=durations.completed - durations.planned)
     durations = durations.assign(total_worker=durations.published - durations.enqueued)

--- a/src/cascade/controller/act.py
+++ b/src/cascade/controller/act.py
@@ -3,14 +3,12 @@ Implements the invocation of Bridge/Executor methods given a sequence of Actions
 """
 
 import logging
-from typing import Iterator
 
 from cascade.controller.notify import consider_purge
 from cascade.executor.bridge import Bridge
 from cascade.executor.msg import TaskSequence
-from cascade.low.func import assert_never
 from cascade.low.tracing import TaskLifecycle, TransmitLifecycle, mark
-from cascade.scheduler.core import Assignment, DatasetStatus, State, TaskStatus
+from cascade.scheduler.core import Assignment, State
 
 logger = logging.getLogger(__name__)
 

--- a/src/cascade/controller/impl.py
+++ b/src/cascade/controller/impl.py
@@ -1,21 +1,15 @@
 import logging
-from time import perf_counter_ns
-from typing import Any
 
 import cascade.executor.serde as serde
 from cascade.controller.act import act, flush_queues
 from cascade.controller.notify import notify
 from cascade.executor.bridge import Bridge, Event
-from cascade.low.core import DatasetId, Environment, JobInstance, TaskId, WorkerId
-from cascade.low.func import assert_never
+from cascade.low.core import DatasetId, JobInstance
 from cascade.low.tracing import ControllerPhases, Microtrace, label, mark, timer
-from cascade.low.views import dependants, param_source
 from cascade.scheduler.api import assign, initialize, plan
 from cascade.scheduler.core import (
-    Assignment,
     Preschedule,
     State,
-    TaskStatus,
     has_awaitable,
     has_computable,
 )
@@ -55,7 +49,7 @@ def run(
 
             mark({"action": ControllerPhases.wait})
             if has_awaitable(state):
-                logger.debug(f"about to await bridge")
+                logger.debug("about to await bridge")
                 events = timer(bridge.recv_events, Microtrace.ctrl_wait)()
                 timer(notify, Microtrace.ctrl_notify)(state, job, events)
                 logger.debug(f"received {len(events)} events")
@@ -64,6 +58,6 @@ def run(
         raise
     finally:
         mark({"action": ControllerPhases.shutdown})
-        logger.debug(f"shutting down executors")
+        logger.debug("shutting down executors")
         bridge.shutdown()
     return state

--- a/src/cascade/controller/notify.py
+++ b/src/cascade/controller/notify.py
@@ -5,15 +5,13 @@ Implements the mutation of State after Executors have reported some Events
 # NOTE currently the implementation is mutating, but we may replace with pyrsistent etc.
 # Thus the caller always *must* use the return value and cease using the input.
 
-import base64
 import logging
 from typing import Iterable
 
 import cascade.executor.serde as serde
 from cascade.executor.bridge import Event
-from cascade.executor.comms import callback
 from cascade.executor.msg import DatasetPublished, DatasetTransmitPayload
-from cascade.low.core import DatasetId, HostId, JobInstance, TaskId, WorkerId
+from cascade.low.core import DatasetId, HostId, JobInstance, WorkerId
 from cascade.low.func import assert_never
 from cascade.low.tracing import TaskLifecycle, TransmitLifecycle, mark
 from cascade.scheduler.assign import set_worker2task_overhead

--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -13,7 +13,6 @@ import zmq
 from cascade.executor.msg import (
     Ack,
     BackboneAddress,
-    DatasetTransmitCommand,
     DatasetTransmitPayload,
     DatasetTransmitPayloadHeader,
     Message,
@@ -114,12 +113,12 @@ class Listener:
             # TODO move parts of this to serde, including corresponding `send_data` and `ReliableSender.send` parts
             data = ready[0][0].recv_multipart()
             if len(data) == 0:
-                raise ValueError(f"unexpected empty message")
+                raise ValueError("unexpected empty message")
             m0 = des_message(data[0])
             if isinstance(m0, Syn):
                 callback(m0.addr, Ack(idx=m0.idx))
                 if len(data) == 1:
-                    raise ValueError(f"unexpected message with Syn only")
+                    raise ValueError("unexpected message with Syn only")
                 if m0 in self.acked:
                     logger.warning(
                         f"received already-acked {m0}, assuming retry, dropping message"
@@ -140,7 +139,7 @@ class Listener:
                 return m0
             m1 = des_message(data[1])
             if isinstance(m1, Syn):
-                raise ValueError(f"unexpected double Syn")
+                raise ValueError("unexpected double Syn")
             elif isinstance(m1, DatasetTransmitPayloadHeader):
                 if len(data) != 3:
                     raise ValueError(

--- a/src/cascade/executor/data_server.py
+++ b/src/cascade/executor/data_server.py
@@ -101,7 +101,7 @@ class DataServer:
             except shm_client.ConflictError as e:
                 # NOTE this branch is for situations where the controller issued redundantly two transmits
                 logger.warning(
-                    f"store of {payload.header.ds} failed, presumably already computed; continuing"
+                    f"store of {payload.header.ds} failed with {e}, presumably already computed; continuing"
                 )
                 mark(
                     {
@@ -287,7 +287,7 @@ class DataServer:
                         fut = self.ds_proc_tp.submit(self.send_payload, command)
                         self.futs_in_progress[command] = fut
                         self.awaiting_confirmation[e] = (command, -1)
-            except Exception as e:
+            except:
                 # NOTE do something more clean here? Not critical since we monitor this process anyway
                 raise
 

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -14,7 +14,7 @@ import os
 import socket
 from multiprocessing import get_context
 from multiprocessing.process import BaseProcess
-from typing import Iterable, cast
+from typing import Iterable
 
 import cascade.shm.api as shm_api
 import cascade.shm.client as shm_client
@@ -41,10 +41,8 @@ from cascade.executor.msg import (
     WorkerShutdown,
 )
 from cascade.executor.runner.entrypoint import RunnerContext, entrypoint, worker_address
-from cascade.executor.runner.memory import ds2shmid
-from cascade.low.core import DatasetId, HostId, JobInstance, TaskId, WorkerId
-from cascade.low.func import assert_never
-from cascade.low.tracing import Microtrace, TaskLifecycle, label, mark, timer
+from cascade.low.core import DatasetId, HostId, JobInstance, WorkerId
+from cascade.low.tracing import TaskLifecycle, mark
 from cascade.low.views import param_source
 from cascade.shm.server import entrypoint as shm_server
 
@@ -202,7 +200,7 @@ class Executor:
             self.start_workers(self.workers.keys())
             logger.debug(f"about to send register message from {self.host}")
             self.to_controller(self.registration)
-        except Exception as e:
+        except:
             logger.exception("failed during register")
             self.terminate()
         # NOTE we don't mind this registration message being lost -- if that happens, we send it
@@ -261,7 +259,7 @@ class Executor:
                     elif isinstance(m, Ack):
                         self.sender.ack(m.idx)
                     elif isinstance(m, DatasetPurge):
-                        if not m.ds in self.datasets:
+                        if m.ds not in self.datasets:
                             logger.warning(f"unexpected purge of {m.ds}")
                         else:
                             for worker in self.workers:

--- a/src/cascade/executor/msg.py
+++ b/src/cascade/executor/msg.py
@@ -12,7 +12,7 @@ as externally to eg Controller or Runner
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
-from cascade.low.core import DatasetId, HostId, TaskId, TaskInstance, WorkerId
+from cascade.low.core import DatasetId, HostId, TaskId, WorkerId
 
 ## Meta
 

--- a/src/cascade/executor/runner/memory.py
+++ b/src/cascade/executor/runner/memory.py
@@ -12,7 +12,7 @@ import cascade.executor.serde as serde
 import cascade.shm.client as shm_client
 from cascade.executor.comms import callback
 from cascade.executor.msg import BackboneAddress, DatasetPublished
-from cascade.low.core import NO_OUTPUT_PLACEHOLDER, DatasetId, TaskId, WorkerId
+from cascade.low.core import NO_OUTPUT_PLACEHOLDER, DatasetId, WorkerId
 from cascade.low.tracing import Microtrace, timer
 
 logger = logging.getLogger(__name__)
@@ -78,7 +78,7 @@ class Memory(AbstractContextManager):
 
     def pop(self, ds: DatasetId) -> None:
         if ds in self.local:
-            val = self.local.pop(ds)
+            val = self.local.pop(ds)  # noqa: F841
             del val
         if ds in self.bufs:
             buf = self.bufs.pop(ds)

--- a/src/cascade/executor/runner/runner.py
+++ b/src/cascade/executor/runner/runner.py
@@ -4,14 +4,12 @@ Thin wrapper over a single Task/Callable
 Just io handling (ie, using Memory api), tracing and callable invocation
 """
 
-import importlib
 import logging
 from dataclasses import dataclass
 from time import perf_counter_ns
 from typing import Any, Callable
 
-from cascade.executor.comms import callback
-from cascade.executor.msg import BackboneAddress, TaskSequence
+from cascade.executor.msg import BackboneAddress
 from cascade.executor.runner.memory import Memory
 from cascade.low.core import DatasetId, TaskDefinition, TaskId, TaskInstance
 from cascade.low.func import assert_iter_empty, assert_never, ensure, resolve_callable
@@ -99,10 +97,10 @@ def run(taskId: TaskId, executionContext: ExecutionContext, memory: Memory) -> N
                 outputId in executionContext.publish,
             )
         if not assert_iter_empty(outputsI):
-            raise ValueError(f"schema declared more outputs than there were results")
+            raise ValueError("schema declared more outputs than there were results")
         if not assert_iter_empty(result):
             raise ValueError(
-                f"function produced more results than there were schema outputs"
+                "function produced more results than there were schema outputs"
             )
         # in principle, we should mark computed & calc run_end prior to ultimate publish, but imo not worth it
         mark({"task": taskId, "action": TaskLifecycle.computed})

--- a/src/cascade/executor/serde.py
+++ b/src/cascade/executor/serde.py
@@ -7,14 +7,8 @@ from typing import Any, Callable, Type
 
 import cloudpickle
 
-from cascade.executor.msg import (
-    DatasetTransmitCommand,
-    DatasetTransmitPayload,
-    DatasetTransmitPayloadHeader,
-    Message,
-)
-from cascade.low.core import DatasetId
-from cascade.low.func import assert_never, resolve_callable
+from cascade.executor.msg import Message
+from cascade.low.func import resolve_callable
 
 # NOTE for start, we simply pickle the msg classes -- this makes it possible
 # to serialize eg `set`s (unlike `msgpack` or json-based serializers) while

--- a/src/cascade/low/core.py
+++ b/src/cascade/low/core.py
@@ -6,11 +6,10 @@ import re
 from base64 import b64decode, b64encode
 from collections import defaultdict
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any, Callable, Optional, Type, cast
 
 import cloudpickle
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 from typing_extensions import Self
 
 # NOTE it would be tempting to dict[str|int, ...] at places where we deal with kwargs/args, instead of

--- a/src/cascade/low/func.py
+++ b/src/cascade/low/func.py
@@ -4,7 +4,6 @@ Things.
 
 import importlib
 from abc import abstractmethod
-from time import perf_counter_ns
 from typing import (
     Any,
     Callable,
@@ -127,7 +126,7 @@ def pyd_replace(model: B, **kwargs) -> B:
 
 def assert_iter_empty(i: Iterator) -> bool:
     try:
-        v = next(i)
+        _ = next(i)
     except StopIteration:
         return True
     else:

--- a/src/cascade/low/into.py
+++ b/src/cascade/low/into.py
@@ -7,7 +7,6 @@ from typing import Any, Callable, cast
 
 from cascade.graph import Graph, Node, serialise
 from cascade.low.core import (
-    NO_OUTPUT_PLACEHOLDER,
     DatasetId,
     JobInstance,
     Task2TaskEdge,

--- a/src/cascade/low/tracing.py
+++ b/src/cascade/low/tracing.py
@@ -6,13 +6,9 @@ level since this is assumed to be high level tracing
 """
 
 import logging
-import os
 from enum import Enum
 from functools import wraps
 from time import perf_counter_ns, time_ns
-from typing import Literal
-
-from cascade.low.func import assert_never
 
 d: dict[str, str] = {}
 

--- a/src/cascade/scheduler/assign.py
+++ b/src/cascade/scheduler/assign.py
@@ -22,8 +22,6 @@ from cascade.scheduler.core import (
     ComponentId,
     DatasetStatus,
     State,
-    Task2TaskDistance,
-    Worker2TaskDistance,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/cascade/scheduler/core.py
+++ b/src/cascade/scheduler/core.py
@@ -1,5 +1,4 @@
-from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
@@ -48,9 +47,8 @@ class ComponentSchedule:
     # tasks that are either computable or that are among outputs of currently prepared tasks (as those
     # could become computable without any further planning)
     worker2task_distance: Worker2TaskDistance
-    worker2task_values: set[
-        TaskId
-    ]  # eligible values -- a cached value. Used when migrating new workers to the component, inserted whenever a parent of this task gets `preparing`, removed when this task is made computable
+    # eligible values -- a cached value. Used when migrating new workers to the component, inserted whenever a parent of this task gets `preparing`, removed when this task is made computable
+    worker2task_values: set[TaskId]
 
 
 class DatasetStatus(int, Enum):

--- a/src/cascade/scheduler/graph.py
+++ b/src/cascade/scheduler/graph.py
@@ -16,7 +16,6 @@ from cascade.scheduler.core import (
     ComponentCore,
     Preschedule,
     Task2TaskDistance,
-    TaskValue,
 )
 
 logger = logging.getLogger(__name__)
@@ -31,7 +30,7 @@ def nearest_common_descendant(
     try:
         import coptrs
 
-        logger.debug(f"using coptrs library, watch out for the blazing speed")
+        logger.debug("using coptrs library, watch out for the blazing speed")
         m = {}
         d1 = {}
         d2 = {}
@@ -54,7 +53,7 @@ def nearest_common_descendant(
                 ncd[d2[ai]] = {}
             ncd[d2[ai]][d2[bi]] = e
     except ImportError:
-        logger.warning(f"coptrs not found, falling back to python")
+        logger.warning("coptrs not found, falling back to python")
         for a in nodes:
             ncd[a] = {}
             for b in nodes:

--- a/tests/controller/test_run.py
+++ b/tests/controller/test_run.py
@@ -12,12 +12,7 @@ from cascade.executor.config import logging_config
 from cascade.executor.executor import Executor
 from cascade.executor.msg import BackboneAddress, ExecutorShutdown
 from cascade.low.builders import JobBuilder, TaskBuilder
-from cascade.low.core import (
-    Environment,
-    JobExecutionRecord,
-    JobInstance,
-    TaskExecutionRecord,
-)
+from cascade.low.core import JobInstance
 from cascade.scheduler.graph import precompute
 
 
@@ -51,7 +46,7 @@ def run_cluster(job: JobInstance, portBase: int, executors: int):
     try:
         b = Bridge(c, executors)
         run(job, b, preschedule)
-    except Exception as e:
+    except:
         for p in ps:
             if p.is_alive():
                 callback(m, ExecutorShutdown())

--- a/tests/executor/test_executor.py
+++ b/tests/executor/test_executor.py
@@ -8,7 +8,6 @@ from logging.config import dictConfig
 from multiprocessing import Process
 
 import numpy as np
-import pytest
 
 import cascade.executor.serde as serde
 from cascade.executor.comms import Listener, callback, send_data
@@ -194,7 +193,7 @@ def test_executor():
         ms = l.recv_messages()
         assert ms == [ExecutorExit(host="test_executor")]
         p.join()
-    except Exception as e:
+    except:
         if p.is_alive():
             callback(m1, ExecutorShutdown())
             import time

--- a/tests/executor/test_runner.py
+++ b/tests/executor/test_runner.py
@@ -2,8 +2,6 @@
 Tests running a Callable in the same process
 """
 
-import pytest
-
 import cascade.executor.runner.entrypoint as entrypoint
 import cascade.executor.runner.memory as memory
 import cascade.executor.serde as serde

--- a/tests/scheduler/test_graph.py
+++ b/tests/scheduler/test_graph.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 
 from cascade.low.core import TaskId
-from cascade.scheduler.core import Preschedule, Task2TaskDistance, TaskValue
 from cascade.scheduler.graph import decompose, enrich
 
 


### PR DESCRIPTION
Continues the previous PR to fix QA

note: ideally we switch to `ruff` (faster, can be configured via pyproject.toml, less discrepancies between versions, actually respects `exclude`, ...) and `precommit` (humans should not run this by hand, this is too nineties)