### PR TITLE
Fix: Remove Grib Assumption

### DIFF
--- a/src/earthkit/workflows/backends/earthkit.py
+++ b/src/earthkit/workflows/backends/earthkit.py
@@ -59,7 +59,7 @@ def new_fieldlist(data, metadata: list[ekdMetadata], overrides: dict):
                 "Error setting metadata",
                 overrides,
                 "On data with: ",
-                list(map(lambda x: x.dump(), metadata))
+                list(map(lambda x: x.dump(), metadata)),
             )
             print(e)
     return FieldList.from_array(standardise_output(data), metadata)

--- a/src/earthkit/workflows/backends/earthkit.py
+++ b/src/earthkit/workflows/backends/earthkit.py
@@ -10,7 +10,7 @@ from typing import TypeAlias
 
 import array_api_compat
 from earthkit.data import FieldList
-from earthkit.data.readers.grib.metadata import StandAloneGribMetadata
+from earthkit.data.core.metadata import Metadata as ekdMetadata
 
 from earthkit.workflows.backends import num_args
 
@@ -44,7 +44,7 @@ def resolve_metadata(metadata: Metadata, *args) -> dict:
     return metadata(*args)
 
 
-def new_fieldlist(data, metadata: list[StandAloneGribMetadata], overrides: dict):
+def new_fieldlist(data, metadata: list[ekdMetadata], overrides: dict):
     if len(overrides) > 0:
         try:
             new_metadata = [
@@ -58,10 +58,8 @@ def new_fieldlist(data, metadata: list[StandAloneGribMetadata], overrides: dict)
             print(
                 "Error setting metadata",
                 overrides,
-                "edition",
-                metadata[0]["edition"],
-                "param",
-                metadata[0]["paramId"],
+                "On data with: ",
+                list(map(lambda x: x.dump(), metadata))
             )
             print(e)
     return FieldList.from_array(standardise_output(data), metadata)

--- a/src/earthkit/workflows/backends/earthkit.py
+++ b/src/earthkit/workflows/backends/earthkit.py
@@ -58,7 +58,7 @@ def new_fieldlist(data, metadata: list[ekdMetadata], overrides: dict):
             print(
                 "Error setting metadata",
                 overrides,
-                "On data with: ",
+                "On data with:",
                 list(map(lambda x: x.dump(), metadata)),
             )
             print(e)


### PR DESCRIPTION
The earthkit backend had an assumption that the metadata was grib, as earthkit.data can do more it makes to expand this.