### PR TITLE
[gateway] allow custom jobs

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
 set dotenv-path := ".env"
 
 val:
-	mypy src/cascade/low src/cascade/scheduler src/cascade/controller src/cascade/executor --ignore-missing-imports
+	mypy src/cascade/low src/cascade/scheduler src/cascade/controller src/cascade/executor src/cascade/gateway src/cascade/benchmarks --ignore-missing-imports
 	mypy tests --ignore-missing-imports
 	pytest tests
 

--- a/scripts/slurm_entrypoint.sh
+++ b/scripts/slurm_entrypoint.sh
@@ -31,7 +31,10 @@ else
         echo "WORKER $SLURM_PROCID believes it can use $CASCADE_GPU_COUNT gpus with impunity"
         EXTRA_ARGS=""
 fi
+if [ -n "$JOB" ] ; then EXTRA_ARGS="$EXTRA_ARGS --job $JOB" ;
+elif [ -n "$INSTANCE" ]; then EXTRA_ARGS="$EXTRA_ARGS --instance $INSTANCE" ;
+else echo "neither job nor instance"; exit 1 ; fi
 
 # TODO check procid == 0 <-> nodelist head -n 1
-python -m cascade.benchmarks dist --job $JOB --idx $SLURM_PROCID $EXTRA_ARGS --controller-url $CONTROLLER_URL --hosts $EXECUTOR_HOSTS --workers-per-host $WORKERS_PER_HOST --shm-vol-gb $SHM_VOL_GB 2>&1 | tee $LOGDIR
+python -m cascade.benchmarks dist --idx $SLURM_PROCID $EXTRA_ARGS --controller-url $CONTROLLER_URL --hosts $EXECUTOR_HOSTS --workers-per-host $WORKERS_PER_HOST --shm-vol-gb $SHM_VOL_GB 2>&1 | tee $LOGDIR
 # *** ------- ***

--- a/src/cascade/benchmarks/plotting.py
+++ b/src/cascade/benchmarks/plotting.py
@@ -1,5 +1,4 @@
-"""
-Intended to be run inside a jupyter notebook
+"""Intended to be run inside a jupyter notebook
 
 Run `dirTaskLane(<path-to-your-logs-directory>)`
 """
@@ -108,8 +107,8 @@ def plotTaskLane(
     yaxis = LinearAxis()
     plot.add_layout(yaxis, "left")
 
-    plot.add_layout(Grid(dimension=0, ticker=xaxis.ticker))
-    plot.add_layout(Grid(dimension=1, ticker=yaxis.ticker))
+    plot.add_layout(Grid(dimension=0, ticker=xaxis.ticker))  # type: ignore
+    plot.add_layout(Grid(dimension=1, ticker=yaxis.ticker))  # type: ignore
 
     curdoc().add_root(plot)
 

--- a/src/cascade/controller/impl.py
+++ b/src/cascade/controller/impl.py
@@ -5,7 +5,7 @@ from cascade.controller.act import act, flush_queues
 from cascade.controller.notify import notify
 from cascade.controller.report import Reporter
 from cascade.executor.bridge import Bridge, Event
-from cascade.low.core import DatasetId, JobInstance
+from cascade.low.core import DatasetId, JobInstance, type_dec
 from cascade.low.tracing import ControllerPhases, Microtrace, label, mark, timer
 from cascade.scheduler.api import assign, initialize, plan
 from cascade.scheduler.core import Preschedule, State, has_awaitable, has_computable
@@ -27,8 +27,8 @@ def run(
     state = timer(initialize, Microtrace.ctrl_init)(env, preschedule, outputs)
     label("host", "controller")
     events: list[Event] = []
-    for serdeType, (serdeSer, serdeDes) in job.serdes.items():
-        serde.SerdeRegistry.register(serdeType, serdeSer, serdeDes)
+    for serdeTypeEnc, (serdeSer, serdeDes) in job.serdes.items():
+        serde.SerdeRegistry.register(type_dec(serdeTypeEnc), serdeSer, serdeDes)
     reporter = Reporter(report_address)
 
     try:

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -1,6 +1,4 @@
-"""
-The entrypoint itself
-"""
+"""The entrypoint itself"""
 
 import logging
 import logging.config
@@ -24,7 +22,7 @@ from cascade.executor.msg import (
 from cascade.executor.runner.memory import Memory
 from cascade.executor.runner.packages import PackagesEnv
 from cascade.executor.runner.runner import ExecutionContext, run
-from cascade.low.core import DatasetId, JobInstance, TaskId, WorkerId
+from cascade.low.core import DatasetId, JobInstance, TaskId, WorkerId, type_dec
 from cascade.low.tracing import label
 
 logger = logging.getLogger(__name__)
@@ -101,8 +99,8 @@ def entrypoint(runnerContext: RunnerContext):
         # NOTE check any(task.definition.needs_gpu) anywhere?
         # TODO configure OMP_NUM_THREADS, blas, mkl, etc -- not clear how tho
 
-        for serdeType, (serdeSer, serdeDes) in runnerContext.job.serdes.items():
-            serde.SerdeRegistry.register(serdeType, serdeSer, serdeDes)
+        for serdeTypeEnc, (serdeSer, serdeDes) in runnerContext.job.serdes.items():
+            serde.SerdeRegistry.register(type_dec(serdeTypeEnc), serdeSer, serdeDes)
 
         availab_ds: set[DatasetId] = set()
         waiting_ts: TaskSequence | None = None

--- a/src/cascade/gateway/api.py
+++ b/src/cascade/gateway/api.py
@@ -3,19 +3,20 @@ from dataclasses import dataclass
 from pydantic import BaseModel
 
 from cascade.controller.report import JobId, JobProgress
-from cascade.low.core import DatasetId
+from cascade.low.core import DatasetId, JobInstance
 
 CascadeGatewayAPI = BaseModel
 
 
 @dataclass
 class JobSpec:
-    # job -- atm its "catalog" approach, alternatively we just job: JobInstance
-    benchmark_name: str
+    # job benchmark + envvars -- set to None/{} if using custom jobs instead
+    benchmark_name: str | None
     envvars: dict[str, str]
     # example values:
     # benchmark_name="generators"
     # envvars={"GENERATORS_N": "8", "GENERATORS_K": "10", "GENERATORS_L": "4"}
+    job_instance: JobInstance | None
 
     # infra
     workers_per_host: int

--- a/src/cascade/gateway/client.py
+++ b/src/cascade/gateway/client.py
@@ -1,6 +1,4 @@
-"""
-Handles request & response communication for classes in gateway.api
-"""
+"""Handles request & response communication for classes in gateway.api"""
 
 import logging
 import threading
@@ -68,8 +66,8 @@ def parse_request(rr: bytes) -> api.CascadeGatewayAPI:
             raise ValueError("message clazz not understood")
         return cast(api.CascadeGatewayAPI, api.__dict__[rdc](**rd))
     except Exception as e:
-        logger.exception(f"failed to parse message: {rr[:32]}")
-        raise ValueError(f"failed to parse message: {rr[:32]} => {repr(e)[:32]}")
+        logger.exception(f"failed to parse message: {rr[:32]!r}")
+        raise ValueError(f"failed to parse message: {rr[:32]!r} => {repr(e)[:32]}")
 
 
 def serialize_response(m: api.CascadeGatewayAPI) -> bytes:

--- a/src/cascade/low/core.py
+++ b/src/cascade/low/core.py
@@ -1,6 +1,4 @@
-"""
-Core graph data structures -- prescribes most of the API
-"""
+"""Core graph data structures -- prescribes most of the API"""
 
 import re
 from base64 import b64decode, b64encode
@@ -91,10 +89,19 @@ class TaskInstance(BaseModel):
     )
 
 
+# Type can't be json serialized directly -- use these two functions with `serdes` on JobInstance
+def type_dec(t: str) -> Type:
+    return cast(Type, cloudpickle.loads(b64decode(t)))
+
+
+def type_enc(t: Type) -> str:
+    return b64encode(cloudpickle.dumps(t)).decode("ascii")
+
+
 class JobInstance(BaseModel):
     tasks: dict[TaskId, TaskInstance]
     edges: list[Task2TaskEdge]
-    serdes: dict[Type, tuple[str, str]] = Field(
+    serdes: dict[str, tuple[str, str]] = Field(
         {},
         description="for each Type with custom serde, add entry here. The string is fully qualified name of the ser/des functions",
     )


### PR DESCRIPTION
```
import cascade.gateway.api as api
import cascade.gateway.client as client
import os
os.environ["GENERATORS_N"] = "8"
os.environ["GENERATORS_K"] = "10"
os.environ["GENERATORS_L"] = "4"
import cascade.benchmarks.generators as generators
job = generators.get_job()
r = api.SubmitJobRequest(job=api.JobSpec(benchmark_name=None, workers_per_host=2, hosts=2, envvars={}, use_slurm=False, job_instance=job))
o = client.request_response(r, "tcp://localhost:8081")
```

as previous examples, but this time we manually construct the JobInstance

Implementation is most-dumb -- similarly to how we propagate the configuration for slurm using tempfiles, we dump the job instance as a file to be available at the startup