### PR TITLE
[cascade.executor] fix bug in healthcheck

### DIFF
--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -222,17 +222,17 @@ class Executor:
         procFail = lambda ex: ex is not None and ex != 0
         for k, e in self.workers.items():
             if e is None:
-                ValueError(f"process on {k} is not alive")
+                raise ValueError(f"process on {k} is not alive")
             elif procFail(e.exitcode):
-                ValueError(
+                raise ValueError(
                     f"process on {k} failed to terminate correctly: {e.pid} -> {e.exitcode}"
                 )
         if procFail(self.shm_process.exitcode):
-            ValueError(
+            raise ValueError(
                 f"shm server {self.shm_process.pid} failed with {self.shm_process.exitcode}"
             )
         if procFail(self.data_server.exitcode):
-            ValueError(
+            raise ValueError(
                 f"data server {self.data_server.pid} failed with {self.data_server.exitcode}"
             )
         if self.heartbeat_watcher.is_breach() > 0:

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -194,8 +194,6 @@ def test_executor():
                 daddress=c1,
             ),
         )
-        ms = l.recv_messages()
-        assert all(isinstance(m, ExecutorRegistration) for m in ms)
         # NOTE the below ceased to work since we introduced retries. Now recomputation of a result after a purge is not possible
         # assert len(ms) == 1 and isinstance(ms[0], DatasetTransmitPayload) and ms[0].header.ds == DatasetId(task='sink', output='o')
         # assert serde.des_output(ms[0].value, 'ndarray', ms[0].header.deser_fun)[0] == 11.
@@ -204,7 +202,7 @@ def test_executor():
         # shutdown
         callback(m1, ExecutorShutdown())
         ms = l.recv_messages()
-        assert ms == [ExecutorExit(host="test_executor")]
+        assert ExecutorExit(host="test_executor") in ms
         p.join()
     except:
         if p.is_alive():


### PR DESCRIPTION
missing raise statement caused to happily proceed when a worker process got OOM etc. Now correctly raises and the whole job crashes
