### PR TITLE
[cascade.scheduler] initial state dismantling

### DIFF
--- a/src/cascade/benchmarks/job1.py
+++ b/src/cascade/benchmarks/job1.py
@@ -19,7 +19,7 @@ import earthkit.data
 from ppcascade.fluent import from_source
 from ppcascade.utils.window import Range
 
-from cascade.fluent import Payload
+from earthkit.workflows.fluent import Payload
 
 # *** PARAMS ***
 

--- a/src/cascade/controller/act.py
+++ b/src/cascade/controller/act.py
@@ -11,7 +11,6 @@
 import logging
 
 from cascade.controller.core import State
-from cascade.controller.notify import consider_purge
 from cascade.executor.bridge import Bridge
 from cascade.executor.msg import TaskSequence
 from cascade.low.execution_context import JobExecutionContext
@@ -67,30 +66,18 @@ def act(bridge: Bridge, assignment: Assignment) -> None:
     bridge.task_sequence(task_sequence)
 
 
-# TODO refac less explicit mutation of context, use class methods
 def flush_queues(bridge: Bridge, state: State, context: JobExecutionContext):
-    """Flushes elements in purging and fetching queues in State. Mutates State, JobExecutionContext,
+    """Flushes elements in purging and fetching queues in State. Marks the respective
+    changes in Context, sends commands via Bridge. Mutates State, JobExecutionContext,
     and via bridge the Executors.
     """
 
-    # TODO handle this in some eg thread pool... may need lock on state, result queueing, handle purge tracking, etc
-    fetchable = list(state.fetching_queue.keys())
-    for dataset in fetchable:
-        host = state.fetching_queue.pop(dataset)
+    for dataset, host in state.drain_fetching_queue():
         bridge.fetch(dataset, host)
-        consider_purge(state, dataset)
 
-    for ds in state.purging_queue:
-        # TODO finegraining, restrictions, checks for validity, etc. Do in concert with extension of `purging_queue`
-        for host in context.ds2host[ds]:
-            logger.debug(f"identified purge of {ds} at {host}")
+    for ds in state.drain_purging_queue():
+        for host in context.purge_dataset(ds):
+            logger.debug(f"issuing purge of {ds=} to {host=}")
             bridge.purge(host, ds)
-            context.host2ds[host].pop(ds)
-            for worker in context.host2workers[host]:
-                if ds in context.worker2ds[worker]:
-                    context.worker2ds[worker].pop(ds)
-                    context.ds2worker[ds].pop(worker)
-        context.ds2host.pop(ds)
-    state.purging_queue = []
 
     return state

--- a/src/cascade/controller/act.py
+++ b/src/cascade/controller/act.py
@@ -10,16 +10,18 @@
 
 import logging
 
+from cascade.controller.core import State
 from cascade.controller.notify import consider_purge
 from cascade.executor.bridge import Bridge
 from cascade.executor.msg import TaskSequence
+from cascade.low.execution_context import JobExecutionContext
 from cascade.low.tracing import TaskLifecycle, TransmitLifecycle, mark
-from cascade.scheduler.core import Assignment, State
+from cascade.scheduler.core import Assignment
 
 logger = logging.getLogger(__name__)
 
 
-def act(bridge: Bridge, state: State, assignment: Assignment) -> None:
+def act(bridge: Bridge, assignment: Assignment) -> None:
     """Converts an assignment to one or more actions which are sent to the bridge, and returned
     for tracing/updating purposes. Does *not* mutate State, but executors behind the Bridge *are* mutated.
     """
@@ -65,9 +67,10 @@ def act(bridge: Bridge, state: State, assignment: Assignment) -> None:
     bridge.task_sequence(task_sequence)
 
 
-def flush_queues(bridge: Bridge, state: State) -> State:
-    """Flushes elements in purging and fetching queues in State (and mutating it thus, as well as Executor).
-    Returns the mutated State, as all tracing and updates are handled here.
+# TODO refac less explicit mutation of context, use class methods
+def flush_queues(bridge: Bridge, state: State, context: JobExecutionContext):
+    """Flushes elements in purging and fetching queues in State. Mutates State, JobExecutionContext,
+    and via bridge the Executors.
     """
 
     # TODO handle this in some eg thread pool... may need lock on state, result queueing, handle purge tracking, etc
@@ -75,19 +78,19 @@ def flush_queues(bridge: Bridge, state: State) -> State:
     for dataset in fetchable:
         host = state.fetching_queue.pop(dataset)
         bridge.fetch(dataset, host)
-        state = consider_purge(state, dataset)
+        consider_purge(state, dataset)
 
     for ds in state.purging_queue:
         # TODO finegraining, restrictions, checks for validity, etc. Do in concert with extension of `purging_queue`
-        for host in state.ds2host[ds]:
+        for host in context.ds2host[ds]:
             logger.debug(f"identified purge of {ds} at {host}")
             bridge.purge(host, ds)
-            state.host2ds[host].pop(ds)
-            for worker in state.host2workers[host]:
-                if ds in state.worker2ds[worker]:
-                    state.worker2ds[worker].pop(ds)
-                    state.ds2worker[ds].pop(worker)
-        state.ds2host.pop(ds)
+            context.host2ds[host].pop(ds)
+            for worker in context.host2workers[host]:
+                if ds in context.worker2ds[worker]:
+                    context.worker2ds[worker].pop(ds)
+                    context.ds2worker[ds].pop(worker)
+        context.ds2host.pop(ds)
     state.purging_queue = []
 
     return state

--- a/src/cascade/controller/core.py
+++ b/src/cascade/controller/core.py
@@ -1,33 +1,86 @@
+"""Declares core data structures and methods -- most notably Controller's state,
+which handles dynamic work outside of scheduler control, such as dataset purging
+or outputs retrieval
+"""
+
+import logging
 from dataclasses import dataclass
+from typing import Any, Iterator
+
+import cascade.executor.serde as serde
+from cascade.executor.msg import DatasetTransmitPayload
 from cascade.low.core import DatasetId, HostId, TaskId
-from typing import Any
+
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class State:
     # key add by core.initialize, value add by notify.notify
     outputs: dict[DatasetId, Any]
-    # add by notify.consider_fetch, remove by act.flush_queues
+    # add by notify.notify, remove by act.flush_queues
     fetching_queue: dict[DatasetId, HostId]
-    # add by notify.consider_purge, removed by act.flush_queues
-    # TODO extend with `at`, for fine graining?
+    # add by notify.notify, removed by act.flush_queues
     purging_queue: list[DatasetId]
-    # add by core.initialize, remove by notify.notify
+    # add by core.init_state, remove by notify.notify
     purging_tracker: dict[DatasetId, set[TaskId]]
 
     def has_awaitable(self) -> bool:
         # TODO replace the None in outputs with check on fetch queue (but change that from binary to ternary first)
         return None in self.outputs.values()
 
+    def _consider_purge(self, dataset: DatasetId) -> None:
+        """If dataset not required anymore, add to purging_queue"""
+        no_dependants = not self.purging_tracker.get(dataset, None)
+        not_required_output = self.outputs.get(dataset, 1) is not None
+        if no_dependants and not_required_output:
+            logger.debug(f"adding {dataset=} to purging queue")
+            if dataset in self.purging_tracker:
+                self.purging_tracker.pop(dataset)
+            self.purging_queue.append(dataset)
+
+    def consider_fetch(self, dataset: DatasetId, at: HostId) -> None:
+        """If required as output and not yet arrived, add to fetching queue"""
+        if (
+            dataset in self.outputs
+            and self.outputs[dataset] is None
+            and dataset not in self.fetching_queue
+        ):
+            self.fetching_queue[dataset] = at
+
+    def receive_payload(self, payload: DatasetTransmitPayload) -> None:
+        """Stores deserialized value into outputs, considers purge"""
+        # NOTE ifneedbe get annotation from job.tasks[event.ds.task].definition.output_schema[event.ds.output]
+        self.outputs[payload.header.ds] = serde.des_output(
+            payload.value, "Any", payload.header.deser_fun
+        )
+        self._consider_purge(payload.header.ds)
+
+    def task_done(self, task: TaskId, inputs: set[DatasetId]) -> None:
+        """Marks that the inputs are not needed for this task anymore, considers purge of each"""
+        for sourceDataset in inputs:
+            self.purging_tracker[sourceDataset].remove(task)
+            self._consider_purge(sourceDataset)
+
+    def drain_purging_queue(self) -> Iterator[DatasetId]:
+        for e in self.purging_queue:
+            yield e
+        self.purging_queue = []
+
+    def drain_fetching_queue(self) -> Iterator[tuple[DatasetId, HostId]]:
+        for dataset, host in self.fetching_queue.items():
+            yield dataset, host
+        self.fetching_queue = {}
+
 
 def init_state(outputs: set[DatasetId], edge_o: dict[DatasetId, set[TaskId]]) -> State:
     purging_tracker = {
-        ds: {task for task in dependants}
-        for ds, dependants in edge_o.items()
+        ds: {task for task in dependants} for ds, dependants in edge_o.items()
     }
 
     return State(
         outputs={e: None for e in outputs},
         fetching_queue={},
         purging_queue=[],
-        purging_tracker=purging_tracker
+        purging_tracker=purging_tracker,
     )

--- a/src/cascade/controller/core.py
+++ b/src/cascade/controller/core.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from cascade.low.core import DatasetId, HostId, TaskId
+from typing import Any
+
+@dataclass
+class State:
+    # key add by core.initialize, value add by notify.notify
+    outputs: dict[DatasetId, Any]
+    # add by notify.consider_fetch, remove by act.flush_queues
+    fetching_queue: dict[DatasetId, HostId]
+    # add by notify.consider_purge, removed by act.flush_queues
+    # TODO extend with `at`, for fine graining?
+    purging_queue: list[DatasetId]
+    # add by core.initialize, remove by notify.notify
+    purging_tracker: dict[DatasetId, set[TaskId]]
+
+    def has_awaitable(self) -> bool:
+        # TODO replace the None in outputs with check on fetch queue (but change that from binary to ternary first)
+        return None in self.outputs.values()
+
+
+def init_state(outputs: set[DatasetId], edge_o: dict[DatasetId, set[TaskId]]) -> State:
+    purging_tracker = {
+        ds: {task for task in dependants}
+        for ds, dependants in edge_o.items()
+    }
+
+    return State(
+        outputs={e: None for e in outputs},
+        fetching_queue={},
+        purging_queue=[],
+        purging_tracker=purging_tracker
+    )

--- a/src/cascade/controller/impl.py
+++ b/src/cascade/controller/impl.py
@@ -10,13 +10,15 @@ import logging
 
 import cascade.executor.serde as serde
 from cascade.controller.act import act, flush_queues
+from cascade.controller.core import State, init_state
 from cascade.controller.notify import notify
 from cascade.controller.report import Reporter
 from cascade.executor.bridge import Bridge, Event
 from cascade.low.core import JobInstance, type_dec
+from cascade.low.execution_context import init_context
 from cascade.low.tracing import ControllerPhases, Microtrace, label, mark, timer
-from cascade.scheduler.api import assign, initialize, plan
-from cascade.scheduler.core import Preschedule, State, has_awaitable, has_computable
+from cascade.scheduler.api import assign, init_schedule, plan
+from cascade.scheduler.core import Preschedule
 
 logger = logging.getLogger(__name__)
 
@@ -27,35 +29,44 @@ def run(
     preschedule: Preschedule,
     report_address: str | None = None,
 ) -> State:
-    outputs = set(job.ext_outputs)
     env = bridge.get_environment()
+    context = init_context(env, job, preschedule.edge_o, preschedule.edge_i)
+    outputs = set(context.job_instance.ext_outputs)
     logger.debug(f"starting with {env=} and {report_address=}")
-    state = timer(initialize, Microtrace.ctrl_init)(env, preschedule, outputs)
+    schedule = timer(init_schedule, Microtrace.ctrl_init)(preschedule, context)
+    state = init_state(outputs, context.edge_o)
+
     label("host", "controller")
     events: list[Event] = []
-    for serdeTypeEnc, (serdeSer, serdeDes) in job.serdes.items():
+    for serdeTypeEnc, (serdeSer, serdeDes) in context.job_instance.serdes.items():
         serde.SerdeRegistry.register(type_dec(serdeTypeEnc), serdeSer, serdeDes)
     reporter = Reporter(report_address)
 
     try:
-        while has_computable(state) or has_awaitable(state):
+        while (
+            state.has_awaitable()
+            or context.has_awaitable()
+            or schedule.has_computable()
+        ):
             mark({"action": ControllerPhases.assign})
             assignments = []
-            if has_computable(state):
-                for assignment in assign(state, job, env):
-                    timer(act, Microtrace.ctrl_act)(bridge, state, assignment)
+            if schedule.has_computable():
+                for assignment in assign(schedule, context):
+                    timer(act, Microtrace.ctrl_act)(bridge, assignment)
                     assignments.append(assignment)
 
             mark({"action": ControllerPhases.plan})
-            state = plan(state, assignments)
+            plan(schedule, context, assignments)
             mark({"action": ControllerPhases.flush})
-            state = flush_queues(bridge, state)
+            flush_queues(bridge, state, context)
 
             mark({"action": ControllerPhases.wait})
-            if has_awaitable(state):
-                logger.debug(f"about to await bridge with {state.ongoing_total=}")
+            if state.has_awaitable() or context.has_awaitable():
+                logger.debug(f"about to await bridge with {context.ongoing_total=}")
                 events = timer(bridge.recv_events, Microtrace.ctrl_wait)()
-                timer(notify, Microtrace.ctrl_notify)(state, job, events, reporter)
+                timer(notify, Microtrace.ctrl_notify)(
+                    state, schedule, context, events, reporter
+                )
                 logger.debug(f"received {len(events)} events")
     except Exception as ex:
         logger.error("crash in controller, shuting down")

--- a/src/cascade/controller/notify.py
+++ b/src/cascade/controller/notify.py
@@ -14,7 +14,6 @@
 import logging
 from typing import Iterable
 
-import cascade.executor.serde as serde
 from cascade.controller.core import State
 from cascade.controller.report import Reporter
 from cascade.executor.bridge import Event
@@ -27,25 +26,6 @@ from cascade.scheduler.assign import set_worker2task_overhead
 from cascade.scheduler.core import Schedule
 
 logger = logging.getLogger(__name__)
-
-
-def consider_purge(state: State, dataset: DatasetId):
-    no_dependants = not state.purging_tracker.get(dataset, None)
-    not_required_output = state.outputs.get(dataset, 1) is not None
-    if no_dependants and not_required_output:
-        logger.debug(f"adding {dataset=} to purging queue")
-        if dataset in state.purging_tracker:
-            state.purging_tracker.pop(dataset)
-        state.purging_queue.append(dataset)
-
-
-def consider_fetch(state: State, dataset: DatasetId, at: HostId):
-    if (
-        dataset in state.outputs
-        and state.outputs[dataset] is None
-        and dataset not in state.fetching_queue
-    ):
-        state.fetching_queue[dataset] = at
 
 
 # TODO refac move to scheduler
@@ -106,7 +86,7 @@ def notify(
             )
             context.host2ds[host][event.ds] = DatasetStatus.available
             context.ds2host[event.ds][host] = DatasetStatus.available
-            consider_fetch(state, event.ds, host)
+            state.consider_fetch(event.ds, host)
             consider_computable(schedule, state, context, event.ds, host)
             if event.transmit_idx is not None:
                 mark(
@@ -135,9 +115,7 @@ def notify(
                         "host": "controller",
                     }
                 )
-                for sourceDataset in context.edge_i.get(event.ds.task, set()):
-                    state.purging_tracker[sourceDataset].remove(event.ds.task)
-                    consider_purge(state, sourceDataset)
+                state.task_done(event.ds.task, context.edge_i.get(event.ds.task, set()))
                 if event.ds.task in context.ongoing[worker]:
                     context.ongoing[worker].remove(event.ds.task)
                     context.ongoing_total -= 1
@@ -150,11 +128,7 @@ def notify(
                 if not context.ongoing[worker]:
                     context.idle_workers.add(worker)
         elif isinstance(event, DatasetTransmitPayload):
-            # TODO ifneedbe get annotation from job.tasks[event.ds.task].definition.output_schema[event.ds.output]
-            state.outputs[event.header.ds] = serde.des_output(
-                event.value, "Any", event.header.deser_fun
-            )
+            state.receive_payload(event)
             reporter.send_result(event.header.ds, event.value)
         else:
             assert_never(event)
-    return state

--- a/src/cascade/controller/notify.py
+++ b/src/cascade/controller/notify.py
@@ -19,7 +19,7 @@ from cascade.controller.report import Reporter
 from cascade.executor.bridge import Event
 from cascade.executor.msg import DatasetPublished, DatasetTransmitPayload
 from cascade.low.core import DatasetId, HostId, WorkerId
-from cascade.low.execution_context import DatasetStatus, JobExecutionContext, TaskStatus
+from cascade.low.execution_context import DatasetStatus, JobExecutionContext
 from cascade.low.func import assert_never
 from cascade.low.tracing import TaskLifecycle, TransmitLifecycle, mark
 from cascade.scheduler.assign import set_worker2task_overhead
@@ -98,35 +98,24 @@ def notify(
                     }
                 )
             elif context.is_last_output_of(event.ds):
-                if not isinstance((worker := event.origin), WorkerId):
+                worker = event.origin
+                task = event.ds.task
+                if not isinstance(worker, WorkerId):
                     raise ValueError(
                         f"malformed event, expected origin to be WorkerId: {event}"
                     )
-                logger.debug(
-                    f"last output of {event.ds.task} published, assuming completion"
-                )
-                context.worker2ts[worker][event.ds.task] = TaskStatus.succeeded
-                context.ts2worker[event.ds.task][worker] = TaskStatus.succeeded
+                logger.debug(f"last output of {task}, assuming completion")
                 mark(
                     {
-                        "task": event.ds.task,
+                        "task": task,
                         "action": TaskLifecycle.completed,
                         "worker": repr(worker),
                         "host": "controller",
                     }
                 )
-                state.task_done(event.ds.task, context.edge_i.get(event.ds.task, set()))
-                if event.ds.task in context.ongoing[worker]:
-                    context.ongoing[worker].remove(event.ds.task)
-                    context.ongoing_total -= 1
-                    context.remaining -= 1
-                    reporter.send_progress(context)
-                else:
-                    raise ValueError(
-                        f"{event.ds.task} succeeded but removal from `ongoing` impossible"
-                    )
-                if not context.ongoing[worker]:
-                    context.idle_workers.add(worker)
+                state.task_done(task, context.edge_i.get(event.ds.task, set()))
+                context.task_done(task, worker)
+                reporter.send_progress(context)
         elif isinstance(event, DatasetTransmitPayload):
             state.receive_payload(event)
             reporter.send_result(event.header.ds, event.value)

--- a/src/cascade/controller/notify.py
+++ b/src/cascade/controller/notify.py
@@ -15,19 +15,21 @@ import logging
 from typing import Iterable
 
 import cascade.executor.serde as serde
+from cascade.controller.core import State
 from cascade.controller.report import Reporter
 from cascade.executor.bridge import Event
 from cascade.executor.msg import DatasetPublished, DatasetTransmitPayload
-from cascade.low.core import DatasetId, HostId, JobInstance, WorkerId
+from cascade.low.core import DatasetId, HostId, WorkerId
+from cascade.low.execution_context import DatasetStatus, JobExecutionContext, TaskStatus
 from cascade.low.func import assert_never
 from cascade.low.tracing import TaskLifecycle, TransmitLifecycle, mark
 from cascade.scheduler.assign import set_worker2task_overhead
-from cascade.scheduler.core import DatasetStatus, State, TaskStatus
+from cascade.scheduler.core import Schedule
 
 logger = logging.getLogger(__name__)
 
 
-def consider_purge(state: State, dataset: DatasetId) -> State:
+def consider_purge(state: State, dataset: DatasetId):
     no_dependants = not state.purging_tracker.get(dataset, None)
     not_required_output = state.outputs.get(dataset, 1) is not None
     if no_dependants and not_required_output:
@@ -35,33 +37,39 @@ def consider_purge(state: State, dataset: DatasetId) -> State:
         if dataset in state.purging_tracker:
             state.purging_tracker.pop(dataset)
         state.purging_queue.append(dataset)
-    return state
 
 
-def consider_fetch(state: State, dataset: DatasetId, at: HostId) -> State:
+def consider_fetch(state: State, dataset: DatasetId, at: HostId):
     if (
         dataset in state.outputs
         and state.outputs[dataset] is None
         and dataset not in state.fetching_queue
     ):
         state.fetching_queue[dataset] = at
-    return state
 
 
-def consider_computable(state: State, dataset: DatasetId, host: HostId) -> State:
+# TODO refac move to scheduler
+def consider_computable(
+    schedule: Schedule,
+    state: State,
+    context: JobExecutionContext,
+    dataset: DatasetId,
+    host: HostId,
+):
     # In case this is the first time this dataset was made available, we check
     # what tasks can now *in principle* be computed anywhere -- we ignore transfer
     # costs etc here, this is just about updating the `computable` part of `state`.
     # It may happen this is called after a transfer of an already computed dataset, in
     # which case this is a fast no-op
-    component = state.components[state.ts2component[dataset.task]]
+    component = schedule.components[schedule.ts2component[dataset.task]]
+    # TODO refac do we need purging_tracker here, or is edge_o enough?
     for child_task in state.purging_tracker.get(dataset, set()):
         if child_task in component.computable:
-            for worker in state.host2workers[host]:
+            for worker in context.host2workers[host]:
                 # NOTE since the child_task has already been computable, and the current
                 # implementation of `overhead` assumes host2host being homogeneous, we can
                 # afford to recalc overhead for the event's host only
-                state = set_worker2task_overhead(state, worker, child_task)
+                set_worker2task_overhead(schedule, context, worker, child_task)
         if child_task not in component.is_computable_tracker:
             continue
         if dataset in component.is_computable_tracker[child_task]:
@@ -74,25 +82,21 @@ def consider_computable(state: State, dataset: DatasetId, host: HostId) -> State
                         value = new_opt
                 component.computable[child_task] = value
                 logger.debug(f"{child_task} just became computable!")
-                state.computable += 1
+                schedule.computable += 1
                 for worker in component.worker2task_distance.keys():
                     # NOTE this is a task newly made computable, so we need to calc
                     # `overhead` for all hosts/workers assigned to the component
-                    state = set_worker2task_overhead(state, worker, child_task)
-
-    return state
+                    set_worker2task_overhead(schedule, context, worker, child_task)
 
 
-def is_last_output_of(dataset: DatasetId, job: JobInstance) -> bool:
-    definition = job.tasks[dataset.task].definition
-    # TODO change the definition to actually be the sorted list
-    last = sorted(definition.output_schema.keys())[-1]
-    return last == dataset.output
-
-
+# TODO refac less explicit mutation of context, use class methods
 def notify(
-    state: State, job: JobInstance, events: Iterable[Event], reporter: Reporter
-) -> State:
+    state: State,
+    schedule: Schedule,
+    context: JobExecutionContext,
+    events: Iterable[Event],
+    reporter: Reporter,
+):
     for event in events:
         if isinstance(event, DatasetPublished):
             logger.debug(f"received {event=}")
@@ -100,10 +104,10 @@ def notify(
             host = (
                 event.origin if isinstance(event.origin, HostId) else event.origin.host
             )
-            state.host2ds[host][event.ds] = DatasetStatus.available
-            state.ds2host[event.ds][host] = DatasetStatus.available
-            state = consider_fetch(state, event.ds, host)
-            state = consider_computable(state, event.ds, host)
+            context.host2ds[host][event.ds] = DatasetStatus.available
+            context.ds2host[event.ds][host] = DatasetStatus.available
+            consider_fetch(state, event.ds, host)
+            consider_computable(schedule, state, context, event.ds, host)
             if event.transmit_idx is not None:
                 mark(
                     {
@@ -113,7 +117,7 @@ def notify(
                         "host": "controller",
                     }
                 )
-            elif is_last_output_of(event.ds, job):
+            elif context.is_last_output_of(event.ds):
                 if not isinstance((worker := event.origin), WorkerId):
                     raise ValueError(
                         f"malformed event, expected origin to be WorkerId: {event}"
@@ -121,8 +125,8 @@ def notify(
                 logger.debug(
                     f"last output of {event.ds.task} published, assuming completion"
                 )
-                state.worker2ts[worker][event.ds.task] = TaskStatus.succeeded
-                state.ts2worker[event.ds.task][worker] = TaskStatus.succeeded
+                context.worker2ts[worker][event.ds.task] = TaskStatus.succeeded
+                context.ts2worker[event.ds.task][worker] = TaskStatus.succeeded
                 mark(
                     {
                         "task": event.ds.task,
@@ -131,20 +135,20 @@ def notify(
                         "host": "controller",
                     }
                 )
-                for sourceDataset in state.edge_i.get(event.ds.task, set()):
+                for sourceDataset in context.edge_i.get(event.ds.task, set()):
                     state.purging_tracker[sourceDataset].remove(event.ds.task)
-                    state = consider_purge(state, sourceDataset)
-                if event.ds.task in state.ongoing[worker]:
-                    state.ongoing[worker].remove(event.ds.task)
-                    state.ongoing_total -= 1
-                    state.remaining -= 1
-                    reporter.send_progress(state)
+                    consider_purge(state, sourceDataset)
+                if event.ds.task in context.ongoing[worker]:
+                    context.ongoing[worker].remove(event.ds.task)
+                    context.ongoing_total -= 1
+                    context.remaining -= 1
+                    reporter.send_progress(context)
                 else:
                     raise ValueError(
                         f"{event.ds.task} succeeded but removal from `ongoing` impossible"
                     )
-                if not state.ongoing[worker]:
-                    state.idle_workers.add(worker)
+                if not context.ongoing[worker]:
+                    context.idle_workers.add(worker)
         elif isinstance(event, DatasetTransmitPayload):
             # TODO ifneedbe get annotation from job.tasks[event.ds.task].definition.output_schema[event.ds.output]
             state.outputs[event.header.ds] = serde.des_output(

--- a/src/cascade/controller/report.py
+++ b/src/cascade/controller/report.py
@@ -18,7 +18,7 @@ from typing_extensions import Self
 
 from cascade.executor.comms import get_context
 from cascade.low.core import DatasetId
-from cascade.scheduler.core import State
+from cascade.low.execution_context import JobExecutionContext
 
 logger = logging.getLogger(__name__)
 
@@ -34,16 +34,16 @@ class JobProgress:
     failure: str | None
 
     @classmethod
-    def failure(cls, failure: str) -> Self:
+    def failed(cls, failure: str) -> Self:
         return cls(True, None, failure)
 
     @classmethod
-    def progress(cls, pct: float) -> Self:
+    def progressed(cls, pct: float) -> Self:
         progress = "{:.2%}".format(pct)[:-1]
         return cls(False, progress, None)
 
     @classmethod
-    def success(cls) -> Self:
+    def succeeded(cls) -> Self:
         return cls(True, None, None)
 
 
@@ -86,13 +86,13 @@ class Reporter:
         self.socket = get_context().socket(zmq.PUSH)
         self.socket.connect(address)
 
-    def send_progress(self, state: State) -> None:
+    def send_progress(self, context: JobExecutionContext) -> None:
         if self.socket is None:
             return
-        pct = 1.0 - state.remaining / state.total
+        pct = 1.0 - context.remaining / context.total
         logger.debug(f"reporting progress {pct=}")
         report = ControllerReport(
-            self.job_id, JobProgress.progress(pct), monotonic_ns(), []
+            self.job_id, JobProgress.progressed(pct), monotonic_ns(), []
         )
         _send(self.socket, report)
 
@@ -110,7 +110,7 @@ class Reporter:
             return
         logger.debug(f"reporting failure {failure=}")
         report = ControllerReport(
-            self.job_id, JobProgress.failure(failure), monotonic_ns(), []
+            self.job_id, JobProgress.failed(failure), monotonic_ns(), []
         )
         _send(self.socket, report)
 
@@ -119,6 +119,6 @@ class Reporter:
             return
         logger.debug("reporter sending shutdown")
         report = ControllerReport(
-            self.job_id, JobProgress.success(), monotonic_ns(), []
+            self.job_id, JobProgress.succeeded(), monotonic_ns(), []
         )
         _send(self.socket, report)

--- a/src/cascade/low/execution_context.py
+++ b/src/cascade/low/execution_context.py
@@ -14,6 +14,7 @@ Primarily manifesting in the JobExecutionContext class -- a proto-scheduler of s
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
+from typing import Iterator
 
 from cascade.low.core import (
     DatasetId,
@@ -79,6 +80,17 @@ class JobExecutionContext:
         # TODO dont sort on each invoke -- precompute
         last = sorted(definition.output_schema.keys())[-1]
         return last == dataset.output
+
+    def purge_dataset(self, ds: DatasetId) -> Iterator[HostId]:
+        """Drop dataset from all tracking structures, yields hosts that should be sent purge command"""
+        for host in self.ds2host[ds]:
+            self.host2ds[host].pop(ds)
+            for worker in self.host2workers[host]:
+                if ds in self.worker2ds[worker]:
+                    self.worker2ds[worker].pop(ds)
+                    self.ds2worker[ds].pop(worker)
+            yield host
+        self.ds2host.pop(ds)
 
     # TODO refac pop idle worker, extend ongoing
     def assign_task(self) -> None:

--- a/src/cascade/low/execution_context.py
+++ b/src/cascade/low/execution_context.py
@@ -96,9 +96,34 @@ class JobExecutionContext:
     def assign_task(self) -> None:
         raise NotImplementedError
 
-    # TODO refac mutate ongoing, ongoing total
-    def finish_task(self) -> None:
-        raise NotImplementedError
+    def task_done(self, task: TaskId, worker: WorkerId) -> None:
+        self.worker2ts[worker][task] = TaskStatus.succeeded
+        self.ts2worker[task][worker] = TaskStatus.succeeded
+        if task in self.ongoing[worker]:
+            self.ongoing[worker].remove(task)
+            self.ongoing_total -= 1
+            self.remaining -= 1
+        else:
+            raise ValueError(f"{task} success but cant remove from `ongoing`")
+        if not self.ongoing[worker]:
+            self.idle_workers.add(worker)
+
+    def dataset_preparing(self, dataset: DatasetId, worker: WorkerId) -> None:
+        # NOTE Currently, these `if`s are necessary because we issue transmit
+        # command when host *has* DS but worker does *not*. This ends up no-op,
+        # but we totally dont want host state to reset -- it wouldnt recover
+        host_s = self.host2ds[worker.host].get(dataset, DatasetStatus.missing)
+        if host_s != DatasetStatus.available:
+            self.host2ds[worker.host][dataset] = DatasetStatus.preparing
+        ds_s = self.ds2host[dataset].get(worker.host, DatasetStatus.missing)
+        if ds_s != DatasetStatus.available:
+            self.ds2host[dataset][worker.host] = DatasetStatus.preparing
+        self.worker2ds[worker][dataset] = DatasetStatus.preparing
+        self.ds2worker[dataset][worker] = DatasetStatus.preparing
+        # TODO check that there is no invalid transition? Eg, if it already was
+        # preparing or available
+        # TODO do we want to do anything for the other workers on the same host?
+        # Probably not, rather consider host2ds during assignments
 
 
 def init_context(

--- a/src/cascade/low/execution_context.py
+++ b/src/cascade/low/execution_context.py
@@ -1,0 +1,121 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Common data structures and utility methods that form the interface between scheduler and controller.
+Primarily manifesting in the JobExecutionContext class -- a proto-scheduler of sorts
+"""
+
+
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import Enum
+
+from cascade.low.core import (
+    DatasetId,
+    Environment,
+    HostId,
+    JobInstance,
+    TaskId,
+    WorkerId,
+)
+
+
+class DatasetStatus(int, Enum):
+    missing = -1  # virtual default status, never stored
+    preparing = 0  # set by controller
+    available = 1  # set by executor
+    purged = 2  # temporal command status used as local comms between controller.act and controller.state
+
+
+class TaskStatus(int, Enum):
+    enqueued = 0  # set by controller
+    running = 1  # set by executor
+    succeeded = 2  # set by executor
+    failed = 3  # set by executor
+
+
+@dataclass
+class JobExecutionContext:
+    """Captures what is where -- datasets, running tasks, ... Used for decision making and progress tracking.
+    Broad interface between (generic) scheduler and controller
+    """
+
+    # static
+    job_instance: JobInstance
+    edge_o: dict[DatasetId, set[TaskId]]
+    edge_i: dict[TaskId, set[DatasetId]]
+    task_o: dict[TaskId, set[DatasetId]]
+    environment: Environment
+
+    # dynamic
+    worker2ds: dict[WorkerId, dict[DatasetId, DatasetStatus]]
+    ds2worker: dict[DatasetId, dict[WorkerId, DatasetStatus]]
+    ts2worker: dict[TaskId, dict[WorkerId, TaskStatus]]
+    worker2ts: dict[WorkerId, dict[TaskId, TaskStatus]]
+    host2ds: dict[HostId, dict[DatasetId, DatasetStatus]]
+    ds2host: dict[DatasetId, dict[HostId, DatasetStatus]]
+    host2workers: dict[HostId, list[WorkerId]]
+
+    # aggregations
+    idle_workers: set[WorkerId]  # all workers such that worker2ts is empty
+    ongoing: dict[WorkerId, set[TaskId]]  # like worker2ts where value is `running`
+    ongoing_total: int  # sum of ongoing
+    total: int  # size of JobInstance
+    remaining: int  # total - sum(tasks that are in `succeeded`)
+
+    def has_awaitable(self) -> bool:
+        return self.ongoing_total > 0 or self.remaining > 0
+
+    def is_last_output_of(self, dataset: DatasetId) -> bool:
+        """For single-output tasks, always true. For generator tasks, true for the last one.
+        Generic KV outputs not supported -- this method wouldnt make any sense.
+        """
+        definition = self.job_instance.tasks[dataset.task].definition
+        # TODO dont sort on each invoke -- precompute
+        last = sorted(definition.output_schema.keys())[-1]
+        return last == dataset.output
+
+    # TODO refac pop idle worker, extend ongoing
+    def assign_task(self) -> None:
+        raise NotImplementedError
+
+    # TODO refac mutate ongoing, ongoing total
+    def finish_task(self) -> None:
+        raise NotImplementedError
+
+
+def init_context(
+    environment: Environment,
+    job_instance: JobInstance,
+    edge_o: dict[DatasetId, set[TaskId]],
+    edge_i: dict[TaskId, set[DatasetId]],
+) -> JobExecutionContext:
+    host2workers: dict[HostId, list[WorkerId]] = defaultdict(list)
+    for worker in environment.workers:
+        host2workers[worker.host].append(worker)
+    task_o = {task: job_instance.outputs_of(task) for task in job_instance.tasks.keys()}
+    total = len(job_instance.tasks.keys())
+    return JobExecutionContext(
+        job_instance=job_instance,
+        edge_o=edge_o,
+        edge_i=edge_i,
+        task_o=task_o,
+        environment=environment,
+        worker2ds=defaultdict(dict),
+        ds2worker=defaultdict(dict),
+        ts2worker=defaultdict(dict),
+        worker2ts=defaultdict(dict),
+        host2ds=defaultdict(dict),
+        ds2host=defaultdict(dict),
+        host2workers=host2workers,
+        idle_workers=set(environment.workers.keys()),
+        ongoing=defaultdict(set),
+        ongoing_total=0,
+        total=total,
+        remaining=total,
+    )

--- a/src/cascade/scheduler/api.py
+++ b/src/cascade/scheduler/api.py
@@ -10,14 +10,8 @@ import logging
 from collections import defaultdict
 from typing import Iterator
 
-from cascade.low.core import (
-    DatasetId,
-    Environment,
-    HostId,
-    JobInstance,
-    TaskId,
-    WorkerId,
-)
+from cascade.low.core import DatasetId, TaskId, WorkerId
+from cascade.low.execution_context import DatasetStatus, JobExecutionContext, TaskStatus
 from cascade.low.tracing import Microtrace, timer
 from cascade.scheduler.assign import (
     assign_within_component,
@@ -28,32 +22,18 @@ from cascade.scheduler.core import (
     Assignment,
     ComponentId,
     ComponentSchedule,
-    DatasetStatus,
     Preschedule,
-    State,
-    TaskStatus,
+    Schedule,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def initialize(
-    environment: Environment, preschedule: Preschedule, outputs: set[DatasetId]
-) -> State:
-    """Initializes State based on Preschedule and Environment. Assigns hosts to components"""
-    purging_tracker = {
-        ds: {task for task in dependants}
-        for ds, dependants in preschedule.edge_o.items()
-    }
-
+def init_schedule(preschedule: Preschedule, context: JobExecutionContext) -> Schedule:
     components: list[ComponentSchedule] = []
     ts2component: dict[TaskId, ComponentId] = {}
-    host2workers: dict[HostId, list[WorkerId]] = defaultdict(list)
-    for worker in environment.workers:
-        host2workers[worker.host].append(worker)
 
     computable = 0
-    total = 0
     for componentId, precomponent in enumerate(preschedule.components):
         component = ComponentSchedule(
             core=precomponent,
@@ -62,7 +42,7 @@ def initialize(
             worker2task_distance={},
             worker2task_values=set(precomponent.sources),
             is_computable_tracker={
-                task: {inp for inp in preschedule.edge_i[task]}
+                task: {inp for inp in context.edge_i[task]}
                 for task in precomponent.nodes
             },
         )
@@ -70,37 +50,17 @@ def initialize(
         computable += len(precomponent.sources)
         for task in precomponent.nodes:
             ts2component[task] = componentId
-        total += len(component.core.nodes)
 
-    return State(
-        edge_o=preschedule.edge_o,
-        edge_i=preschedule.edge_i,
-        task_o=preschedule.task_o,
-        worker2ds=defaultdict(dict),
-        ds2worker=defaultdict(dict),
-        ts2worker=defaultdict(dict),
-        worker2ts=defaultdict(dict),
-        host2ds=defaultdict(dict),
-        ds2host=defaultdict(dict),
+    return Schedule(
         components=components,
         ts2component=ts2component,
-        host2component={host: None for host in host2workers.keys()},
-        host2workers=host2workers,
+        host2component={host: None for host in context.host2workers.keys()},
         computable=computable,
-        remaining=total,
-        total=total,
         worker2task_overhead=defaultdict(dict),
-        idle_workers=set(environment.workers.keys()),
-        ongoing=defaultdict(set),
-        ongoing_total=0,
-        purging_tracker=purging_tracker,
-        purging_queue=[],
-        outputs={e: None for e in outputs},
-        fetching_queue={},
     )
 
 
-def assign(state: State, job: JobInstance, env: Environment) -> Iterator[Assignment]:
+def assign(schedule: Schedule, context: JobExecutionContext) -> Iterator[Assignment]:
     """Given idle workers in `state`, assign actions to workers. Mutates the state:
      - pops from computable & idle workers,
      - decreases weight,
@@ -112,23 +72,23 @@ def assign(state: State, job: JobInstance, env: Environment) -> Iterator[Assignm
 
     # step I: assign within existing components
     component2workers: dict[ComponentId, list[WorkerId]] = defaultdict(list)
-    for worker in state.idle_workers:
-        if (component := state.host2component[worker.host]) is not None:
+    for worker in context.idle_workers:
+        if (component := schedule.host2component[worker.host]) is not None:
             component2workers[component].append(worker)
 
     for component_id, local_workers in component2workers.items():
         if local_workers:
             yield from assign_within_component(
-                state, local_workers, component_id, job, env
+                schedule, local_workers, component_id, context
             )
 
-    if not state.idle_workers:
+    if not context.idle_workers:
         return
 
     # step II: assign remaining workers to new components
     components = [
         (component.weight, component_id)
-        for component_id, component in enumerate(state.components)
+        for component_id, component in enumerate(schedule.components)
         if component.weight > 0
     ]
     if not components:
@@ -138,10 +98,10 @@ def assign(state: State, job: JobInstance, env: Environment) -> Iterator[Assignm
         reverse=True
     )  # TODO consider number of currently assigned workers too
     migrants = defaultdict(list)
-    for worker in state.idle_workers:
+    for worker in context.idle_workers:
         # TODO we dont currently allow partial assignments, this is subopt!
-        if (component := state.host2component[worker.host]) is None or (
-            state.components[component].weight == 0
+        if (component := schedule.host2component[worker.host]) is None or (
+            schedule.components[component].weight == 0
         ):
             migrants[worker.host].append(worker)
         # TODO we ultimately want to be able to have weight-and-capacity-aware m-n host2component
@@ -150,43 +110,48 @@ def assign(state: State, job: JobInstance, env: Environment) -> Iterator[Assignm
     component_i = 0
     for host, workers in migrants.items():
         component_id = components[component_i][1]
-        state = timer(migrate_to_component, Microtrace.ctrl_migrate)(
-            host, component_id, state
+        timer(migrate_to_component, Microtrace.ctrl_migrate)(
+            host, component_id, schedule, context
         )
-        yield from assign_within_component(state, workers, component_id, job, env)
+        yield from assign_within_component(schedule, workers, component_id, context)
         component_i = (component_i + 1) % len(components)
 
 
 def _set_preparing_at(
-    dataset: DatasetId, worker: WorkerId, state: State, children: set[TaskId]
-) -> State:
+    dataset: DatasetId,
+    worker: WorkerId,
+    schedule: Schedule,
+    context: JobExecutionContext,
+    children: set[TaskId],
+):
     # NOTE this may need to change once we switch to persistent workers. Currently, these `if`s are necessary
     # because we issue transmit command when host *has* DS but worker does *not*. This ends up a no-op, but we
     # totally dont want the host state to reset -- because it wouldnt recover from it
     if (
-        state.host2ds[worker.host].get(dataset, DatasetStatus.missing)
+        context.host2ds[worker.host].get(dataset, DatasetStatus.missing)
         != DatasetStatus.available
     ):
-        state.host2ds[worker.host][dataset] = DatasetStatus.preparing
-    state.host2ds[worker.host][dataset] = DatasetStatus.preparing
+        context.host2ds[worker.host][dataset] = DatasetStatus.preparing
+    context.host2ds[worker.host][dataset] = DatasetStatus.preparing
     if (
-        state.ds2host[dataset].get(worker.host, DatasetStatus.missing)
+        context.ds2host[dataset].get(worker.host, DatasetStatus.missing)
         != DatasetStatus.available
     ):
-        state.ds2host[dataset][worker.host] = DatasetStatus.preparing
-    state.worker2ds[worker][dataset] = DatasetStatus.preparing
-    state.ds2worker[dataset][worker] = DatasetStatus.preparing
+        context.ds2host[dataset][worker.host] = DatasetStatus.preparing
+    context.worker2ds[worker][dataset] = DatasetStatus.preparing
+    context.ds2worker[dataset][worker] = DatasetStatus.preparing
     # TODO check that there is no invalid transition? Eg, if it already was preparing or available
     # TODO do we want to do anything for the other workers on the same host? Probably not, rather consider
     # host2ds during assignments
 
     for task in children:
-        component_id = state.ts2component[task]
-        state = update_worker2task_distance(component_id, task, worker, state)
-    return state
+        component_id = schedule.ts2component[task]
+        update_worker2task_distance(component_id, task, worker, schedule, context)
 
 
-def plan(state: State, assignments: list[Assignment]) -> State:
+def plan(
+    schedule: Schedule, context: JobExecutionContext, assignments: list[Assignment]
+):
     """Given actions that were just sent to a worker, update state to reflect it, including preparation
     and planning for future assignments.
     Unlike `assign`, this is less performance critical, so slightly longer calculations can happen here.
@@ -197,17 +162,15 @@ def plan(state: State, assignments: list[Assignment]) -> State:
 
     for assignment in assignments:
         for prep in assignment.prep:
-            children = state.purging_tracker[prep[0]]
-            state = _set_preparing_at(prep[0], assignment.worker, state, children)
+            children = context.edge_o[prep[0]]
+            _set_preparing_at(prep[0], assignment.worker, schedule, context, children)
         for task in assignment.tasks:
             for ds in assignment.outputs:
-                children = state.edge_o[ds]
-                state = _set_preparing_at(ds, assignment.worker, state, children)
-            state.worker2ts[assignment.worker][task] = TaskStatus.enqueued
-            state.ts2worker[task][assignment.worker] = TaskStatus.enqueued
-            if task in state.ongoing[assignment.worker]:
+                children = context.edge_o[ds]
+                _set_preparing_at(ds, assignment.worker, schedule, context, children)
+            context.worker2ts[assignment.worker][task] = TaskStatus.enqueued
+            context.ts2worker[task][assignment.worker] = TaskStatus.enqueued
+            if task in context.ongoing[assignment.worker]:
                 raise ValueError(f"double add of {task} to {assignment.worker}")
-            state.ongoing[assignment.worker].add(task)
-            state.ongoing_total += 1
-
-    return state
+            context.ongoing[assignment.worker].add(task)
+            context.ongoing_total += 1

--- a/src/cascade/scheduler/api.py
+++ b/src/cascade/scheduler/api.py
@@ -10,8 +10,8 @@ import logging
 from collections import defaultdict
 from typing import Iterator
 
-from cascade.low.core import DatasetId, TaskId, WorkerId
-from cascade.low.execution_context import DatasetStatus, JobExecutionContext, TaskStatus
+from cascade.low.core import TaskId, WorkerId
+from cascade.low.execution_context import JobExecutionContext, TaskStatus
 from cascade.low.tracing import Microtrace, timer
 from cascade.scheduler.assign import (
     assign_within_component,
@@ -117,38 +117,6 @@ def assign(schedule: Schedule, context: JobExecutionContext) -> Iterator[Assignm
         component_i = (component_i + 1) % len(components)
 
 
-def _set_preparing_at(
-    dataset: DatasetId,
-    worker: WorkerId,
-    schedule: Schedule,
-    context: JobExecutionContext,
-    children: set[TaskId],
-):
-    # NOTE this may need to change once we switch to persistent workers. Currently, these `if`s are necessary
-    # because we issue transmit command when host *has* DS but worker does *not*. This ends up a no-op, but we
-    # totally dont want the host state to reset -- because it wouldnt recover from it
-    if (
-        context.host2ds[worker.host].get(dataset, DatasetStatus.missing)
-        != DatasetStatus.available
-    ):
-        context.host2ds[worker.host][dataset] = DatasetStatus.preparing
-    context.host2ds[worker.host][dataset] = DatasetStatus.preparing
-    if (
-        context.ds2host[dataset].get(worker.host, DatasetStatus.missing)
-        != DatasetStatus.available
-    ):
-        context.ds2host[dataset][worker.host] = DatasetStatus.preparing
-    context.worker2ds[worker][dataset] = DatasetStatus.preparing
-    context.ds2worker[dataset][worker] = DatasetStatus.preparing
-    # TODO check that there is no invalid transition? Eg, if it already was preparing or available
-    # TODO do we want to do anything for the other workers on the same host? Probably not, rather consider
-    # host2ds during assignments
-
-    for task in children:
-        component_id = schedule.ts2component[task]
-        update_worker2task_distance(component_id, task, worker, schedule, context)
-
-
 def plan(
     schedule: Schedule, context: JobExecutionContext, assignments: list[Assignment]
 ):
@@ -162,12 +130,16 @@ def plan(
 
     for assignment in assignments:
         for prep in assignment.prep:
+            context.dataset_preparing(prep[0], assignment.worker)
             children = context.edge_o[prep[0]]
-            _set_preparing_at(prep[0], assignment.worker, schedule, context, children)
+            update_worker2task_distance(children, assignment.worker, schedule, context)
         for task in assignment.tasks:
             for ds in assignment.outputs:
                 children = context.edge_o[ds]
-                _set_preparing_at(ds, assignment.worker, schedule, context, children)
+                context.dataset_preparing(ds, assignment.worker)
+                update_worker2task_distance(
+                    children, assignment.worker, schedule, context
+                )
             context.worker2ts[assignment.worker][task] = TaskStatus.enqueued
             context.ts2worker[task][assignment.worker] = TaskStatus.enqueued
             if task in context.ongoing[assignment.worker]:

--- a/src/cascade/scheduler/assign.py
+++ b/src/cascade/scheduler/assign.py
@@ -13,7 +13,7 @@ for all other purposes this should be treated private
 import logging
 from collections import defaultdict
 from time import perf_counter_ns
-from typing import Iterator
+from typing import Iterable, Iterator
 
 from cascade.low.core import DatasetId, HostId, TaskId, WorkerId
 from cascade.low.execution_context import DatasetStatus, JobExecutionContext
@@ -155,8 +155,7 @@ def assign_within_component(
 
 
 def update_worker2task_distance(
-    component_id: ComponentId,
-    task: TaskId,
+    tasks: Iterable[TaskId],
     worker: WorkerId,
     schedule: Schedule,
     context: JobExecutionContext,
@@ -168,24 +167,26 @@ def update_worker2task_distance(
     # TODO we don't currently consider other workers at the host, probably subopt! Ultimately,
     # we need the `assign_within_component` to take both overhead *and* distance into account
     # simultaneously
-    worker2task = schedule.components[component_id].worker2task_distance
-    task2task = schedule.components[component_id].core.distance_matrix
     eligible = {DatasetStatus.preparing, DatasetStatus.available}
-    schedule.components[component_id].worker2task_values.add(task)
-    computable = schedule.components[component_id].computable
-    for ds_key, ds_status in context.worker2ds[worker].items():
-        if ds_status not in eligible:
-            continue
-        if schedule.ts2component[ds_key.task] != component_id:
-            continue
-        # TODO we only consider min task distance, whereas weighing by volume/ratio would make more sense
-        val = min(
-            worker2task[worker][task],
-            task2task[ds_key.task][task],
-        )
-        worker2task[worker][task] = val
-        if ((current := computable.get(task, None)) is not None) and current > val:
-            computable[task] = val
+    for task in tasks:
+        component_id = schedule.ts2component[task]
+        worker2task = schedule.components[component_id].worker2task_distance
+        task2task = schedule.components[component_id].core.distance_matrix
+        schedule.components[component_id].worker2task_values.add(task)
+        computable = schedule.components[component_id].computable
+        for ds_key, ds_status in context.worker2ds[worker].items():
+            if ds_status not in eligible:
+                continue
+            if schedule.ts2component[ds_key.task] != component_id:
+                continue
+            # TODO we only consider min task distance, whereas weighing by volume/ratio would make more sense
+            val = min(
+                worker2task[worker][task],
+                task2task[ds_key.task][task],
+            )
+            worker2task[worker][task] = val
+            if ((current := computable.get(task, None)) is not None) and current > val:
+                computable[task] = val
 
 
 def set_worker2task_overhead(
@@ -230,6 +231,8 @@ def migrate_to_component(
         component.worker2task_distance[worker] = defaultdict(
             lambda: component.core.depth
         )
+        update_worker2task_distance(
+            component.worker2task_values, worker, schedule, context
+        )
         for task in component.worker2task_values:
-            update_worker2task_distance(component_id, task, worker, schedule, context)
             set_worker2task_overhead(schedule, context, worker, task)

--- a/src/cascade/scheduler/assign.py
+++ b/src/cascade/scheduler/assign.py
@@ -15,29 +15,25 @@ from collections import defaultdict
 from time import perf_counter_ns
 from typing import Iterator
 
-from cascade.low.core import (
-    DatasetId,
-    Environment,
-    HostId,
-    JobInstance,
-    TaskId,
-    WorkerId,
-)
+from cascade.low.core import DatasetId, HostId, TaskId, WorkerId
+from cascade.low.execution_context import DatasetStatus, JobExecutionContext
 from cascade.low.tracing import Microtrace, trace
-from cascade.scheduler.core import Assignment, ComponentId, DatasetStatus, State
+from cascade.scheduler.core import Assignment, ComponentId, Schedule
 
 logger = logging.getLogger(__name__)
 
 
-def build_assignment(worker: WorkerId, task: TaskId, state: State) -> Assignment:
+def build_assignment(
+    worker: WorkerId, task: TaskId, context: JobExecutionContext
+) -> Assignment:
     eligible_load = {DatasetStatus.preparing, DatasetStatus.available}
     eligible_transmit = {DatasetStatus.available}
     prep: list[tuple[DatasetId, HostId]] = []
-    for dataset in state.edge_i[task]:
-        at_worker = state.worker2ds[worker]
+    for dataset in context.edge_i[task]:
+        at_worker = context.worker2ds[worker]
         if at_worker.get(dataset, DatasetStatus.missing) not in eligible_load:
             if (
-                state.host2ds[worker.host].get(dataset, DatasetStatus.missing)
+                context.host2ds[worker.host].get(dataset, DatasetStatus.missing)
                 in eligible_load
             ):
                 # NOTE this currently leads to no-op, but with persistent workers would possibly allow an early fetch
@@ -45,15 +41,15 @@ def build_assignment(worker: WorkerId, task: TaskId, state: State) -> Assignment
             else:
                 if any(
                     candidate := host
-                    for host, status in state.ds2host[dataset].items()
+                    for host, status in context.ds2host[dataset].items()
                     if status in eligible_transmit
                 ):
                     prep.append((dataset, candidate))
                     # NOTE this is a slight hack, to prevent issuing further transmit commands of this ds to this host
                     # in this phase. A proper state transition happens later in the `plan` phase. We may want to instead
                     # create a new `transmit_queue` state field to capture this, and consume it later during plan
-                    state.host2ds[worker.host][dataset] = DatasetStatus.preparing
-                    state.ds2host[dataset][worker.host] = DatasetStatus.preparing
+                    context.host2ds[worker.host][dataset] = DatasetStatus.preparing
+                    context.ds2host[dataset][worker.host] = DatasetStatus.preparing
                 else:
                     raise ValueError(f"{dataset=} not found in any host, whoa whoa!")
 
@@ -64,20 +60,21 @@ def build_assignment(worker: WorkerId, task: TaskId, state: State) -> Assignment
         ],  # TODO eager fusing for outdeg=1? Or heuristic via ratio of outdeg vs workers@component?
         prep=prep,
         outputs={  # TODO trim for only the necessary ones
-            ds for ds in state.task_o[task]
+            ds for ds in context.task_o[task]
         },
     )
 
 
 def _assignment_heuristic(
-    state: State,
+    schedule: Schedule,
     tasks: list[TaskId],
     workers: list[WorkerId],
     component_id: ComponentId,
+    context: JobExecutionContext,
 ) -> Iterator[Assignment]:
     """Finds a reasonable assignment within a single component. Does not migrate hosts to a different component"""
     start = perf_counter_ns()
-    component = state.components[component_id]
+    component = schedule.components[component_id]
 
     # first, attempt optimum-distance assignment
     unassigned: list[TaskId] = []
@@ -88,14 +85,14 @@ def _assignment_heuristic(
             if component.worker2task_distance[worker][task] == opt_dist:
                 end = perf_counter_ns()
                 trace(Microtrace.ctrl_assign, end - start)
-                yield build_assignment(worker, task, state)
+                yield build_assignment(worker, task, context)
                 start = perf_counter_ns()
                 workers.pop(idx)
                 component.computable.pop(task)
                 component.worker2task_values.remove(task)
                 component.weight -= 1
-                state.computable -= 1
-                state.idle_workers.remove(worker)
+                schedule.computable -= 1
+                context.idle_workers.remove(worker)
                 was_assigned = True
                 break
         if not was_assigned:
@@ -105,7 +102,7 @@ def _assignment_heuristic(
     remaining_t = set(unassigned)
     remaining_w = set(workers)
     candidates = [
-        (state.worker2task_overhead[w][t], component.core.value[t], w, t)
+        (schedule.worker2task_overhead[w][t], component.core.value[t], w, t)
         for w in workers
         for t in remaining_t
     ]
@@ -114,14 +111,14 @@ def _assignment_heuristic(
         if task in remaining_t and worker in remaining_w:
             end = perf_counter_ns()
             trace(Microtrace.ctrl_assign, end - start)
-            yield build_assignment(worker, task, state)
+            yield build_assignment(worker, task, context)
             start = perf_counter_ns()
             component.computable.pop(task)
             component.worker2task_values.remove(task)
             remaining_t.remove(task)
             remaining_w.remove(worker)
-            state.idle_workers.remove(worker)
-            state.computable -= 1
+            context.idle_workers.remove(worker)
+            schedule.computable -= 1
             component.weight -= 1
 
     end = perf_counter_ns()
@@ -129,11 +126,10 @@ def _assignment_heuristic(
 
 
 def assign_within_component(
-    state: State,
+    schedule: Schedule,
     workers: list[WorkerId],
     component_id: ComponentId,
-    job: JobInstance,
-    env: Environment,
+    context: JobExecutionContext,
 ) -> Iterator[Assignment]:
     """We first handle gpu things, second cpu things, using the same algorithm for either case"""
     # TODO employ a more systematic solution and handle all multicriterially at once -- ideally together with adding support for multi-gpu-groups
@@ -141,26 +137,30 @@ def assign_within_component(
     gpu_t: list[TaskId] = []
     gpu_w: list[WorkerId] = []
     cpu_w: list[WorkerId] = []
-    for task in state.components[component_id].computable.keys():
-        if job.tasks[task].definition.needs_gpu:
+    for task in schedule.components[component_id].computable.keys():
+        if context.job_instance.tasks[task].definition.needs_gpu:
             gpu_t.append(task)
         else:
             cpu_t.append(task)
     for worker in workers:
-        if env.workers[worker].gpu > 0:
+        if context.environment.workers[worker].gpu > 0:
             gpu_w.append(worker)
         else:
             cpu_w.append(worker)
-    yield from _assignment_heuristic(state, gpu_t, gpu_w, component_id)
+    yield from _assignment_heuristic(schedule, gpu_t, gpu_w, component_id, context)
     for worker in gpu_w:
-        if worker in state.idle_workers:
+        if worker in context.idle_workers:
             cpu_w.append(worker)
-    yield from _assignment_heuristic(state, cpu_t, cpu_w, component_id)
+    yield from _assignment_heuristic(schedule, cpu_t, cpu_w, component_id, context)
 
 
 def update_worker2task_distance(
-    component_id: ComponentId, task: TaskId, worker: WorkerId, state: State
-) -> State:
+    component_id: ComponentId,
+    task: TaskId,
+    worker: WorkerId,
+    schedule: Schedule,
+    context: JobExecutionContext,
+):
     """For a given task and worker, consider all tasks at the worker and see if any attains a better distance to said
     task. If additionally the task is _already_ computable and the global minimum attained by `component.computable`
     is improved, set that too.
@@ -168,15 +168,15 @@ def update_worker2task_distance(
     # TODO we don't currently consider other workers at the host, probably subopt! Ultimately,
     # we need the `assign_within_component` to take both overhead *and* distance into account
     # simultaneously
-    worker2task = state.components[component_id].worker2task_distance
-    task2task = state.components[component_id].core.distance_matrix
+    worker2task = schedule.components[component_id].worker2task_distance
+    task2task = schedule.components[component_id].core.distance_matrix
     eligible = {DatasetStatus.preparing, DatasetStatus.available}
-    state.components[component_id].worker2task_values.add(task)
-    computable = state.components[component_id].computable
-    for ds_key, ds_status in state.worker2ds[worker].items():
+    schedule.components[component_id].worker2task_values.add(task)
+    computable = schedule.components[component_id].computable
+    for ds_key, ds_status in context.worker2ds[worker].items():
         if ds_status not in eligible:
             continue
-        if state.ts2component[ds_key.task] != component_id:
+        if schedule.ts2component[ds_key.task] != component_id:
             continue
         # TODO we only consider min task distance, whereas weighing by volume/ratio would make more sense
         val = min(
@@ -187,49 +187,49 @@ def update_worker2task_distance(
         if ((current := computable.get(task, None)) is not None) and current > val:
             computable[task] = val
 
-    return state
 
-
-def set_worker2task_overhead(state: State, worker: WorkerId, task: TaskId) -> State:
+def set_worker2task_overhead(
+    schedule: Schedule, context: JobExecutionContext, worker: WorkerId, task: TaskId
+):
     # NOTE beware this is used in migrate host2component as well as twice in notify. We may
     # want to later distinguish between `calc_new` (for migrate and new computable) vs
     # `calc_update` (basicaly when host2host transmit finishes)
     # TODO replace the numerical heuristic here with some numbers based on transfer speeds
     # and dataset volumes
     overhead = 0
-    for ds in state.edge_i[task]:
-        workerState = state.worker2ds[worker].get(ds, DatasetStatus.missing)
+    for ds in context.edge_i[task]:
+        workerState = context.worker2ds[worker].get(ds, DatasetStatus.missing)
         if workerState == DatasetStatus.available:
             continue
         if workerState == DatasetStatus.preparing:
             overhead += 1
             continue
-        hostState = state.host2ds[worker.host].get(ds, DatasetStatus.missing)
+        hostState = context.host2ds[worker.host].get(ds, DatasetStatus.missing)
         if hostState == DatasetStatus.available or hostState == DatasetStatus.preparing:
             overhead += 10
             continue
         overhead += 100
-    state.worker2task_overhead[worker][task] = overhead
-    return state
+    schedule.worker2task_overhead[worker][task] = overhead
 
 
 def migrate_to_component(
-    host: HostId, component_id: ComponentId, state: State
-) -> State:
+    host: HostId,
+    component_id: ComponentId,
+    schedule: Schedule,
+    context: JobExecutionContext,
+):
     """Assuming original component assigned to the host didn't have enough tasks anymore,
     we invoke this function and update state to reflect it
     """
-    state.host2component[host] = component_id
-    component = state.components[component_id]
+    schedule.host2component[host] = component_id
+    component = schedule.components[component_id]
     logger.debug(
         f"migrate {host=} to {component_id=} => {component.worker2task_values=}"
     )
-    for worker in state.host2workers[host]:
+    for worker in context.host2workers[host]:
         component.worker2task_distance[worker] = defaultdict(
             lambda: component.core.depth
         )
         for task in component.worker2task_values:
-            state = update_worker2task_distance(component_id, task, worker, state)
-            state = set_worker2task_overhead(state, worker, task)
-
-    return state
+            update_worker2task_distance(component_id, task, worker, schedule, context)
+            set_worker2task_overhead(schedule, context, worker, task)

--- a/src/cascade/scheduler/core.py
+++ b/src/cascade/scheduler/core.py
@@ -7,8 +7,6 @@
 # nor does it submit to any jurisdiction.
 
 from dataclasses import dataclass
-from enum import Enum
-from typing import Any
 
 from cascade.low.core import DatasetId, HostId, TaskId, WorkerId
 
@@ -35,7 +33,6 @@ class Preschedule:
     components: list[ComponentCore]  # sorted desc by weight
     edge_o: dict[DatasetId, set[TaskId]]
     edge_i: dict[TaskId, set[DatasetId]]
-    task_o: dict[TaskId, set[DatasetId]]
 
 
 Worker2TaskDistance = dict[WorkerId, dict[TaskId, int]]
@@ -59,73 +56,17 @@ class ComponentSchedule:
     worker2task_values: set[TaskId]
 
 
-class DatasetStatus(int, Enum):
-    missing = -1  # virtual default status, never stored
-    preparing = 0  # set by controller
-    available = 1  # set by executor
-    purged = 2  # temporal command status used as local comms between controller.act and controller.state
-
-
-class TaskStatus(int, Enum):
-    enqueued = 0  # set by controller
-    running = 1  # set by executor
-    succeeded = 2  # set by executor
-    failed = 3  # set by executor
-
-
 @dataclass
-class State:
-    """Captures what is where -- datasets, running tasks, ... Used for decision making and progress tracking"""
-
-    # NOTE there is some leak of controller's trackers in here... but the whole scheduler-controller-executorFacade
-    # separation is getting quite weird
-
-    # lookups
-    edge_o: dict[DatasetId, set[TaskId]]
-    edge_i: dict[TaskId, set[DatasetId]]
-    task_o: dict[TaskId, set[DatasetId]]
-    worker2ds: dict[WorkerId, dict[DatasetId, DatasetStatus]]
-    ds2worker: dict[DatasetId, dict[WorkerId, DatasetStatus]]
-    ts2worker: dict[TaskId, dict[WorkerId, TaskStatus]]
-    worker2ts: dict[WorkerId, dict[TaskId, TaskStatus]]
-    host2ds: dict[HostId, dict[DatasetId, DatasetStatus]]
-    ds2host: dict[DatasetId, dict[HostId, DatasetStatus]]
-
-    # schedule -- updated by scheduler.api.{assign, plan}, except `computable` and `components.computable` which controller.notify updates
+class Schedule:
     components: list[ComponentSchedule]
     ts2component: dict[TaskId, ComponentId]
     host2component: dict[HostId, ComponentId | None]
-    host2workers: dict[HostId, list[WorkerId]]
-    computable: int
-    remaining: int
-    total: int
     worker2task_overhead: Worker2TaskDistance
 
-    # trackers
-    # add by controller.notify, remove by scheduler.api.assign
-    idle_workers: set[WorkerId]
-    # add by scheduler.api.plan, remove by controller.notify. A projection of worker2ts for running only
-    ongoing: dict[WorkerId, set[TaskId]]
-    ongoing_total: int  # view of the above
-    # NOTE the purging_tracker is also used in `consider_computable` and `api.plan` -- come up with a better name! Or separate lookup from tracker?
-    # add by scheduler.api.initialize, remove by controller.notify
-    purging_tracker: dict[DatasetId, set[TaskId]]
-    # add by controller.act post-fetch and by controller.notify, removed by controller.act.
-    # TODO extend with `at`, for fine graining?
-    purging_queue: list[DatasetId]
-    # key add by scheduler.api.init, value add by controller.notify
-    outputs: dict[DatasetId, Any]
-    # add by controller.notify, remove by controller.act
-    fetching_queue: dict[DatasetId, HostId]
+    computable: int  # sum over components.computable
 
-
-def has_computable(state: State) -> bool:
-    return state.computable > 0
-
-
-def has_awaitable(state: State) -> bool:
-    # TODO replace the None in outputs with check on fetch queue (but change that from binary to ternary first)
-    return state.ongoing_total > 0 or (None in state.outputs.values())
+    def has_computable(self) -> bool:
+        return self.computable > 0
 
 
 @dataclass

--- a/src/cascade/scheduler/graph.py
+++ b/src/cascade/scheduler/graph.py
@@ -160,19 +160,17 @@ def enrich(
 
 
 def precompute(job_instance: JobInstance) -> Preschedule:
-    edge_o: dict[DatasetId, set[TaskId]] = dependants(job_instance.edges)
+    edge_o = dependants(job_instance.edges)
+    edge_i: dict[TaskId, set[DatasetId]] = defaultdict(set)
+    for task, inputs in param_source(job_instance.edges).items():
+        edge_i[task] = {e for e in inputs.values()}
     edge_o_proj: dict[TaskId, set[TaskId]] = defaultdict(set)
     for dataset, outs in edge_o.items():
         edge_o_proj[dataset.task] = edge_o_proj[dataset.task].union(outs)
 
-    edge_i: dict[TaskId, set[DatasetId]] = defaultdict(set)
-    for task, inputs in param_source(job_instance.edges).items():
-        edge_i[task] = {e for e in inputs.values()}
     edge_i_proj: dict[TaskId, set[TaskId]] = defaultdict(set)
     for vert, inps in edge_i.items():
         edge_i_proj[vert] = {dataset.task for dataset in inps}
-
-    task_o = {task: job_instance.outputs_of(task) for task in job_instance.tasks.keys()}
 
     with ThreadPoolExecutor(max_workers=4) as tp:
         # TODO if coptrs is not used, then this doesnt make sense
@@ -191,6 +189,4 @@ def precompute(job_instance: JobInstance) -> Preschedule:
 
     components.sort(key=lambda c: c.weight(), reverse=True)
 
-    return Preschedule(
-        components=components, edge_o=edge_o, edge_i=edge_i, task_o=task_o
-    )
+    return Preschedule(components=components, edge_o=edge_o, edge_i=edge_i)

--- a/tests/cascade/scheduler/test_api.py
+++ b/tests/cascade/scheduler/test_api.py
@@ -9,8 +9,9 @@
 """Tests calculation of preschedule, state initialize & first assign and plan"""
 
 from cascade.low.core import DatasetId, WorkerId
-from cascade.scheduler.api import assign, initialize, plan
-from cascade.scheduler.core import Assignment, TaskStatus
+from cascade.low.execution_context import TaskStatus, init_context
+from cascade.scheduler.api import assign, init_schedule, plan
+from cascade.scheduler.core import Assignment
 from cascade.scheduler.graph import precompute
 
 from .util import get_env, get_job0, get_job1
@@ -25,8 +26,9 @@ def test_job0():
 
     h1w1 = get_env(1, 1)
     h1w1_w = WorkerId("h0", "w0")
-    state = initialize(h1w1, preschedule, set())
-    assignment = list(assign(state, job0, h1w1))
+    context = init_context(h1w1, job0, preschedule.edge_o, preschedule.edge_i)
+    schedule = init_schedule(preschedule, context)
+    assignment = list(assign(schedule, context))
     assert assignment == [
         Assignment(
             worker=h1w1_w,
@@ -36,8 +38,8 @@ def test_job0():
         )
     ]
 
-    state = plan(state, assignment)
-    assert state.worker2ts == {h1w1_w: {"source": TaskStatus.enqueued}}
+    plan(schedule, context, assignment)
+    assert context.worker2ts == {h1w1_w: {"source": TaskStatus.enqueued}}
 
 
 def test_job1():
@@ -46,8 +48,9 @@ def test_job1():
 
     h1w1 = get_env(1, 1)
     h1w1_w = WorkerId("h0", "w0")
-    state = initialize(h1w1, preschedule, set())
-    assignment = list(assign(state, job1, h1w1))
+    context = init_context(h1w1, job1, preschedule.edge_o, preschedule.edge_i)
+    schedule = init_schedule(preschedule, context)
+    assignment = list(assign(schedule, context))
     assert assignment == [
         Assignment(
             worker=h1w1_w,
@@ -57,8 +60,8 @@ def test_job1():
         )
     ]
 
-    state = plan(state, assignment)
-    assert state.worker2ts == {h1w1_w: {"source": TaskStatus.enqueued}}
+    plan(schedule, context, assignment)
+    assert context.worker2ts == {h1w1_w: {"source": TaskStatus.enqueued}}
 
 
 # TODO add some multi-source or multi-component job


### PR DESCRIPTION
The `State` in scheduler was a bloated spaghetti object that was mutated all over place. In this PR, we factor out two subobjects (`controller.state` and `low.execution_context`), with different lifecycles and responsibilities

This is motivated by future work in cascade such as (re)introducing simulating executor, or introduction of alternative schedulers such as ML- or CSP-based