### PR TITLE
[cascade.gateway] fix shutdown bug

### DIFF
--- a/src/cascade/gateway/router.py
+++ b/src/cascade/gateway/router.py
@@ -186,6 +186,8 @@ class JobRouter:
         for job_id, proc in self.procs.items():
             logger.debug(f"awaiting job {job_id}")
             try:
+                proc.terminate()
                 proc.wait(2)
             except subprocess.TimeoutExpired:
-                logger.error(f"{job_id=} failed to terminate")
+                logger.error(f"{job_id=} failed to terminate, killing")
+                proc.kill()


### PR DESCRIPTION
Instead of just waiting, we terminate and kill

The problem this caused that gateway-restart in fiab integration tests left a process hanging for a while after pytest has finished

cc @HCookie 