### PR TITLE
Earthkit compatible branding

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,10 +7,10 @@
 
 <p align="center">
   <a href="https://github.com/ecmwf/codex/raw/refs/heads/main/ESEE">
-    <img src="https://github.com/ecmwf/codex/raw/refs/heads/main/ESEE/foundation_badge.svg" alt="ECMWF Software EnginE">
+    <img src="https://github.com/ecmwf/codex/raw/refs/heads/main/ESEE/production_chain_badge.svg" alt="ECMWF Software EnginE">
   </a>
   <a href="https://github.com/ecmwf/codex/raw/refs/heads/main/Project Maturity">
-    <img src="https://github.com/ecmwf/codex/raw/refs/heads/main/Project Maturity/sandbox_badge.svg" alt="Maturity Level">
+    <img src="https://github.com/ecmwf/codex/raw/refs/heads/main/Project Maturity/incubating_badge.svg" alt="Maturity Level">
   </a>
   <a href="https://opensource.org/licenses/apache-2-0">
     <img src="https://img.shields.io/badge/Licence-Apache 2.0-blue.svg" alt="Licence">
@@ -29,11 +29,7 @@
 </p>
 
 > \[!IMPORTANT\]
-> This software is **Sandbox** and subject to ECMWF's guidelines on [Software Maturity](https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity).
-
-
-> **DISCLAIMER**
-> This project is **Sandbox** and will be **sandbox** for the foreseeable future. Interfaces and functionality are likely to change, and the project itself may be scrapped. **DO NOT** use this software in any project/software that is operational.
+> This software is **Incubating** and subject to ECMWF's guidelines on [Software Maturity](https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity).
 
 Earthkit Workflows is a Python library for declaring earthkit task as DAGs.
 It contains an internal `cascade` engine for scheduling and executing task graphs almost optimally across heterogeneous platforms with complex network technologies and topologies.
@@ -100,7 +96,7 @@ There is also `python -m cascade.benchmarks local <..>` -- you may use that as a
 
 ## Documentation
 
-This is a sandbox project. Read the code.
+Not yet available.
 
 ## License
 


### PR DESCRIPTION
Just making the earthkit style readme. The logos don't exists, neither do the releases -- but all is in place for when they appear. Mild update of the readme content to reflect the `cascade -> earthkit-workflows`.