### PR TITLE
[cascade.gateway] report available datasets

### DIFF
--- a/src/cascade/gateway/api.py
+++ b/src/cascade/gateway/api.py
@@ -50,6 +50,7 @@ class JobProgressRequest(CascadeGatewayAPI):
 
 class JobProgressResponse(CascadeGatewayAPI):
     progresses: dict[JobId, JobProgress]
+    datasets: dict[JobId, list[DatasetId]]
     error: str | None  # top level error
 
 

--- a/src/cascade/gateway/router.py
+++ b/src/cascade/gateway/router.py
@@ -127,10 +127,16 @@ class JobRouter:
         _spawn_subprocess(job_spec, full_addr, job_id)
         return job_id
 
-    def progress_of(self, job_ids: Iterable[JobId]) -> dict[JobId, JobProgress]:
+    def progress_of(
+        self, job_ids: Iterable[JobId]
+    ) -> tuple[dict[JobId, JobProgress], dict[JobId, list[DatasetId]]]:
         if not job_ids:
             job_ids = self.jobs.keys()
-        return {job_id: self.jobs[job_id].progress for job_id in job_ids}
+        progresses = {job_id: self.jobs[job_id].progress for job_id in job_ids}
+        datasets = {
+            job_id: list(self.jobs[job_id].results.keys()) for job_id in job_ids
+        }
+        return progresses, datasets
 
     def get_result(self, job_id: JobId, dataset_id: DatasetId) -> bytes:
         return self.jobs[job_id].results[dataset_id]

--- a/src/cascade/gateway/server.py
+++ b/src/cascade/gateway/server.py
@@ -38,8 +38,10 @@ def handle_fe(socket: zmq.Socket, jobs: JobRouter) -> bool:
             rv = api.SubmitJobResponse(job_id=None, error=repr(e))
     elif isinstance(m, api.JobProgressRequest):
         try:
-            progresses = jobs.progress_of(m.job_ids)
-            rv = api.JobProgressResponse(progresses=progresses, error=None)
+            progresses, datasets = jobs.progress_of(m.job_ids)
+            rv = api.JobProgressResponse(
+                progresses=progresses, datasets=datasets, error=None
+            )
         except Exception as e:
             logger.exception(f"failed to get progress of: {m}")
             rv = api.JobProgressResponse(progresses={}, error=repr(e))

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -79,12 +79,14 @@ def test_job():
         assert submit_job_res.error is None
         assert job_id is not None
 
-        tries = 3
+        tries = 4
         job_progress_req = api.JobProgressRequest(job_ids=[job_id])
         while tries > 0:
             job_progress_res = client.request_response(job_progress_req, url)
             assert job_progress_res.error is None
-            if job_progress_res.progresses[job_id].pct == "100.00":
+            is_computed = job_progress_res.progresses[job_id].pct == "100.00"
+            is_datasets = ji.ext_outputs[0] in job_progress_res.datasets[job_id]
+            if is_computed and is_datasets:
                 break
             else:
                 tries -= 1


### PR DESCRIPTION
Adding the `datasets` to the api.JobProgressResponse

Semantically it's a `set`, but because of going through json, we formally use a list