### PR TITLE
[cascade.gateway] report job failure

### DIFF
--- a/src/cascade/controller/impl.py
+++ b/src/cascade/controller/impl.py
@@ -57,12 +57,14 @@ def run(
                 events = timer(bridge.recv_events, Microtrace.ctrl_wait)()
                 timer(notify, Microtrace.ctrl_notify)(state, job, events, reporter)
                 logger.debug(f"received {len(events)} events")
-    except Exception:
+    except Exception as ex:
         logger.error("crash in controller, shuting down")
+        reporter.send_failure(repr(ex))
         raise
+    else:
+        reporter.success()
     finally:
         mark({"action": ControllerPhases.shutdown})
         logger.debug("shutting down executors")
         bridge.shutdown()
-        reporter.shutdown()
     return state

--- a/src/cascade/controller/report.py
+++ b/src/cascade/controller/report.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from time import monotonic_ns
 
 import zmq
+from typing_extensions import Self
 
 from cascade.executor.comms import get_context
 from cascade.low.core import DatasetId
@@ -22,9 +23,31 @@ from cascade.scheduler.core import State
 logger = logging.getLogger(__name__)
 
 JobId = str
-JobProgress = str
-JobProgressStarted: JobProgress = "0.00"
-JobProgressShutdown: JobProgress = "Shutdown"
+
+
+@dataclass
+class JobProgress:
+    completed: bool
+    pct: (
+        str | None
+    )  # number in (0, 1) formatted as {:.2%} without the percent sign -- eg 0.10, 23.68
+    failure: str | None
+
+    @classmethod
+    def failure(cls, failure: str) -> Self:
+        return cls(True, None, failure)
+
+    @classmethod
+    def progress(cls, pct: float) -> Self:
+        progress = "{:.2%}".format(pct)[:-1]
+        return cls(False, progress, None)
+
+    @classmethod
+    def success(cls) -> Self:
+        return cls(True, None, None)
+
+
+JobProgressStarted = JobProgress(False, "0.00", None)
 
 
 @dataclass
@@ -66,23 +89,36 @@ class Reporter:
     def send_progress(self, state: State) -> None:
         if self.socket is None:
             return
-        progress = "{:.2%}".format(1.0 - state.remaining / state.total)[:-1]
-        logger.debug(f"reporting {progress=}")
-        report = ControllerReport(self.job_id, progress, monotonic_ns(), [])
+        pct = 1.0 - state.remaining / state.total
+        logger.debug(f"reporting progress {pct=}")
+        report = ControllerReport(
+            self.job_id, JobProgress.progress(pct), monotonic_ns(), []
+        )
         _send(self.socket, report)
 
     def send_result(self, dataset: DatasetId, result: bytes) -> None:
         if self.socket is None:
             return
-        logger.debug(f"uploading reuslt {dataset=}")
+        logger.debug(f"uploading result {dataset=}")
         report = ControllerReport(
             self.job_id, None, monotonic_ns(), [(dataset, result)]
         )
         _send(self.socket, report)
 
-    def shutdown(self) -> None:
+    def send_failure(self, failure: str) -> None:
         if self.socket is None:
             return
-        logger.debug("reporter shutting down")
-        report = ControllerReport(self.job_id, JobProgressShutdown, monotonic_ns(), [])
+        logger.debug(f"reporting failure {failure=}")
+        report = ControllerReport(
+            self.job_id, JobProgress.failure(failure), monotonic_ns(), []
+        )
+        _send(self.socket, report)
+
+    def success(self) -> None:
+        if self.socket is None:
+            return
+        logger.debug("reporter sending shutdown")
+        report = ControllerReport(
+            self.job_id, JobProgress.success(), monotonic_ns(), []
+        )
         _send(self.socket, report)

--- a/src/cascade/gateway/router.py
+++ b/src/cascade/gateway/router.py
@@ -20,12 +20,7 @@ from typing import Iterable
 import orjson
 import zmq
 
-from cascade.controller.report import (
-    JobId,
-    JobProgress,
-    JobProgressShutdown,
-    JobProgressStarted,
-)
+from cascade.controller.report import JobId, JobProgress, JobProgressStarted
 from cascade.executor.comms import get_context
 from cascade.gateway.api import JobSpec
 from cascade.low.core import DatasetId
@@ -146,12 +141,13 @@ class JobRouter:
         if progress is None:
             return
         job = self.jobs[job_id]
-        if progress == JobProgressShutdown:
+        if progress.completed:
             self.poller.unregister(job.socket)
-            return
-        if job.last_seen >= timestamp:
-            return
-        else:
+        if progress.failure is not None and job.progress.failure is None:
+            job.progress = progress
+        elif job.last_seen >= timestamp or job.progress.failure is not None:
+            pass
+        elif progress.pct is not None:
             job.progress = progress
 
     def put_result(self, job_id: JobId, dataset_id: DatasetId, result: bytes) -> None:

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -11,7 +11,7 @@ init_value = 10
 job_func = lambda i: i * 2
 
 
-def get_job() -> JobInstance:
+def get_job_succ() -> JobInstance:
     sod = TaskDefinition(
         func=TaskDefinition.func_enc(lambda: init_value),
         environment=[],
@@ -39,6 +39,19 @@ def get_job() -> JobInstance:
     return ji
 
 
+def get_job_fail() -> JobInstance:
+    td = TaskDefinition(
+        func=TaskDefinition.func_enc(job_func),
+        environment=[],
+        input_schema={},
+        output_schema={"o": "int"},
+    )
+    ti = TaskInstance(definition=td, static_input_kw={}, static_input_ps={"0": None})
+
+    ji = JobBuilder().with_node("t", ti).build().get_or_raise()
+    return ji
+
+
 def spawn_gateway() -> tuple[str, Process]:
     url = "tcp://localhost:12355"
     p = Process(target=gateway_entrypoint, args=(url,))
@@ -49,7 +62,8 @@ def spawn_gateway() -> tuple[str, Process]:
 def test_job():
     url, gw = spawn_gateway()
     try:
-        ji = get_job()
+        # succ job
+        ji = get_job_succ()
         js = api.JobSpec(
             benchmark_name=None,
             envvars={},
@@ -70,7 +84,7 @@ def test_job():
         while tries > 0:
             job_progress_res = client.request_response(job_progress_req, url)
             assert job_progress_res.error is None
-            if job_progress_res.progresses[job_id] == "100.00":
+            if job_progress_res.progresses[job_id].pct == "100.00":
                 break
             else:
                 tries -= 1
@@ -92,11 +106,43 @@ def test_job():
         result_deletion_res = client.request_response(result_deletion_req, url)
         assert result_deletion_res.error is None
 
+        # fail job
+        ji = get_job_fail()
+        js = api.JobSpec(
+            benchmark_name=None,
+            envvars={},
+            job_instance=ji,
+            workers_per_host=1,
+            hosts=1,
+            use_slurm=False,
+        )
+
+        submit_job_req = api.SubmitJobRequest(job=js)
+        submit_job_res = client.request_response(submit_job_req, url)
+        job_id = submit_job_res.job_id
+        assert submit_job_res.error is None
+        assert job_id is not None
+
+        tries = 3
+        job_progress_req = api.JobProgressRequest(job_ids=[job_id])
+        while tries > 0:
+            job_progress_res = client.request_response(job_progress_req, url)
+            assert job_progress_res.error is None
+            assert job_progress_res.progresses[job_id].pct != "100.00"
+            if job_progress_res.progresses[job_id].failure is not None:
+                break
+            else:
+                tries -= 1
+                time.sleep(1)
+        assert tries > 0
+
+        # gw shutdown
         shutdown_req = api.ShutdownRequest()
         shutdown_res = client.request_response(shutdown_req, url)
         assert shutdown_res.error is None
         gw.join(5)
         assert gw.exitcode == 0
+
     except:
         if gw.is_alive():
             gw.kill()


### PR DESCRIPTION
The contract of JobProgressResponse is extended -- originally, it contained JobProgress which was just a string like `"13.27"`. Now we change it to a dataclass with `pct`, `failure` and `completed` fields:
- `pct` holds the original value, eg, `"13.27"`,
- `failure` is the exception repr which controller sent in case of a crash,
- `completed` is a bool, basically `True <=> pct == "100.00" or failure is not None`,
such that `failure` and `pct` are mutually exclusive, and once a `failure` is set to not-`None`, it can never change