### PR TITLE
[cascade.low.core] output schema user friendly

### DIFF
--- a/src/cascade/benchmarks/generators.py
+++ b/src/cascade/benchmarks/generators.py
@@ -44,7 +44,7 @@ def get_job() -> JobInstance:
         func=TaskDefinition.func_enc(generator),
         environment=[],
         input_schema={},
-        output_schema={f"{i}": "ndarray" for i in range(N)},
+        output_schema=[(f"{i}", "ndarray") for i in range(N)],
     )
     generator_i = TaskInstance(
         definition=generator_d, static_input_kw={}, static_input_ps={}

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -46,14 +46,14 @@ class RunnerContext:
     param_source: dict[TaskId, dict[int | str, DatasetId]]
 
     def project(self, taskSequence: TaskSequence) -> ExecutionContext:
+        schema_lookup: dict[DatasetId, str] = {}
+        for task_id, task_instance in self.job.tasks.items():
+            for output, fqn in task_instance.definition.output_schema:
+                schema_lookup[DatasetId(task_id, output)] = fqn
+
         param_source_ext: dict[TaskId, dict[int | str, tuple[DatasetId, str]]] = {
             task: {
-                k: (
-                    dataset_id,
-                    self.job.tasks[dataset_id.task].definition.output_schema[
-                        dataset_id.output
-                    ],
-                )
+                k: (dataset_id, schema_lookup[dataset_id])
                 for k, dataset_id in self.param_source[task].items()
             }
             for task in taskSequence.tasks
@@ -143,9 +143,7 @@ def entrypoint(runnerContext: RunnerContext):
                 } - {
                     DatasetId(task, key)
                     for task in mDes.tasks
-                    for key in runnerContext.job.tasks[
-                        task
-                    ].definition.output_schema.keys()
+                    for key, _ in runnerContext.job.tasks[task].definition.output_schema
                 }
                 missing_ds = required - availab_ds
                 if missing_ds:

--- a/src/cascade/executor/runner/runner.py
+++ b/src/cascade/executor/runner/runner.py
@@ -72,8 +72,7 @@ def run(taskId: TaskId, executionContext: ExecutionContext, memory: Memory) -> N
         else:
             assert_never(param_pos)
 
-    outputs = list(task.definition.output_schema.items())
-    outputs.sort()
+    outputs = task.definition.output_schema
     outputsN = len(outputs)
     if outputsN == 0:
         raise ValueError(f"no output key for task {taskId}")

--- a/src/cascade/low/builders.py
+++ b/src/cascade/low/builders.py
@@ -52,7 +52,7 @@ class TaskBuilder(TaskInstance):
             func=TaskDefinition.func_enc(f),
             environment=environment if environment else [],
             input_schema=input_schema,
-            output_schema={Node.DEFAULT_OUTPUT: type2str(sig.return_annotation)},
+            output_schema=[(Node.DEFAULT_OUTPUT, type2str(sig.return_annotation))],
         )
         return cls(
             definition=definition, static_input_kw=static_input_kw, static_input_ps={}
@@ -74,7 +74,7 @@ class TaskBuilder(TaskInstance):
             func=None,
             environment=environment if environment else [],
             input_schema=input_schema,
-            output_schema={Node.DEFAULT_OUTPUT: output_class},
+            output_schema=[(Node.DEFAULT_OUTPUT, output_class)],
         )
         return cls(definition=definition, static_input_kw={}, static_input_ps={})
 
@@ -133,9 +133,9 @@ class JobBuilder:
             if not source_task:
                 yield f"edge pointing from non-existent task {edge.source}"
             else:
-                output_param = source_task.definition.output_schema.get(
-                    edge.source.output, None
-                )
+                for key, schema in source_task.definition.output_schema:
+                    if key == edge.source.output:
+                        output_param = schema
                 if not output_param:
                     yield f"edge pointing from non-existent param {edge.source.output}"
             sink_task = self.nodes.get(edge.sink_task, None)

--- a/src/cascade/low/core.py
+++ b/src/cascade/low/core.py
@@ -45,8 +45,8 @@ class TaskDefinition(BaseModel):
     input_schema: dict[str, str] = Field(
         description="kv of input kw params and their types (fqn of class). Non-kw params not validated"
     )
-    output_schema: dict[str, str] = Field(
-        description="kv of outputs and their types (fqn of class). Assumes key-sorted corresponds to func output order"
+    output_schema: list[tuple[str, str]] = Field(
+        description="kv of outputs and their types (fqn of class). Assumes listing in func output order"
     )
     needs_gpu: bool = Field(
         False
@@ -120,7 +120,7 @@ class JobInstance(BaseModel):
     def outputs_of(self, task_id: TaskId) -> set[DatasetId]:
         return {
             DatasetId(task_id, output)
-            for output in self.tasks[task_id].definition.output_schema.keys()
+            for output, _ in self.tasks[task_id].definition.output_schema
         }
 
 

--- a/src/cascade/low/execution_context.py
+++ b/src/cascade/low/execution_context.py
@@ -77,8 +77,7 @@ class JobExecutionContext:
         Generic KV outputs not supported -- this method wouldnt make any sense.
         """
         definition = self.job_instance.tasks[dataset.task].definition
-        # TODO dont sort on each invoke -- precompute
-        last = sorted(definition.output_schema.keys())[-1]
+        last = definition.output_schema[-1][0]
         return last == dataset.output
 
     def purge_dataset(self, ds: DatasetId) -> Iterator[HostId]:

--- a/src/cascade/low/into.py
+++ b/src/cascade/low/into.py
@@ -76,7 +76,7 @@ def node2task(name: str, node: dict) -> tuple[TaskInstance, list[Task2TaskEdge]]
         environment=cast(list[str], metadata.get("environment", [])),
         entrypoint="",
         input_schema=input_schema,
-        output_schema={e: "Any" for e in outputs},
+        output_schema=[(e, "Any") for e in outputs],
         needs_gpu=cast(bool, metadata.get("needs_gpu", False)),
     )
     task = TaskInstance(

--- a/src/earthkit/workflows/fluent.py
+++ b/src/earthkit/workflows/fluent.py
@@ -140,7 +140,9 @@ class Node(BaseNode):
         super().__init__(
             name,
             outputs=(
-            None if num_outputs == 1 else [f"{x:0{len(str(num_outputs - 1))}d}" for x in range(num_outputs)]
+                None
+                if num_outputs == 1
+                else [f"{x:0{len(str(num_outputs - 1))}d}" for x in range(num_outputs)]
             ),
             payload=payload,
             **{self.input_name(x): node for x, node in enumerate(inputs)},

--- a/src/earthkit/workflows/fluent.py
+++ b/src/earthkit/workflows/fluent.py
@@ -140,7 +140,7 @@ class Node(BaseNode):
         super().__init__(
             name,
             outputs=(
-                None if num_outputs == 1 else [str(x) for x in range(num_outputs)]
+            None if num_outputs == 1 else [f"{x:0{len(str(num_outputs - 1))}d}" for x in range(num_outputs)]
             ),
             payload=payload,
             **{self.input_name(x): node for x, node in enumerate(inputs)},

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -66,7 +66,7 @@ def test_executor():
         func=TaskDefinition.func_enc(test_func),
         environment=[],
         input_schema={"x": "ndarray"},
-        output_schema={"o": "ndarray"},
+        output_schema=[("o", "ndarray")],
     )
     source = TaskInstance(
         definition=task_definition,

--- a/tests/cascade/executor/test_runner.py
+++ b/tests/cascade/executor/test_runner.py
@@ -100,7 +100,7 @@ def test_runner(monkeypatch):
         func=TaskDefinition.func_enc(test_func),
         environment=[],
         input_schema={"x": "int"},
-        output_schema={"o": "int"},
+        output_schema=[("o", "int")],
     )
     t2 = TaskInstance(
         definition=task_definition,
@@ -183,14 +183,14 @@ def test_runner(monkeypatch):
         func=TaskDefinition.func_enc(gen_func),
         environment=[],
         input_schema={},
-        output_schema={f"{i}": "int" for i in range(N)},
+        output_schema=[(f"{i}", "int") for i in range(N)],
     )
     t4g = TaskInstance(
         definition=gen_definition,
         static_input_kw={},
         static_input_ps={},
     )
-    t4gOutputs = [DatasetId("t4g", k) for k in gen_definition.output_schema.keys()]
+    t4gOutputs = [DatasetId("t4g", k) for k, _ in gen_definition.output_schema]
     t4c = TaskInstance(
         definition=task_definition,
         static_input_kw={},

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -16,14 +16,14 @@ def get_job_succ() -> JobInstance:
         func=TaskDefinition.func_enc(lambda: init_value),
         environment=[],
         input_schema={},
-        output_schema={"o": "int"},
+        output_schema=[("o", "int")],
     )
     soi = TaskInstance(definition=sod, static_input_kw={}, static_input_ps={})
     sid = TaskDefinition(
         func=TaskDefinition.func_enc(job_func),
         environment=[],
         input_schema={},  # TODO add 0: int once supported
-        output_schema={"o": "int"},
+        output_schema=[("o", "int")],
     )
     sii = TaskInstance(definition=sid, static_input_kw={}, static_input_ps={})
 
@@ -44,7 +44,7 @@ def get_job_fail() -> JobInstance:
         func=TaskDefinition.func_enc(job_func),
         environment=[],
         input_schema={},
-        output_schema={"o": "int"},
+        output_schema=[("o", "int")],
     )
     ti = TaskInstance(definition=td, static_input_kw={}, static_input_ps={"0": None})
 


### PR DESCRIPTION
Previously, TaskDefinition.output_schema was a dict, and we required key-sorted order to correspond to function output order in the generator case. Thats a bit error prone / user unfriendly. We change to a list, assuming the user provides the keys in the sorted order instead.

This makes us rely on pydantic/pickle preserving order -- but since its a list of string tuples, it should be true.