### PR TITLE
[cascade] scheduling and memory improvements

### DIFF
--- a/src/cascade/benchmarks/__main__.py
+++ b/src/cascade/benchmarks/__main__.py
@@ -41,7 +41,7 @@ from cascade.executor.executor import Executor
 from cascade.executor.msg import BackboneAddress, ExecutorShutdown
 from cascade.low.core import JobInstance
 from cascade.low.func import msum
-from cascade.scheduler.graph import precompute
+from cascade.scheduler.precompute import precompute
 from earthkit.workflows.graph import Graph, deduplicate_nodes
 
 logger = logging.getLogger("cascade.benchmarks")
@@ -73,6 +73,10 @@ def get_job(benchmark: str | None, instance_path: str | None) -> JobInstance:
             import cascade.benchmarks.generators as generators
 
             return generators.get_job()
+        elif benchmark.startswith("matmul"):
+            import cascade.benchmarks.matmul as matmul
+
+            return matmul.get_job()
         else:
             raise NotImplementedError(benchmark)
     else:
@@ -81,6 +85,12 @@ def get_job(benchmark: str | None, instance_path: str | None) -> JobInstance:
 
 def get_gpu_count() -> int:
     try:
+        if "CUDA_VISIBLE_DEVICES" in os.environ:
+            # TODO we dont want to just count, we want to actually use literally these ids
+            # NOTE this is particularly useful for "" value -- careful when refactoring
+            visible = os.environ["CUDA_VISIBLE_DEVICES"]
+            visible_count = sum(1 for e in visible if e == ",") + (1 if visible else 0)
+            return visible_count
         gpus = sum(
             1
             for l in subprocess.run(

--- a/src/cascade/benchmarks/job1.py
+++ b/src/cascade/benchmarks/job1.py
@@ -16,10 +16,10 @@ Controlled by env var params: JOB1_{DATA_ROOT, GRID, ...}, see below
 import os
 
 import earthkit.data
-from ppcascade.fluent import from_source
-from ppcascade.utils.window import Range
 
 from earthkit.workflows.fluent import Payload
+from earthkit.workflows.plugins.pproc.fluent import from_source
+from earthkit.workflows.plugins.pproc.utils.window import Range
 
 # *** PARAMS ***
 

--- a/src/cascade/benchmarks/matmul.py
+++ b/src/cascade/benchmarks/matmul.py
@@ -34,7 +34,8 @@ def get_job() -> JobInstance:
 
     source, powr = get_funcs()
     source_node = TaskBuilder.from_callable(source)
-    # source_node.definition.needs_gpu = True
+    if os.environ.get("CUDA_VISIBLE_DEVICES", "") != "":
+        source_node.definition.needs_gpu = True
     # currently no need to set True downstream since scheduler prefers no transfer
 
     job = JobBuilder().with_node("source", source_node)
@@ -55,9 +56,9 @@ def execute_locally():
 
     source, powr = get_funcs()
 
-    with jax.default_device(
-        jax.devices("cpu")[0]
-    ):  # TODO change based on visible devices
+    device = "gpu" if os.environ.get("CUDA_VISIBLE_DEVICES", "") != "" else "cpu"
+    print(f"device is {device}")
+    with jax.default_device(jax.devices(device)[0]):
         m0 = source()
         for _ in range(L):
             m0 = powr(m0)

--- a/src/cascade/benchmarks/matmul.py
+++ b/src/cascade/benchmarks/matmul.py
@@ -1,0 +1,64 @@
+import os
+from typing import Any
+
+import jax
+import jax.numpy as jp
+import jax.random as jr
+
+from cascade.low.builders import JobBuilder, TaskBuilder
+from cascade.low.core import JobInstance
+
+
+def get_funcs():
+    K = int(os.environ["MATMUL_K"])
+    size = (2**K, 2**K)
+    E = int(os.environ["MATMUL_E"])
+
+    def source() -> Any:
+        k0 = jr.key(0)
+        m = jr.uniform(key=k0, shape=size)
+        return m
+
+    def powr(m: Any) -> Any:
+        print(f"powr device is {m.device}")
+        return m**E * jp.percentile(m, 0.7)
+
+    return source, powr
+
+
+def get_job() -> JobInstance:
+    L = int(os.environ["MATMUL_L"])
+    # D = os.environ["MATMUL_D"]
+    # it would be tempting to with jax.default_device(jax.devices(D)):
+    # alas, it doesn't work because we can't inject this at deser time
+
+    source, powr = get_funcs()
+    source_node = TaskBuilder.from_callable(source)
+    source_node.definition.needs_gpu = True
+    # currently no need to set True downstream since scheduler prefers no transfer
+
+    job = JobBuilder().with_node("source", source_node)
+    prv = "source"
+    for i in range(L):
+        cur = f"pow{i}"
+        node = TaskBuilder.from_callable(powr)
+        job = job.with_node(cur, node).with_edge(prv, cur, 0)
+        prv = cur
+
+    return job.build().get_or_raise()
+
+
+def execute_locally():
+    L = int(os.environ["MATMUL_L"])
+
+    source, powr = get_funcs()
+
+    # or gpu
+    with jax.default_device(jax.devices("cpu")[0]):
+        m0 = source()
+        for _ in range(L):
+            m0 = powr(m0)
+
+
+if __name__ == "__main__":
+    execute_locally()

--- a/src/cascade/benchmarks/matmul.py
+++ b/src/cascade/benchmarks/matmul.py
@@ -34,7 +34,7 @@ def get_job() -> JobInstance:
 
     source, powr = get_funcs()
     source_node = TaskBuilder.from_callable(source)
-    source_node.definition.needs_gpu = True
+    # source_node.definition.needs_gpu = True
     # currently no need to set True downstream since scheduler prefers no transfer
 
     job = JobBuilder().with_node("source", source_node)
@@ -45,7 +45,9 @@ def get_job() -> JobInstance:
         job = job.with_node(cur, node).with_edge(prv, cur, 0)
         prv = cur
 
-    return job.build().get_or_raise()
+    job = job.build().get_or_raise()
+    job.ext_outputs = list(job.outputs_of(cur))
+    return job
 
 
 def execute_locally():
@@ -53,11 +55,17 @@ def execute_locally():
 
     source, powr = get_funcs()
 
-    # or gpu
-    with jax.default_device(jax.devices("cpu")[0]):
+    with jax.default_device(
+        jax.devices("cpu")[0]
+    ):  # TODO change based on visible devices
         m0 = source()
         for _ in range(L):
             m0 = powr(m0)
+
+    from multiprocessing.shared_memory import SharedMemory
+
+    mem = SharedMemory("benchmark_tmp", create=True, size=m0.nbytes)
+    mem.buf[:] = m0.tobytes()
 
 
 if __name__ == "__main__":

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -67,6 +67,25 @@ class RunnerContext:
         )
 
 
+class Config:
+    """Some parameters to drive behaviour. Currently not exposed externally -- no clear argument
+    that they should be. As is, just a means of code experimentation.
+    """
+
+    # flushing approach -- when we finish a computation of task sequence, there is a question what
+    # to do with the output. We could either publish & drop, or publish and retain in memory. The
+    # former is is slower -- if the next task sequence needs this output, it requires a fetch & deser
+    # from cashme. But the latter is more risky -- we effectively have the same dataset twice in
+    # system memory. The `posttask_flush` below goes the former way, the `pretask_flush` is a careful
+    # way of latter -- we drop the output from memory only if the *next* task sequence does not need
+    # it, ie, we retain a cache of age 1. We could ultimately have controller decide about this, or
+    # decide dynamically based on memory pressure -- but neither is easy.
+    posttask_flush = False  # after task is done, drop all outputs from memory
+    pretask_flush = (
+        True  # when we receive a task, we drop those in memory that wont be needed
+    )
+
+
 def worker_address(workerId: WorkerId) -> BackboneAddress:
     return f"ipc:///tmp/{repr(workerId)}.socket"
 
@@ -83,7 +102,8 @@ def execute_sequence(
         for taskId in taskSequence.tasks:
             pckg.extend(executionContext.tasks[taskId].definition.environment)
             run(taskId, executionContext, memory)
-        memory.flush()
+        if Config.posttask_flush:
+            memory.flush()
     except Exception as e:
         logger.exception("runner failure, about to report")
         callback(
@@ -107,8 +127,11 @@ def entrypoint(runnerContext: RunnerContext):
         PackagesEnv() as pckg,
     ):
         label("worker", repr(runnerContext.workerId))
-        gpu_id = str(runnerContext.workerId.worker_num())
-        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(gpu_id)
+        worker_num = runnerContext.workerId.worker_num()
+        gpus = int(os.environ.get("CASCADE_GPU_COUNT", "0"))
+        os.environ["CUDA_VISIBLE_DEVICES"] = (
+            ",".join(str(worker_num)) if worker_num < gpus else ""
+        )
         # NOTE check any(task.definition.needs_gpu) anywhere?
         # TODO configure OMP_NUM_THREADS, blas, mkl, etc -- not clear how tho
 
@@ -151,6 +174,9 @@ def entrypoint(runnerContext: RunnerContext):
                     for key, _ in runnerContext.job.tasks[task].definition.output_schema
                 }
                 missing_ds = required - availab_ds
+                if Config.pretask_flush:
+                    extraneous_ds = availab_ds - required
+                    memory.flush(extraneous_ds)
                 if missing_ds:
                     waiting_ts = mDes
                     for ds in availab_ds.intersection(required):

--- a/src/cascade/executor/runner/memory.py
+++ b/src/cascade/executor/runner/memory.py
@@ -70,8 +70,9 @@ class Memory(AbstractContextManager):
         else:
             # NOTE even if its not actually published, we send the message to allow for
             # marking the task itself as completed -- its odd, but arguably better than
-            # introducing a TaskCompleted message. Alternatively, we fine-grain host-wide
-            # and worker-only publishes at the `controller.notify` level
+            # introducing a TaskCompleted message. TODO we should fine-grain host-wide
+            # and worker-only publishes at the `controller.notify` level, to not cause
+            # incorrect shm.purge calls at worklow end, which log an annoying key error
             logger.debug(f"fake publish of {outputId} for the sake of task completion")
             shmid = ds2shmid(outputId)
             callback(

--- a/src/cascade/executor/runner/memory.py
+++ b/src/cascade/executor/runner/memory.py
@@ -51,7 +51,6 @@ class Memory(AbstractContextManager):
             else:
                 outputValue = "ok"
 
-        # TODO how do we purge from here over time?
         self.local[outputId] = outputValue
 
         if isPublish:
@@ -64,6 +63,17 @@ class Memory(AbstractContextManager):
             rbuf = shm_client.allocate(shmid, l, deser_fun)
             rbuf.view()[:l] = result_ser
             rbuf.close()
+            callback(
+                self.callback,
+                DatasetPublished(ds=outputId, origin=self.worker, transmit_idx=None),
+            )
+        else:
+            # NOTE even if its not actually published, we send the message to allow for
+            # marking the task itself as completed -- its odd, but arguably better than
+            # introducing a TaskCompleted message. Alternatively, we fine-grain host-wide
+            # and worker-only publishes at the `controller.notify` level
+            logger.debug(f"fake publish of {outputId} for the sake of task completion")
+            shmid = ds2shmid(outputId)
             callback(
                 self.callback,
                 DatasetPublished(ds=outputId, origin=self.worker, transmit_idx=None),

--- a/src/cascade/executor/runner/memory.py
+++ b/src/cascade/executor/runner/memory.py
@@ -85,18 +85,24 @@ class Memory(AbstractContextManager):
 
     def pop(self, ds: DatasetId) -> None:
         if ds in self.local:
+            logger.debug(f"popping local {ds}")
             val = self.local.pop(ds)  # noqa: F841
             del val
         if ds in self.bufs:
+            logger.debug(f"popping buf {ds}")
             buf = self.bufs.pop(ds)
             buf.close()
 
-    def flush(self) -> None:
-        # NOTE poor man's memory management -- just drop those locals that weren't published. Called
+    def flush(self, datasets: set[DatasetId] = set()) -> None:
+        # NOTE poor man's memory management -- just drop those locals that didn't come from cashme. Called
         # after every taskSequence. In principle, we could purge some locals earlier, and ideally scheduler
         # would invoke some targeted purges to also remove some published ones earlier (eg, they are still
         # needed somewhere but not here)
-        purgeable = [inputId for inputId in self.local if inputId not in self.bufs]
+        purgeable = [
+            inputId
+            for inputId in self.local
+            if inputId not in self.bufs and (not datasets or inputId in datasets)
+        ]
         logger.debug(f"will flush {len(purgeable)} datasets")
         for inputId in purgeable:
             self.local.pop(inputId)
@@ -115,6 +121,8 @@ class Memory(AbstractContextManager):
                     free, total = torch.cuda.mem_get_info()
                     logger.debug(f"cuda mem avail post cache empty: {free/total:.2%}")
                     if free / total < 0.8:
+                        # NOTE this ofc makes low sense if there is any other application (like browser or ollama)
+                        # that the user may be running
                         logger.warning("cuda mem avail low despite cache empty!")
                         logger.debug(torch.cuda.memory_summary())
         except ImportError:

--- a/src/cascade/low/execution_context.py
+++ b/src/cascade/low/execution_context.py
@@ -108,6 +108,12 @@ class JobExecutionContext:
             self.idle_workers.add(worker)
 
     def dataset_preparing(self, dataset: DatasetId, worker: WorkerId) -> None:
+        # NOTE Currently this is invoked during `build_assignment`, as we need
+        # some state tranisition to allow fusing opportunities as well as
+        # preventing double transmits. This may not be the best idea, eg for long
+        # fusing chains -- instead, we may execute this transition at the time
+        # it actually happens, granularize the preparing state into
+        # (will_appear, is_appearing), etc
         # NOTE Currently, these `if`s are necessary because we issue transmit
         # command when host *has* DS but worker does *not*. This ends up no-op,
         # but we totally dont want host state to reset -- it wouldnt recover

--- a/src/cascade/scheduler/api.py
+++ b/src/cascade/scheduler/api.py
@@ -136,7 +136,7 @@ def plan(
         for task in assignment.tasks:
             for ds in assignment.outputs:
                 children = context.edge_o[ds]
-                context.dataset_preparing(ds, assignment.worker)
+                # context.dataset_preparing(ds, assignment.worker) # happends during build already
                 update_worker2task_distance(
                     children, assignment.worker, schedule, context
                 )

--- a/src/cascade/scheduler/assign.py
+++ b/src/cascade/scheduler/assign.py
@@ -18,50 +18,69 @@ from typing import Iterable, Iterator
 from cascade.low.core import DatasetId, HostId, TaskId, WorkerId
 from cascade.low.execution_context import DatasetStatus, JobExecutionContext
 from cascade.low.tracing import Microtrace, trace
-from cascade.scheduler.core import Assignment, ComponentId, Schedule
+from cascade.scheduler.core import Assignment, ComponentCore, ComponentId, Schedule
 
 logger = logging.getLogger(__name__)
 
 
 def build_assignment(
-    worker: WorkerId, task: TaskId, context: JobExecutionContext
+    worker: WorkerId, task: TaskId, context: JobExecutionContext, core: ComponentCore
 ) -> Assignment:
     eligible_load = {DatasetStatus.preparing, DatasetStatus.available}
     eligible_transmit = {DatasetStatus.available}
     prep: list[tuple[DatasetId, HostId]] = []
-    for dataset in context.edge_i[task]:
+    if task in core.fusing_opportunities:
+        tasks = core.fusing_opportunities.pop(task)
+    else:
+        tasks = [task]
+    assigned = []
+    exhausted = False
+    while tasks and not exhausted:
+        task = tasks[0]
         at_worker = context.worker2ds[worker]
-        if at_worker.get(dataset, DatasetStatus.missing) not in eligible_load:
-            if (
-                context.host2ds[worker.host].get(dataset, DatasetStatus.missing)
-                in eligible_load
-            ):
-                # NOTE this currently leads to no-op, but with persistent workers would possibly allow an early fetch
-                prep.append((dataset, worker.host))
-            else:
-                if any(
-                    candidate := host
-                    for host, status in context.ds2host[dataset].items()
-                    if status in eligible_transmit
+        for dataset in context.edge_i[task]:
+            if at_worker.get(dataset, DatasetStatus.missing) not in eligible_load:
+                if (
+                    context.host2ds[worker.host].get(dataset, DatasetStatus.missing)
+                    in eligible_load
                 ):
-                    prep.append((dataset, candidate))
-                    # NOTE this is a slight hack, to prevent issuing further transmit commands of this ds to this host
-                    # in this phase. A proper state transition happens later in the `plan` phase. We may want to instead
-                    # create a new `transmit_queue` state field to capture this, and consume it later during plan
-                    context.host2ds[worker.host][dataset] = DatasetStatus.preparing
-                    context.ds2host[dataset][worker.host] = DatasetStatus.preparing
+                    prep.append((dataset, worker.host))
                 else:
-                    raise ValueError(f"{dataset=} not found in any host, whoa whoa!")
+                    if any(
+                        candidate := host
+                        for host, status in context.ds2host[dataset].items()
+                        if status in eligible_transmit
+                    ):
+                        prep.append((dataset, candidate))
+                        # NOTE this is a slight hack, to prevent issuing further transmit commands of this ds to this host
+                        # in this phase. A proper state transition happens later in the `plan` phase. We may want to instead
+                        # create a new `transmit_queue` state field to capture this, and consume it later during plan
+                        context.host2ds[worker.host][dataset] = DatasetStatus.preparing
+                        context.ds2host[dataset][worker.host] = DatasetStatus.preparing
+                    else:
+                        if not assigned:
+                            raise ValueError(
+                                f"{dataset=} not found in any host, whoa whoa!"
+                            )
+                        else:
+                            # TODO rollback preps done for this one task
+                            exhausted = True
+                            break
+        if not exhausted:
+            assigned.append(tasks.pop(0))
 
+    if len(tasks) > 1:
+        head = tasks.pop(0)
+        if head in core.fusing_opportunities:
+            raise ValueError(f"double assignment to {head} in fusing opportunities!")
+        core.fusing_opportunities[head] = tasks
+
+    # TODO trim for only the necessary ones. But when doing so, modify executor to publish some FakePublished message *anyway*, to ensure state update
     return Assignment(
         worker=worker,
-        tasks=[
-            task
-        ],  # TODO eager fusing for outdeg=1? Or heuristic via ratio of outdeg vs workers@component?
+        tasks=assigned,
         prep=prep,
-        outputs={  # TODO trim for only the necessary ones
-            ds for ds in context.task_o[task]
-        },
+        outputs={ds for task in assigned for ds in context.task_o[task]},
     )
 
 
@@ -76,23 +95,35 @@ def _assignment_heuristic(
     start = perf_counter_ns()
     component = schedule.components[component_id]
 
+    def postproc_assignment(assignment: Assignment) -> None:
+        for assigned in assignment.tasks:
+            if assigned in component.computable:
+                component.computable.pop(assigned)
+                component.worker2task_values.remove(assigned)
+                schedule.computable -= 1
+            else:
+                # shortcut for fused-in tasks
+                component.is_computable_tracker[assigned] = set()
+        context.idle_workers.remove(worker)
+        component.weight -= len(assignment.tasks)
+
     # first, attempt optimum-distance assignment
     unassigned: list[TaskId] = []
     for task in tasks:
+        if task not in component.computable:
+            # it may be that some fusing for previous task already assigned this
+            continue
         opt_dist = component.computable[task]
         was_assigned = False
         for idx, worker in enumerate(workers):
             if component.worker2task_distance[worker][task] == opt_dist:
                 end = perf_counter_ns()
                 trace(Microtrace.ctrl_assign, end - start)
-                yield build_assignment(worker, task, context)
+                assignment = build_assignment(worker, task, context, component.core)
+                yield assignment
                 start = perf_counter_ns()
+                postproc_assignment(assignment)
                 workers.pop(idx)
-                component.computable.pop(task)
-                component.worker2task_values.remove(task)
-                component.weight -= 1
-                schedule.computable -= 1
-                context.idle_workers.remove(worker)
                 was_assigned = True
                 break
         if not was_assigned:
@@ -109,17 +140,17 @@ def _assignment_heuristic(
     candidates.sort(key=lambda e: (e[0], e[1]))
     for _, _, worker, task in candidates:
         if task in remaining_t and worker in remaining_w:
+            if task not in component.computable:
+                # it may be that some fusing for previous task already assigned this
+                continue
             end = perf_counter_ns()
             trace(Microtrace.ctrl_assign, end - start)
-            yield build_assignment(worker, task, context)
+            assignment = build_assignment(worker, task, context, component.core)
+            yield assignment
             start = perf_counter_ns()
-            component.computable.pop(task)
-            component.worker2task_values.remove(task)
+            postproc_assignment(assignment)
             remaining_t.remove(task)
             remaining_w.remove(worker)
-            context.idle_workers.remove(worker)
-            schedule.computable -= 1
-            component.weight -= 1
 
     end = perf_counter_ns()
     trace(Microtrace.ctrl_assign, end - start)

--- a/src/cascade/scheduler/assign.py
+++ b/src/cascade/scheduler/assign.py
@@ -35,9 +35,9 @@ def build_assignment(
         tasks = [task]
     assigned = []
     exhausted = False
+    at_worker = context.worker2ds[worker]
     while tasks and not exhausted:
         task = tasks[0]
-        at_worker = context.worker2ds[worker]
         for dataset in context.edge_i[task]:
             if at_worker.get(dataset, DatasetStatus.missing) not in eligible_load:
                 if (
@@ -52,22 +52,22 @@ def build_assignment(
                         if status in eligible_transmit
                     ):
                         prep.append((dataset, candidate))
-                        # NOTE this is a slight hack, to prevent issuing further transmit commands of this ds to this host
-                        # in this phase. A proper state transition happens later in the `plan` phase. We may want to instead
-                        # create a new `transmit_queue` state field to capture this, and consume it later during plan
-                        context.host2ds[worker.host][dataset] = DatasetStatus.preparing
-                        context.ds2host[dataset][worker.host] = DatasetStatus.preparing
+                        context.dataset_preparing(worker, dataset)
                     else:
+                        # if we are dealing with the first task to assign, we don't expect to be here!
                         if not assigned:
                             raise ValueError(
                                 f"{dataset=} not found in any host, whoa whoa!"
                             )
+                        # if we are already trying some fusing opportunities, it is legit to not find the dataset anywhere
                         else:
                             # TODO rollback preps done for this one task
                             exhausted = True
                             break
         if not exhausted:
             assigned.append(tasks.pop(0))
+            for dataset in context.edge_o[task]:
+                context.dataset_preparing(dataset, worker)
 
     if len(tasks) > 1:
         head = tasks.pop(0)

--- a/src/cascade/scheduler/assign.py
+++ b/src/cascade/scheduler/assign.py
@@ -37,8 +37,14 @@ def build_assignment(
     exhausted = False
     at_worker = context.worker2ds[worker]
     at_host = context.host2ds[worker.host]
+    worker_has_gpu = context.environment.workers[worker].gpu > 0
     while tasks and not exhausted:
         task = tasks[0]
+        if context.job_instance.tasks[task].definition.needs_gpu and not worker_has_gpu:
+            if not assigned:
+                raise ValueError(f"tried to assign gpu {task=} to non-gpu {worker=}")
+            else:
+                break
         for dataset in context.edge_i[task]:
             if at_worker.get(dataset, DatasetStatus.missing) not in eligible_load:
                 if at_host.get(dataset, DatasetStatus.missing) in eligible_load:
@@ -96,7 +102,7 @@ def _assignment_heuristic(
     component_id: ComponentId,
     context: JobExecutionContext,
 ) -> Iterator[Assignment]:
-    """Finds a reasonable assignment within a single component. Does not migrate hosts to a different component"""
+    """Finds a reasonable assignment within a single component. Does not migrate hosts to a different component."""
     start = perf_counter_ns()
     component = schedule.components[component_id]
 
@@ -167,27 +173,29 @@ def assign_within_component(
     component_id: ComponentId,
     context: JobExecutionContext,
 ) -> Iterator[Assignment]:
-    """We first handle gpu things, second cpu things, using the same algorithm for either case"""
+    """We first handle tasks requiring a gpu, then tasks whose child requires a gpu, last cpu only tasks, using the same algorithm for either case"""
     # TODO employ a more systematic solution and handle all multicriterially at once -- ideally together with adding support for multi-gpu-groups
+    # NOTE this is getting even more important as we started considering gpu fused distance
+    # NOTE the concept of "strategic wait" is completely missing here (eg dont assign a gpu worker to a cpu task because there will come a gpu task in a few secs)
     cpu_t: list[TaskId] = []
     gpu_t: list[TaskId] = []
-    gpu_w: list[WorkerId] = []
-    cpu_w: list[WorkerId] = []
-    for task in schedule.components[component_id].computable.keys():
+    opu_t: list[TaskId] = []
+    component = schedule.components[component_id]
+    for task in component.computable.keys():
         if context.job_instance.tasks[task].definition.needs_gpu:
             gpu_t.append(task)
+        elif component.core.gpu_fused_distance[task] is not None:
+            opu_t.append(task)
         else:
             cpu_t.append(task)
-    for worker in workers:
-        if context.environment.workers[worker].gpu > 0:
-            gpu_w.append(worker)
-        else:
-            cpu_w.append(worker)
-    yield from _assignment_heuristic(schedule, gpu_t, gpu_w, component_id, context)
-    for worker in gpu_w:
-        if worker in context.idle_workers:
-            cpu_w.append(worker)
-    yield from _assignment_heuristic(schedule, cpu_t, cpu_w, component_id, context)
+    eligible_w = [
+        worker for worker in workers if context.environment.workers[worker].gpu > 0
+    ]
+    yield from _assignment_heuristic(schedule, gpu_t, eligible_w, component_id, context)
+    eligible_w = [worker for worker in eligible_w if worker in context.idle_workers]
+    yield from _assignment_heuristic(schedule, opu_t, eligible_w, component_id, context)
+    eligible_w = [worker for worker in workers if worker in context.idle_workers]
+    yield from _assignment_heuristic(schedule, cpu_t, eligible_w, component_id, context)
 
 
 def update_worker2task_distance(

--- a/src/cascade/scheduler/assign.py
+++ b/src/cascade/scheduler/assign.py
@@ -75,12 +75,16 @@ def build_assignment(
             raise ValueError(f"double assignment to {head} in fusing opportunities!")
         core.fusing_opportunities[head] = tasks
 
-    # TODO trim for only the necessary ones. But when doing so, modify executor to publish some FakePublished message *anyway*, to ensure state update
+    # trim for only the necessary ones -- that is, having any edge outside of this current assignment
+    all_outputs = {ds for task in assigned for ds in context.task_o[task]}
+    assigned_tasks = set(assigned)
+    trimmed_outputs = {ds for ds in all_outputs if context.edge_o[ds] - assigned_tasks}
+
     return Assignment(
         worker=worker,
         tasks=assigned,
         prep=prep,
-        outputs={ds for task in assigned for ds in context.task_o[task]},
+        outputs=trimmed_outputs,
     )
 
 

--- a/src/cascade/scheduler/assign.py
+++ b/src/cascade/scheduler/assign.py
@@ -39,7 +39,6 @@ def build_assignment(
     at_host = context.host2ds[worker.host]
     while tasks and not exhausted:
         task = tasks[0]
-        logger.debug(f"proceeding to {task}, with datasets {at_worker} and {at_host}")
         for dataset in context.edge_i[task]:
             if at_worker.get(dataset, DatasetStatus.missing) not in eligible_load:
                 if at_host.get(dataset, DatasetStatus.missing) in eligible_load:
@@ -51,7 +50,7 @@ def build_assignment(
                         if status in eligible_transmit
                     ):
                         prep.append((dataset, candidate))
-                        context.dataset_preparing(worker, dataset)
+                        context.dataset_preparing(dataset, worker)
                     else:
                         # if we are dealing with the first task to assign, we don't expect to be here!
                         if not assigned:
@@ -75,7 +74,12 @@ def build_assignment(
     # trim for only the necessary ones -- that is, having any edge outside of this current assignment
     all_outputs = {ds for task in assigned for ds in context.task_o[task]}
     assigned_tasks = set(assigned)
-    trimmed_outputs = {ds for ds in all_outputs if context.edge_o[ds] - assigned_tasks}
+    trimmed_outputs = {
+        ds
+        for ds in all_outputs
+        if (context.edge_o[ds] - assigned_tasks)
+        or (ds in context.job_instance.ext_outputs)
+    }
 
     return Assignment(
         worker=worker,

--- a/src/cascade/scheduler/assign.py
+++ b/src/cascade/scheduler/assign.py
@@ -36,14 +36,13 @@ def build_assignment(
     assigned = []
     exhausted = False
     at_worker = context.worker2ds[worker]
+    at_host = context.host2ds[worker.host]
     while tasks and not exhausted:
         task = tasks[0]
+        logger.debug(f"proceeding to {task}, with datasets {at_worker} and {at_host}")
         for dataset in context.edge_i[task]:
             if at_worker.get(dataset, DatasetStatus.missing) not in eligible_load:
-                if (
-                    context.host2ds[worker.host].get(dataset, DatasetStatus.missing)
-                    in eligible_load
-                ):
+                if at_host.get(dataset, DatasetStatus.missing) in eligible_load:
                     prep.append((dataset, worker.host))
                 else:
                     if any(
@@ -56,9 +55,7 @@ def build_assignment(
                     else:
                         # if we are dealing with the first task to assign, we don't expect to be here!
                         if not assigned:
-                            raise ValueError(
-                                f"{dataset=} not found in any host, whoa whoa!"
-                            )
+                            raise ValueError(f"{dataset=} not found anywhere!")
                         # if we are already trying some fusing opportunities, it is legit to not find the dataset anywhere
                         else:
                             # TODO rollback preps done for this one task
@@ -66,11 +63,11 @@ def build_assignment(
                             break
         if not exhausted:
             assigned.append(tasks.pop(0))
-            for dataset in context.edge_o[task]:
+            for dataset in context.task_o[task]:
                 context.dataset_preparing(dataset, worker)
 
     if len(tasks) > 1:
-        head = tasks.pop(0)
+        head = tasks[0]
         if head in core.fusing_opportunities:
             raise ValueError(f"double assignment to {head} in fusing opportunities!")
         core.fusing_opportunities[head] = tasks

--- a/src/cascade/scheduler/core.py
+++ b/src/cascade/scheduler/core.py
@@ -23,6 +23,9 @@ class ComponentCore:
     value: TaskValue  # closer to a sink -> higher value
     depth: int  # maximum value
     fusing_opportunities: dict[TaskId, list[TaskId]]
+    gpu_fused_distance: dict[
+        TaskId, int | None
+    ]  # closer to a gpu task -> lower value. Using fusing_opportunities paths only
 
     def weight(self) -> int:
         # TODO eventually replace with runtime sum or smth

--- a/src/cascade/scheduler/core.py
+++ b/src/cascade/scheduler/core.py
@@ -22,6 +22,7 @@ class ComponentCore:
     distance_matrix: Task2TaskDistance  # nearest common descendant
     value: TaskValue  # closer to a sink -> higher value
     depth: int  # maximum value
+    fusing_opportunities: dict[TaskId, list[TaskId]]
 
     def weight(self) -> int:
         # TODO eventually replace with runtime sum or smth

--- a/src/cascade/scheduler/precompute.py
+++ b/src/cascade/scheduler/precompute.py
@@ -156,13 +156,41 @@ def _enrich(
     # calculate ncd
     ncd = _nearest_common_descendant(paths, nodes, L, edge_i, edge_o)
 
+    # fusing opportunities
+    # TODO we just arbitrarily crawl down from sinks, until everything is
+    # decomposed into paths. A smarter approach would utilize profiling
+    # information such as dataset size, trying to fuse the large datasets
+    # first so that they end up on the longest paths
+    fusing_opportunities = {}
+    fused = set()
+    while layers:
+        layer = layers.pop(0)
+        while layer:
+            head = layer.pop(0)
+            if head in fused:
+                continue
+            chain = []
+            fused.add(head)
+            found = True
+            while found:
+                found = False
+                for edge in edge_i[head]:
+                    if edge.task not in fused:
+                        chain.insert(0, head)
+                        head = edge.task
+                        fused.add(head)
+                        found = True
+                        break
+            if len(chain) > 0:
+                fusing_opportunities[head] = chain
+
     return ComponentCore(
         nodes=nodes,
         sources=sources,
         distance_matrix=ncd,
         value=value,
         depth=L,
-        fusing_opportunities={},
+        fusing_opportunities=fusing_opportunities,
     )
 
 

--- a/src/cascade/scheduler/precompute.py
+++ b/src/cascade/scheduler/precompute.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 PlainComponent = tuple[list[TaskId], list[TaskId]]  # nodes, sources
 
 
-def nearest_common_descendant(
+def _nearest_common_descendant(
     paths: Task2TaskDistance,
     nodes: list[TaskId],
     L: int,
@@ -74,7 +74,7 @@ def nearest_common_descendant(
     return ncd
 
 
-def decompose(
+def _decompose(
     nodes: list[TaskId],
     edge_i: dict[TaskId, set[TaskId]],
     edge_o: dict[TaskId, set[TaskId]],
@@ -107,7 +107,7 @@ def decompose(
         )
 
 
-def enrich(
+def _enrich(
     plain_component: PlainComponent,
     edge_i: dict[TaskId, set[TaskId]],
     edge_o: dict[TaskId, set[TaskId]],
@@ -154,7 +154,7 @@ def enrich(
                 value[v] = max(value[v], value[c] - 1)
 
     # calculate ncd
-    ncd = nearest_common_descendant(paths, nodes, L, edge_i, edge_o)
+    ncd = _nearest_common_descendant(paths, nodes, L, edge_i, edge_o)
 
     return ComponentCore(
         nodes=nodes,
@@ -162,6 +162,7 @@ def enrich(
         distance_matrix=ncd,
         value=value,
         depth=L,
+        fusing_opportunities={},
     )
 
 
@@ -180,12 +181,12 @@ def precompute(job_instance: JobInstance) -> Preschedule:
 
     with ThreadPoolExecutor(max_workers=4) as tp:
         # TODO if coptrs is not used, then this doesnt make sense
-        f = lambda plain_component: timer(enrich, Microtrace.presched_enrich)(
+        f = lambda plain_component: timer(_enrich, Microtrace.presched_enrich)(
             plain_component, edge_i_proj, edge_o_proj
         )
         plain_components = (
             plain_component
-            for plain_component in timer(decompose, Microtrace.presched_decompose)(
+            for plain_component in timer(_decompose, Microtrace.presched_decompose)(
                 list(job_instance.tasks.keys()),
                 edge_i_proj,
                 edge_o_proj,

--- a/src/cascade/scheduler/precompute.py
+++ b/src/cascade/scheduler/precompute.py
@@ -175,13 +175,14 @@ def _enrich(
             while found:
                 found = False
                 for edge in edge_i[head]:
-                    if edge.task not in fused:
+                    if edge not in fused:
                         chain.insert(0, head)
-                        head = edge.task
+                        head = edge
                         fused.add(head)
                         found = True
                         break
             if len(chain) > 0:
+                chain.insert(0, head)
                 fusing_opportunities[head] = chain
 
     return ComponentCore(

--- a/src/cascade/scheduler/precompute.py
+++ b/src/cascade/scheduler/precompute.py
@@ -111,6 +111,7 @@ def _enrich(
     plain_component: PlainComponent,
     edge_i: dict[TaskId, set[TaskId]],
     edge_o: dict[TaskId, set[TaskId]],
+    needs_gpu: set[TaskId],
 ) -> ComponentCore:
     nodes, sources = plain_component
     logger.debug(
@@ -162,10 +163,12 @@ def _enrich(
     # information such as dataset size, trying to fuse the large datasets
     # first so that they end up on the longest paths
     fusing_opportunities = {}
+    gpu_fused_distance = {}
     fused = set()
     while layers:
         layer = layers.pop(0)
         while layer:
+            gpu_distance = None
             head = layer.pop(0)
             if head in fused:
                 continue
@@ -173,6 +176,11 @@ def _enrich(
             fused.add(head)
             found = True
             while found:
+                if head in needs_gpu:
+                    gpu_distance = 0
+                elif gpu_distance is not None:
+                    gpu_distance += 1
+                gpu_fused_distance[head] = gpu_distance
                 found = False
                 for edge in edge_i[head]:
                     if edge not in fused:
@@ -192,6 +200,7 @@ def _enrich(
         value=value,
         depth=L,
         fusing_opportunities=fusing_opportunities,
+        gpu_fused_distance=gpu_fused_distance,
     )
 
 
@@ -208,10 +217,16 @@ def precompute(job_instance: JobInstance) -> Preschedule:
     for vert, inps in edge_i.items():
         edge_i_proj[vert] = {dataset.task for dataset in inps}
 
+    needs_gpu = {
+        task_id
+        for task_id, task in job_instance.tasks.items()
+        if task.definition.needs_gpu
+    }
+
     with ThreadPoolExecutor(max_workers=4) as tp:
         # TODO if coptrs is not used, then this doesnt make sense
         f = lambda plain_component: timer(_enrich, Microtrace.presched_enrich)(
-            plain_component, edge_i_proj, edge_o_proj
+            plain_component, edge_i_proj, edge_o_proj, needs_gpu
         )
         plain_components = (
             plain_component

--- a/tests/cascade/controller/test_run.py
+++ b/tests/cascade/controller/test_run.py
@@ -19,7 +19,7 @@ from cascade.executor.executor import Executor
 from cascade.executor.msg import BackboneAddress, ExecutorShutdown
 from cascade.low.builders import JobBuilder, TaskBuilder
 from cascade.low.core import JobInstance
-from cascade.scheduler.graph import precompute
+from cascade.scheduler.precompute import precompute
 
 
 def _payload(a: int, b: int) -> int:

--- a/tests/cascade/controller/test_run.py
+++ b/tests/cascade/controller/test_run.py
@@ -8,6 +8,7 @@
 
 """For a given graph and instant executor, check that things complete"""
 
+import os
 from logging.config import dictConfig
 from multiprocessing import Process
 
@@ -19,6 +20,7 @@ from cascade.executor.executor import Executor
 from cascade.executor.msg import BackboneAddress, ExecutorShutdown
 from cascade.low.builders import JobBuilder, TaskBuilder
 from cascade.low.core import JobInstance
+from cascade.scheduler.core import Preschedule
 from cascade.scheduler.precompute import precompute
 
 
@@ -40,8 +42,14 @@ def launch_executor(
     executor.recv_loop()
 
 
-def run_cluster(job: JobInstance, portBase: int, executors: int):
-    preschedule = precompute(job)
+def run_cluster(
+    job: JobInstance,
+    portBase: int,
+    executors: int,
+    preschedule: Preschedule | None = None,
+):
+    if not preschedule:
+        preschedule = precompute(job)
     c = f"tcp://localhost:{portBase}"
     m = f"tcp://localhost:{portBase+1}"
     ps = []
@@ -63,10 +71,14 @@ def run_cluster(job: JobInstance, portBase: int, executors: int):
         raise
 
 
+# TODO there is some race condition, so far observed only on CI without any
+# clue what is exactly happening, freezing this test. Fix one day
+run_all_tests = int(os.environ.get("RUN_ALL_TESTS", "0")) == 1
+
+
 def test_simple():
-    # TODO there is some race condition, so far observed only on CI without any
-    # clue what is exactly happening, freezing this test. Fix one day
-    return
+    if not run_all_tests:
+        return
     # 2-node graph
     task1 = TaskBuilder.from_callable(_payload).with_values(a=1, b=2)
     task2 = TaskBuilder.from_callable(_payload).with_values(a=1)
@@ -120,13 +132,49 @@ def get_job() -> JobInstance:
 
 
 def test_para2():
+    if not run_all_tests:
+        return
     job = get_job()
     run_cluster(job, 12445, 2)
 
 
 def test_para4():
-    # TODO there is some race condition, so far observed only on CI without any
-    # clue what is exactly happening, freezing this test. Fix one day
-    return
+    if not run_all_tests:
+        return
     job = get_job()
     run_cluster(job, 12365, 4)
+
+
+def test_fusing():
+    # if not run_all_tests:
+    #     return
+
+    source = TaskBuilder.from_callable(_payload).with_values(a=1, b=2)
+    middle = TaskBuilder.from_callable(_payload).with_values(b=1)
+
+    job = (
+        JobBuilder()
+        .with_node("source", source)
+        .with_node("m1", middle)
+        .with_edge("source", "m1", "a")
+        .with_node("m2", middle)
+        .with_edge("m1", "m2", "a")
+        .with_node("m3", middle)
+        .with_edge("m2", "m3", "a")
+        .with_node("m4", middle)
+        .with_edge("m3", "m4", "a")
+        .with_node("sink", middle)
+        .with_edge("m4", "sink", "a")
+        .build()
+        .get_or_raise()
+    )
+    preschedule = precompute(job)
+    assert preschedule.components[0].fusing_opportunities["source"] == [
+        "source",
+        "m1",
+        "m2",
+        "m3",
+        "m4",
+        "sink",
+    ]
+    run_cluster(job, 12385, 2, preschedule)

--- a/tests/cascade/controller/test_run.py
+++ b/tests/cascade/controller/test_run.py
@@ -48,6 +48,9 @@ def run_cluster(
     executors: int,
     preschedule: Preschedule | None = None,
 ):
+    # TODO rework the port assignemnt in this whole file -- we waste a lot. Note if there
+    # is a port overlap, it causes *very unpleasant* interference, even when the tests
+    # are executed sequentially
     if not preschedule:
         preschedule = precompute(job)
     c = f"tcp://localhost:{portBase}"
@@ -73,6 +76,7 @@ def run_cluster(
 
 # TODO there is some race condition, so far observed only on CI without any
 # clue what is exactly happening, freezing this test. Fix one day
+# NOTE additionally, this is not really compatible with xdist!!!
 run_all_tests = int(os.environ.get("RUN_ALL_TESTS", "0")) == 1
 
 
@@ -90,7 +94,7 @@ def test_simple():
         .build()
         .get_or_raise()
     )
-    run_cluster(job, 12335, 1)
+    run_cluster(job, 12000, 1)
 
 
 def get_job() -> JobInstance:
@@ -135,19 +139,19 @@ def test_para2():
     if not run_all_tests:
         return
     job = get_job()
-    run_cluster(job, 12445, 2)
+    run_cluster(job, 12200, 2)
 
 
 def test_para4():
     if not run_all_tests:
         return
     job = get_job()
-    run_cluster(job, 12365, 4)
+    run_cluster(job, 12400, 4)
 
 
 def test_fusing():
-    # if not run_all_tests:
-    #     return
+    if not run_all_tests:
+        return
 
     source = TaskBuilder.from_callable(_payload).with_values(a=1, b=2)
     middle = TaskBuilder.from_callable(_payload).with_values(b=1)
@@ -177,4 +181,5 @@ def test_fusing():
         "m4",
         "sink",
     ]
-    run_cluster(job, 12385, 2, preschedule)
+    # TODO we currently dont check that those actually *got fused* -- fix
+    run_cluster(job, 12600, 2, preschedule)

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -125,7 +125,9 @@ def test_executor():
         callback(
             m1, TaskSequence(worker=w0, tasks=["source", "sink"], publish={sink_o})
         )
+        # NOTE we need to expect source_o dataset too, because of no finegraining for host-wide and worker-only
         expected = {
+            DatasetPublished(origin=w0, ds=source_o, transmit_idx=None),
             DatasetPublished(origin=w0, ds=sink_o, transmit_idx=None),
         }
         while expected:

--- a/tests/cascade/executor/test_runner.py
+++ b/tests/cascade/executor/test_runner.py
@@ -167,7 +167,11 @@ def test_runner(monkeypatch):
 
     with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv() as pckg:
         entrypoint.execute_sequence(twoTaskTs, memoryInstance, pckg, twoTaskRc)
+    # NOTE we assert for both messages even though *only* t3o has been specified in `publish`
+    # this is because there is no fine-graining yet to distingiush between worker-mem-only
+    # and host-wide publishings
     assert msgs == [
+        DatasetPublished(origin=worker, ds=t3i, transmit_idx=None),
         DatasetPublished(origin=worker, ds=t3o, transmit_idx=None),
     ]
     msgs = []
@@ -227,7 +231,9 @@ def test_runner(monkeypatch):
 
     with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv() as pckg:
         entrypoint.execute_sequence(t4TaskTs, memoryInstance, pckg, t4Rc)
-    assert msgs == [
+
+    # NOTE as above, we want to ignore the initial worker-mem-only publishes
+    assert msgs[-4:] == [
         DatasetPublished(origin=worker, ds=t4pOutputs[0], transmit_idx=None),
         DatasetPublished(origin=worker, ds=t4pOutputs[1], transmit_idx=None),
         DatasetPublished(origin=worker, ds=t4pOutputs[2], transmit_idx=None),

--- a/tests/cascade/scheduler/test_api.py
+++ b/tests/cascade/scheduler/test_api.py
@@ -23,6 +23,8 @@ from .util import get_env, get_job0, get_job1
 def test_job0():
     job0, _ = get_job0()
     preschedule = precompute(job0)
+    # we disable fusing to test just the basics here
+    preschedule.components[0].fusing_opportunities = {}
 
     h1w1 = get_env(1, 1)
     h1w1_w = WorkerId("h0", "w0")
@@ -45,6 +47,8 @@ def test_job0():
 def test_job1():
     job1, _ = get_job1()
     preschedule = precompute(job1)
+    # we disable fusing to test just the basics here
+    preschedule.components[0].fusing_opportunities = {}
 
     h1w1 = get_env(1, 1)
     h1w1_w = WorkerId("h0", "w0")

--- a/tests/cascade/scheduler/test_api.py
+++ b/tests/cascade/scheduler/test_api.py
@@ -12,7 +12,7 @@ from cascade.low.core import DatasetId, WorkerId
 from cascade.low.execution_context import TaskStatus, init_context
 from cascade.scheduler.api import assign, init_schedule, plan
 from cascade.scheduler.core import Assignment
-from cascade.scheduler.graph import precompute
+from cascade.scheduler.precompute import precompute
 
 from .util import get_env, get_job0, get_job1
 

--- a/tests/cascade/scheduler/test_graph.py
+++ b/tests/cascade/scheduler/test_graph.py
@@ -9,7 +9,7 @@
 from collections import defaultdict
 
 from cascade.low.core import TaskId
-from cascade.scheduler.graph import decompose, enrich
+from cascade.scheduler.precompute import _decompose, _enrich
 
 
 def _oedge2iedge(edge_o: dict[TaskId, set[TaskId]]) -> dict[TaskId, set[TaskId]]:
@@ -39,7 +39,7 @@ def test_decompose():
         (frozenset({"v0", "v1", "v2", "v3"}), frozenset({"v0", "v3"})),
         (frozenset({"v4", "v5", "v6"}), frozenset({"v4"})),
     }
-    for component in decompose(nodes, edge_i, edge_o):
+    for component in _decompose(nodes, edge_i, edge_o):
         e = (frozenset(component[0]), frozenset(component[1]))
         expected.remove(e)
 
@@ -64,7 +64,7 @@ def test_enrich():
     edge_i = _oedge2iedge(edge_o)
     component = (list(set(edge_o.keys()).union(set(edge_i.keys()))), ["v0", "v3", "v4"])
 
-    res = enrich(component, edge_i, edge_o)
+    res = _enrich(component, edge_i, edge_o)
 
     assert res.nodes == component[0]
     assert res.sources == component[1]

--- a/tests/cascade/scheduler/test_graph.py
+++ b/tests/cascade/scheduler/test_graph.py
@@ -64,7 +64,7 @@ def test_enrich():
     edge_i = _oedge2iedge(edge_o)
     component = (list(set(edge_o.keys()).union(set(edge_i.keys()))), ["v0", "v3", "v4"])
 
-    res = _enrich(component, edge_i, edge_o)
+    res = _enrich(component, edge_i, edge_o, set())
 
     assert res.nodes == component[0]
     assert res.sources == component[1]


### PR DESCRIPTION
- new benchmark job with matmul
- respects initial setting of CUDA_VISIBLE_DEVICES
- bugfix in worker claiming gpu even if not allowed to
- runner mem flushing: add new strategy of pre-flush
- runner mem flushing: configurable which strategy to choose
- rename scheduler/graph to scheduler/precompute
- fix impromer handling of task sequence assignments
- added preschedule option of fusing opportunities
- fine-grain the dataset publication command in case of non-trivial task sequences
- add preschedule impl of the fusion opportunities (heaviest-dataset crawls starting from sinks)
- add tests with graphs that would trigger some fusing

small benchmark -- matmul benchmark job with 8 nodes and 2**11 matrices:
 - before PR: ~2.5s on gpu (and ~6.5s on cpu)
 - executed without cascade as a for-cycle + final shmem write: ~2.0s (6.3s)
 - cumulative deserializations ~0.06s (savings of pre-flush strategy)
 - cumulative serializations ~0.4s (savings of fusing (which additionally saves ~.1s comms overhead)
=> improvement from 2.5s to 2.0s, ie, down to .8, with mod-noise-equivalent runtime to no-cascade


fusing and gpu interplay as by a change to assignment heuristic: now we consider "cpu task with a fusable gpu descendant" as a candidate _after_ all gpu-requiring tasks were considered, but _before_ cpu-only tasks are assigned, and we first attempt to assign those to gpu workers

I've executed a run of forecastbox's `bigtest` with this, and "still works" => good enough. Effect on runtime is indiscernible because its dominated by webmars noise. But regarding fusing statistics:
1/ the very first task gets fused, consisting of (get_initial conditions, empty_payload, run_as_earthkit, take), and publishes outputs (run_as_earthkit 0 to 6, take)
2/ then there is a bunch of unfused take & concat tasks
3/ and lastly there are two fused tasks, concat & quickplot, and convert2grib & output-grib
I'm a bit puzzled why the 3/ weren't also fused into something in 2/ and 1/, but this is still ~good. The main thing is probably fusing of initial_conditions and run_as_earthkit -- the remaining takes are quite a fan-out so no real gains obtainable by fusing