### PR TITLE
[earthkit.workflows.plugins] fix editable installs

### DIFF
--- a/src/earthkit/workflows/__init__.py
+++ b/src/earthkit/workflows/__init__.py
@@ -6,7 +6,11 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import pkgutil
+
 import dill
+
+__path__ = pkgutil.extend_path(__path__, __name__)
 
 try:
     from ._version import __version__  # noqa: F401

--- a/src/earthkit/workflows/plugins/__init__.py
+++ b/src/earthkit/workflows/plugins/__init__.py
@@ -1,1 +1,5 @@
 """Placeholder module to be populated by -plugin packages"""
+
+import pkgutil
+
+__path__ = pkgutil.extend_path(__path__, __name__)


### PR DESCRIPTION
when earthkit.workflows was installed as editable but individual plugins were not, the imports of plugins were failing. By recursively extending path, this gets fixed

idea of the fix belongs to @Oisin-M 