### PR TITLE
[gateway] fix macos spawning

### DIFF
--- a/src/cascade/benchmarks/__main__.py
+++ b/src/cascade/benchmarks/__main__.py
@@ -23,10 +23,10 @@ Make sure you correctly configure:
 
 import logging
 import logging.config
+import multiprocessing
 import os
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
-from multiprocessing import Process
 from time import perf_counter_ns
 
 import fire
@@ -139,7 +139,8 @@ def run_locally(
             gpu_count = get_gpu_count()
         else:
             gpu_count = 0
-        p = Process(
+        # NOTE forkserver/spawn seem to forget venv, we need fork
+        p = multiprocessing.get_context("fork").Process(
             target=launch_executor,
             args=(job, c, workers, portBase + 1 + i * 10, i, None, gpu_count),
         )

--- a/src/cascade/gateway/router.py
+++ b/src/cascade/gateway/router.py
@@ -120,7 +120,11 @@ class JobRouter:
 
     def spawn_job(self, job_spec: JobSpec) -> JobId:
         job_id = next_uuid(self.jobs.keys(), lambda: str(uuid.uuid4()))
-        base_addr = f"tcp://{getfqdn()}"
+        if job_spec.use_slurm:
+            base_addr = f"tcp://{getfqdn()}"
+        else:
+            # NOTE on macos, it seems getfqdn does not give zmq-bindable addr
+            base_addr = "tcp://localhost"
         socket = get_context().socket(zmq.PULL)
         port = socket.bind_to_random_port(base_addr)
         full_addr = f"{base_addr}:{port}"


### PR DESCRIPTION
- replace getfqdn() with localhost, as the former seems not zmq bindable on macos
- fix mp context to fork -- macos defaults to spawn, which seems to have some problems finding the module, I guess some venv forgetting
