### PR TITLE
Feat/gang scheduling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,17 @@ repos:
     -   id: python-use-type-annotations # Check for missing type annotations
     -   id: python-check-blanket-noqa # Check for # noqa: all
     -   id: python-no-log-warn # Check for log.warn
+- repo: https://github.com/psf/black-pre-commit-mirror
+  rev: 24.8.0
+  hooks:
+  - id: black
+    # args: [--line-length=120]
 - repo: https://github.com/pycqa/isort
   rev: 5.13.2
   hooks:
   - id: isort
     args:
-    - -l 180
+    # - -l 120
     - --profile black
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.6.5
@@ -30,7 +35,7 @@ repos:
     # Next line if for documenation cod snippets
     exclude: '^[^_].*_\.py$'
     args:
-    - --line-length=180
+    # - --line-length=120
     - --fix
     - --exit-non-zero-on-fix
     - --preview

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,17 +16,12 @@ repos:
     -   id: python-use-type-annotations # Check for missing type annotations
     -   id: python-check-blanket-noqa # Check for # noqa: all
     -   id: python-no-log-warn # Check for log.warn
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 24.8.0
-  hooks:
-  - id: black
-    # args: [--line-length=120]
 - repo: https://github.com/pycqa/isort
   rev: 5.13.2
   hooks:
   - id: isort
     args:
-    # - -l 120
+    - -l 180
     - --profile black
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.6.5
@@ -35,7 +30,7 @@ repos:
     # Next line if for documenation cod snippets
     exclude: '^[^_].*_\.py$'
     args:
-    # - --line-length=120
+    - --line-length=180
     - --fix
     - --exit-non-zero-on-fix
     - --preview

--- a/src/cascade/benchmarks/__main__.py
+++ b/src/cascade/benchmarks/__main__.py
@@ -27,6 +27,7 @@ import multiprocessing
 import os
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
+from socket import getfqdn
 from time import perf_counter_ns
 
 import fire
@@ -116,6 +117,7 @@ def launch_executor(
     shm_vol_gb: int | None,
     gpu_count: int,
     log_base: str | None,
+    url_base: str,
 ):
     if log_base is not None:
         log_base = f"{log_base}.host{i}"
@@ -133,6 +135,7 @@ def launch_executor(
         portBase,
         shm_vol_gb,
         log_base,
+        url_base,
     )
     executor.register()
     executor.recv_loop()
@@ -164,7 +167,17 @@ def run_locally(
         # NOTE forkserver/spawn seem to forget venv, we need fork
         p = multiprocessing.get_context("fork").Process(
             target=launch_executor,
-            args=(job, c, workers, portBase + 1 + i * 10, i, None, gpu_count, log_base),
+            args=(
+                job,
+                c,
+                workers,
+                portBase + 1 + i * 10,
+                i,
+                None,
+                gpu_count,
+                log_base,
+                "tcp://localhost",
+            ),
         )
         p.start()
         ps.append(p)
@@ -247,6 +260,7 @@ def main_dist(
             idx,
             shm_vol_gb,
             gpu_count,
+            f"tcp://{getfqdn()}",
         )
 
 

--- a/src/cascade/benchmarks/__main__.py
+++ b/src/cascade/benchmarks/__main__.py
@@ -78,6 +78,10 @@ def get_job(benchmark: str | None, instance_path: str | None) -> JobInstance:
             import cascade.benchmarks.matmul as matmul
 
             return matmul.get_job()
+        elif benchmark.startswith("dist"):
+            import cascade.benchmarks.dist as dist
+
+            return dist.get_job()
         else:
             raise NotImplementedError(benchmark)
     else:

--- a/src/cascade/benchmarks/dist.py
+++ b/src/cascade/benchmarks/dist.py
@@ -9,6 +9,7 @@ The job is a source -> (dist group) -> sink, where:
 
 There are multiple implementations of that:
     torch
+    jax (actually does a mesh-shard global sum instead of broadcast -- the point is to showcase dist init)
 """
 
 import os
@@ -21,43 +22,73 @@ def source_func() -> int:
     return 42
 
 
-def build_coupled_func(impl: str):
+def dist_func_torch(a: int) -> int:
+    import datetime as dt
+
+    import numpy as np
+    import torch.distributed as dist
+
+    world_size = int(os.environ["CASCADE_GANG_WORLD_SIZE"])
+    rank = int(os.environ["CASCADE_GANG_RANK"])
+    coordinator = os.environ["CASCADE_GANG_COORDINATOR"]
+    print(f"starting with envvars: {rank=}/{world_size=}, {coordinator=}")
+    dist.init_process_group(
+        backend="gloo",
+        init_method=coordinator,
+        timeout=dt.timedelta(minutes=1),
+        world_size=world_size,
+        rank=rank,
+    )
+    group_ranks = np.arange(world_size, dtype=int)
+    group = dist.new_group(group_ranks)
+
+    if rank == 0:
+        buf = [a]
+        dist.broadcast_object_list(buf, src=0, group=group)
+        print("broadcast ok")
+    else:
+        buf = np.array([0], dtype=np.uint64)
+        dist.broadcast_object_list(buf, src=0, group=group)
+        print(f"broadcast recevied {buf}")
+
+    return a * buf[0]
+
+
+def dist_func_jax(a: int) -> int:
+    world_size = int(os.environ["CASCADE_GANG_WORLD_SIZE"])
+    rank = int(os.environ["CASCADE_GANG_RANK"])
+    coordinator = os.environ["CASCADE_GANG_COORDINATOR"]
+    os.environ["JAX_NUM_CPU_DEVICES"] = "1"
+    os.environ["JAX_PLATFORM_NAME"] = "cpu"
+    os.environ["JAX_PLATFORMS"] = "cpu"
+    import jax
+    import jax.numpy as jp
+
+    jax.config.update("jax_platforms", "cpu")
+    jax.config.update("jax_platform_name", "cpu")
+    # NOTE neither of the above seems to actually help with an init error message :(
+    print(f"starting with envvars: {rank=}/{world_size=}, {coordinator=}")
+    if coordinator.startswith("tcp://"):
+        coordinator = coordinator[len("tcp://") :]
+    jax.distributed.initialize(coordinator, num_processes=world_size, process_id=rank)
+    assert jax.device_count() == world_size
+
+    mesh = jax.make_mesh((world_size,), ("i",))
+    global_data = jp.arange(world_size)
+    sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec("i"))
+    global_array = jax.device_put(global_data, sharding)
+    result = jp.sum(global_array)
+    print(f"worker {rank}# got result {result=}")
+    return a + result
+
+
+def build_dist_func(impl: str):
     if impl == "torch":
-
-        def coupled_func(a: int) -> int:
-            import datetime as dt
-
-            import numpy as np
-            import torch.distributed as dist
-
-            world_size = int(os.environ["CASCADE_GANG_WORLD_SIZE"])
-            rank = int(os.environ["CASCADE_GANG_RANK"])
-            coordinator = os.environ["CASCADE_GANG_COORDINATOR"]
-            print(f"starting with envvars: {rank=}/{world_size=}, {coordinator=}")
-            dist.init_process_group(
-                backend="gloo",
-                init_method=coordinator,
-                timeout=dt.timedelta(minutes=1),
-                world_size=world_size,
-                rank=rank,
-            )
-            group_ranks = np.arange(world_size, dtype=int)
-            group = dist.new_group(group_ranks)
-
-            if rank == 0:
-                buf = [a]
-                dist.broadcast_object_list(buf, src=0, group=group)
-                print("broadcast ok")
-            else:
-                buf = np.array([0], dtype=np.uint64)
-                dist.broadcast_object_list(buf, src=0, group=group)
-                print(f"broadcast recevied {buf}")
-
-            return a * buf[0]
-
+        return dist_func_torch
+    elif impl == "jax":
+        return dist_func_jax
     else:
         raise NotImplementedError(impl)
-    return coupled_func
 
 
 def sink_func(**kwargs) -> int:
@@ -74,7 +105,7 @@ def get_job() -> JobInstance:
     job = JobBuilder().with_node("source", source_node).with_node("sink", sink_node)
     L = int(os.environ["DIST_L"])
     IMPL = os.environ["DIST_IMPL"]
-    node = TaskBuilder.from_callable(build_coupled_func(IMPL))
+    node = TaskBuilder.from_callable(build_dist_func(IMPL))
 
     for i in range(L):
         job = (

--- a/src/cascade/benchmarks/dist.py
+++ b/src/cascade/benchmarks/dist.py
@@ -1,0 +1,92 @@
+"""Demonstrates gang scheduling capabilities, ie, multiple nodes capable of mutual communication.
+
+The job is a source -> (dist group) -> sink, where:
+    source just returns an int,
+    dist group is L nodes to be scheduled as a single gang
+        rank=0 node broadcasts a buffer containing the node's input
+        each node returns its input multiplied by broadcasted buffer
+    sink returns the sum of all inputs
+
+There are multiple implementations of that:
+    torch
+"""
+
+import os
+
+from cascade.low.builders import JobBuilder, TaskBuilder
+from cascade.low.core import JobInstance, SchedulingConstraint
+
+
+def source_func() -> int:
+    return 42
+
+
+def build_coupled_func(impl: str):
+    if impl == "torch":
+
+        def coupled_func(a: int) -> int:
+            import datetime as dt
+
+            import numpy as np
+            import torch.distributed as dist
+
+            world_size = int(os.environ["CASCADE_GANG_WORLD_SIZE"])
+            rank = int(os.environ["CASCADE_GANG_RANK"])
+            coordinator = os.environ["CASCADE_GANG_COORDINATOR"]
+            print(f"starting with envvars: {rank=}/{world_size=}, {coordinator=}")
+            dist.init_process_group(
+                backend="gloo",
+                init_method=coordinator,
+                timeout=dt.timedelta(minutes=1),
+                world_size=world_size,
+                rank=rank,
+            )
+            group_ranks = np.arange(world_size, dtype=int)
+            group = dist.new_group(group_ranks)
+
+            if rank == 0:
+                buf = [a]
+                dist.broadcast_object_list(buf, src=0, group=group)
+                print("broadcast ok")
+            else:
+                buf = np.array([0], dtype=np.uint64)
+                dist.broadcast_object_list(buf, src=0, group=group)
+                print(f"broadcast recevied {buf}")
+
+            return a * buf[0]
+
+    else:
+        raise NotImplementedError(impl)
+    return coupled_func
+
+
+def sink_func(**kwargs) -> int:
+    c = 0
+    for _, v in kwargs.items():
+        c += v
+    print(f"sink accumulated {c}")
+    return c
+
+
+def get_job() -> JobInstance:
+    source_node = TaskBuilder.from_callable(source_func)
+    sink_node = TaskBuilder.from_callable(sink_func)
+    job = JobBuilder().with_node("source", source_node).with_node("sink", sink_node)
+    L = int(os.environ["DIST_L"])
+    IMPL = os.environ["DIST_IMPL"]
+    node = TaskBuilder.from_callable(build_coupled_func(IMPL))
+
+    for i in range(L):
+        job = (
+            job.with_node(f"proc{i}", node)
+            .with_edge("source", f"proc{i}", "a")
+            .with_edge(f"proc{i}", "sink", f"v{i}")
+        )
+        job.nodes["sink"].definition.input_schema[
+            f"v{i}"
+        ] = "int"  # TODO put some allow_kw into TaskDefinition instead to allow this
+
+    job = job.build().get_or_raise()
+    job.ext_outputs = list(job.outputs_of("sink"))
+    job.constraints = [SchedulingConstraint(gang=[f"proc{i}" for i in range(L)])]
+    return job

--- a/src/cascade/controller/act.py
+++ b/src/cascade/controller/act.py
@@ -51,6 +51,7 @@ def act(bridge: Bridge, assignment: Assignment) -> None:
         worker=assignment.worker,
         tasks=assignment.tasks,
         publish=assignment.outputs,
+        extra_env=assignment.extra_env,
     )
 
     for task in assignment.tasks:

--- a/src/cascade/controller/notify.py
+++ b/src/cascade/controller/notify.py
@@ -22,6 +22,7 @@ from cascade.low.core import DatasetId, HostId, WorkerId
 from cascade.low.execution_context import DatasetStatus, JobExecutionContext
 from cascade.low.func import assert_never
 from cascade.low.tracing import TaskLifecycle, TransmitLifecycle, mark
+from cascade.scheduler.api import gang_check_ready
 from cascade.scheduler.assign import set_worker2task_overhead
 from cascade.scheduler.core import Schedule
 
@@ -67,6 +68,7 @@ def consider_computable(
                     # NOTE this is a task newly made computable, so we need to calc
                     # `overhead` for all hosts/workers assigned to the component
                     set_worker2task_overhead(schedule, context, worker, child_task)
+                gang_check_ready(child_task, component.gang_preparation)
 
 
 # TODO refac less explicit mutation of context, use class methods

--- a/src/cascade/executor/bridge.py
+++ b/src/cascade/executor/bridge.py
@@ -46,7 +46,7 @@ class Bridge:
         self.transmit_idx_counter = 0
         self.sender = ReliableSender(self.mlistener.address, resend_grace_ms)
         registered = 0
-        self.environment = Environment(workers={})
+        self.environment = Environment(workers={}, host_url_base={})
         logger.debug("about to start receiving registrations")
         registration_grace = time.time_ns() + 3 * 60 * 1_000_000_000
         while registered < expected_executors:
@@ -69,6 +69,7 @@ class Bridge:
                     self.environment.workers[worker.worker_id] = Worker(
                         cpu=worker.cpu, gpu=worker.gpu, memory_mb=worker.memory_mb
                     )
+                self.environment.host_url_base[message.host] = message.url_base
                 registered += 1
                 self.heartbeat_checker[message.host] = GraceWatcher(
                     2 * executor_heartbeat_grace_ms

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -69,8 +69,9 @@ class Executor:
         workers: int,
         host: HostId,
         portBase: int,
-        shm_vol_gb: int | None = None,
-        log_base: str | None = None,
+        shm_vol_gb: int | None,
+        log_base: str | None,
+        url_base: str,
     ) -> None:
         self.job_instance = job_instance
         self.param_source = param_source(job_instance.edges)
@@ -138,6 +139,7 @@ class Executor:
                 )
                 for idx, worker_id in enumerate(self.workers.keys())
             ],
+            url_base=url_base,
         )
         logger.debug("constructed executor")
 

--- a/src/cascade/executor/msg.py
+++ b/src/cascade/executor/msg.py
@@ -71,6 +71,7 @@ class TaskSequence:
     worker: WorkerId  # worker for running those tasks
     tasks: list[TaskId]  # to be executed in the given order
     publish: set[DatasetId]  # set of outputs to be published
+    extra_env: list[tuple[str, str]]  # extra env var to set
 
 
 @dataclass(frozen=True)
@@ -147,6 +148,7 @@ class ExecutorRegistration:
     host: HostId
     maddress: BackboneAddress
     daddress: BackboneAddress
+    url_base: str  # used for eg dist comms init
     workers: list[Worker]
 
 

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -99,7 +99,6 @@ def execute_sequence(
     taskId: TaskId | None = None
     try:
         for key, value in taskSequence.extra_env.items():
-            logger.error(f"extra env: {key=} => {value=}")
             os.environ[key] = value
         executionContext = runnerContext.project(taskSequence)
         for taskId in taskSequence.tasks:

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -99,6 +99,7 @@ def execute_sequence(
     taskId: TaskId | None = None
     try:
         for key, value in taskSequence.extra_env.items():
+            logger.error(f"extra env: {key=} => {value=}")
             os.environ[key] = value
         executionContext = runnerContext.project(taskSequence)
         for taskId in taskSequence.tasks:

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -98,12 +98,17 @@ def execute_sequence(
 ) -> None:
     taskId: TaskId | None = None
     try:
+        for key, value in taskSequence.extra_env.items():
+            os.environ[key] = value
         executionContext = runnerContext.project(taskSequence)
         for taskId in taskSequence.tasks:
             pckg.extend(executionContext.tasks[taskId].definition.environment)
             run(taskId, executionContext, memory)
         if Config.posttask_flush:
             memory.flush()
+        for key in taskSequence.extra_env.keys():
+            # NOTE we should in principle restore the previous value, but we dont expect collisions
+            del os.environ[key]
     except Exception as e:
         logger.exception("runner failure, about to report")
         callback(

--- a/src/cascade/low/core.py
+++ b/src/cascade/low/core.py
@@ -105,16 +105,25 @@ def type_dec(t: str) -> Type:
 def type_enc(t: Type) -> str:
     return b64encode(cloudpickle.dumps(t)).decode("ascii")
 
+class SchedulingConstraint(BaseModel):
+    gang: list[TaskId] = Field(
+        description="this set of TaskIds must be started at the same time, with ranks and address list as envvar",
+    )
 
 class JobInstance(BaseModel):
     tasks: dict[TaskId, TaskInstance]
     edges: list[Task2TaskEdge]
     serdes: dict[str, tuple[str, str]] = Field(
-        {},
+        default_factory=lambda: {},
         description="for each Type with custom serde, add entry here. The string is fully qualified name of the ser/des functions",
     )
     ext_outputs: list[DatasetId] = Field(
-        [], description="ids to externally materialize"
+        default_factory=lambda: [],
+        description="ids to externally materialize",
+    )
+    constraints: list[SchedulingConstraint] = Field(
+        default_factory=lambda : [],
+        description="constraints for the scheduler such as gangs",
     )
 
     def outputs_of(self, task_id: TaskId) -> set[DatasetId]:

--- a/src/cascade/low/core.py
+++ b/src/cascade/low/core.py
@@ -105,10 +105,12 @@ def type_dec(t: str) -> Type:
 def type_enc(t: Type) -> str:
     return b64encode(cloudpickle.dumps(t)).decode("ascii")
 
+
 class SchedulingConstraint(BaseModel):
     gang: list[TaskId] = Field(
         description="this set of TaskIds must be started at the same time, with ranks and address list as envvar",
     )
+
 
 class JobInstance(BaseModel):
     tasks: dict[TaskId, TaskInstance]
@@ -122,7 +124,7 @@ class JobInstance(BaseModel):
         description="ids to externally materialize",
     )
     constraints: list[SchedulingConstraint] = Field(
-        default_factory=lambda : [],
+        default_factory=lambda: [],
         description="constraints for the scheduler such as gangs",
     )
 
@@ -166,6 +168,7 @@ class Worker(BaseModel):
 
 class Environment(BaseModel):
     workers: dict[WorkerId, Worker]
+    host_url_base: dict[HostId, str]
 
 
 class TaskExecutionRecord(BaseModel):

--- a/src/cascade/scheduler/api.py
+++ b/src/cascade/scheduler/api.py
@@ -46,6 +46,7 @@ def gang_check_ready(task: TaskId, gang_prep: GangPreparation):
             )
         remaining.remove(task)
         if not remaining:
+            logger.debug(f"gang just became ready {gang=}")
             gang_prep.ready.append(gang)
             gang_prep.countdown.pop(gang)
 

--- a/src/cascade/scheduler/api.py
+++ b/src/cascade/scheduler/api.py
@@ -13,10 +13,22 @@ from typing import Iterator
 from cascade.low.core import TaskId, WorkerId
 from cascade.low.execution_context import JobExecutionContext, TaskStatus
 from cascade.low.tracing import Microtrace, timer
-from cascade.scheduler.assign import assign_within_component, migrate_to_component, update_worker2task_distance
-from cascade.scheduler.core import Assignment, ComponentId, ComponentSchedule, GangPreparation, Preschedule, Schedule
+from cascade.scheduler.assign import (
+    assign_within_component,
+    migrate_to_component,
+    update_worker2task_distance,
+)
+from cascade.scheduler.core import (
+    Assignment,
+    ComponentId,
+    ComponentSchedule,
+    GangPreparation,
+    Preschedule,
+    Schedule,
+)
 
 logger = logging.getLogger(__name__)
+
 
 def gang_check_ready(task: TaskId, gang_prep: GangPreparation):
     """When a task becomes computable, mutate the gang_prep to possibly
@@ -24,10 +36,14 @@ def gang_check_ready(task: TaskId, gang_prep: GangPreparation):
     """
     for gang in gang_prep.lookup[task]:
         if gang not in gang_prep.countdown:
-            raise ValueError(f"after {task=} marked computable, {gang=} not found -- double compuptable mark?")
+            raise ValueError(
+                f"after {task=} marked computable, {gang=} not found -- double compuptable mark?"
+            )
         remaining = gang_prep.countdown[gang]
         if task not in remaining:
-            raise ValueError(f"after {task=} marked computable, {gang=} does not have it in {remaining=}. Invalid gang?")
+            raise ValueError(
+                f"after {task=} marked computable, {gang=} does not have it in {remaining=}. Invalid gang?"
+            )
         remaining.remove(task)
         if not remaining:
             gang_prep.ready.append(gang)
@@ -38,7 +54,9 @@ def init_schedule(preschedule: Preschedule, context: JobExecutionContext) -> Sch
     components: list[ComponentSchedule] = []
     ts2component: dict[TaskId, ComponentId] = {}
 
-    gangs = [frozenset(constraint.gang) for constraint in context.job_instance.constraints]
+    gangs = [
+        frozenset(constraint.gang) for constraint in context.job_instance.constraints
+    ]
 
     computable = 0
     for componentId, precomponent in enumerate(preschedule.components):

--- a/src/cascade/scheduler/api.py
+++ b/src/cascade/scheduler/api.py
@@ -13,28 +13,58 @@ from typing import Iterator
 from cascade.low.core import TaskId, WorkerId
 from cascade.low.execution_context import JobExecutionContext, TaskStatus
 from cascade.low.tracing import Microtrace, timer
-from cascade.scheduler.assign import (
-    assign_within_component,
-    migrate_to_component,
-    update_worker2task_distance,
-)
-from cascade.scheduler.core import (
-    Assignment,
-    ComponentId,
-    ComponentSchedule,
-    Preschedule,
-    Schedule,
-)
+from cascade.scheduler.assign import assign_within_component, migrate_to_component, update_worker2task_distance
+from cascade.scheduler.core import Assignment, ComponentId, ComponentSchedule, GangPreparation, Preschedule, Schedule
 
 logger = logging.getLogger(__name__)
+
+def gang_check_ready(task: TaskId, gang_prep: GangPreparation):
+    """When a task becomes computable, mutate the gang_prep to possibly
+    transition some gangs to `ready`
+    """
+    for gang in gang_prep.lookup[task]:
+        if gang not in gang_prep.countdown:
+            raise ValueError(f"after {task=} marked computable, {gang=} not found -- double compuptable mark?")
+        remaining = gang_prep.countdown[gang]
+        if task not in remaining:
+            raise ValueError(f"after {task=} marked computable, {gang=} does not have it in {remaining=}. Invalid gang?")
+        remaining.remove(task)
+        if not remaining:
+            gang_prep.ready.append(gang)
+            gang_prep.countdown.pop(gang)
 
 
 def init_schedule(preschedule: Preschedule, context: JobExecutionContext) -> Schedule:
     components: list[ComponentSchedule] = []
     ts2component: dict[TaskId, ComponentId] = {}
 
+    gangs = [frozenset(constraint.gang) for constraint in context.job_instance.constraints]
+
     computable = 0
     for componentId, precomponent in enumerate(preschedule.components):
+        # gang preparation
+        tasks = set(precomponent.nodes)
+        lookup = defaultdict(list)
+        countdown = {}
+        i = 0
+        while i < len(gangs):
+            if not gangs[i].issubset(tasks):
+                i += 1
+                continue
+            gang = gangs.pop(i)
+            countdown[gang] = set(gang)
+            for e in gang:
+                lookup[e].append(gang)
+
+        gang_preparation = GangPreparation(
+            ready=[],
+            lookup=lookup,
+            countdown=countdown,
+        )
+        for source in precomponent.sources:
+            gang_check_ready(source, gang_preparation)
+
+        # component itself
         component = ComponentSchedule(
             core=precomponent,
             weight=precomponent.weight(),
@@ -45,11 +75,17 @@ def init_schedule(preschedule: Preschedule, context: JobExecutionContext) -> Sch
                 task: {inp for inp in context.edge_i[task]}
                 for task in precomponent.nodes
             },
+            gang_preparation=gang_preparation,
         )
         components.append(component)
         computable += len(precomponent.sources)
         for task in precomponent.nodes:
             ts2component[task] = componentId
+
+    if gangs:
+        for gang in gangs:
+            logger.error(f"a gang not part of a component: {gang}")
+        raise ValueError(f"a total of {len(gangs)} were not a subcomponent")
 
     return Schedule(
         components=components,

--- a/src/cascade/scheduler/assign.py
+++ b/src/cascade/scheduler/assign.py
@@ -18,7 +18,7 @@ from typing import Iterable, Iterator
 from cascade.low.core import DatasetId, HostId, TaskId, WorkerId
 from cascade.low.execution_context import DatasetStatus, JobExecutionContext
 from cascade.low.tracing import Microtrace, trace
-from cascade.scheduler.core import Assignment, ComponentCore, ComponentId, Schedule
+from cascade.scheduler.core import Assignment, ComponentCore, ComponentId, ComponentSchedule, Schedule
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +94,99 @@ def build_assignment(
         outputs=trimmed_outputs,
     )
 
+def _postproc_assignment(assignment: Assignment, component: ComponentSchedule, schedule: Schedule, context: JobExecutionContext) -> None:
+    for assigned in assignment.tasks:
+        if assigned in component.computable:
+            component.computable.pop(assigned)
+            component.worker2task_values.remove(assigned)
+            schedule.computable -= 1
+        else:
+            # shortcut for fused-in tasks
+            component.is_computable_tracker[assigned] = set()
+    context.idle_workers.remove(assignment.worker)
+    component.weight -= len(assignment.tasks)
+
+
+def _try_assign_gang(
+    schedule: Schedule,
+    gang: frozenset[TaskId],
+    workers: list[WorkerId],
+    component_id: ComponentId,
+    context: JobExecutionContext,
+) -> Iterator[Assignment]:
+    """We greedily assign by descending worker-task distance"""
+    if len(gang) > len(workers):
+        return
+    start = perf_counter_ns()
+    component = schedule.components[component_id]
+    gpu_tasks: set[TaskId] = set()
+    cpu_tasks: set[TaskId] = set()
+    gpu_workers: set[WorkerId] = set()
+    cpu_workers: set[WorkerId] = set()
+    for task in gang:
+        if context.job_instance.tasks[task].definition.needs_gpu:
+            gpu_tasks.add(task)
+        else:
+            cpu_tasks.add(task)
+    for worker in workers:
+        if context.environment.workers[worker].gpu > 0:
+            gpu_workers.add(worker)
+        else:
+            cpu_workers.add(worker)
+    if len(gpu_tasks) > len(gpu_workers):
+        end = perf_counter_ns()
+        trace(Microtrace.ctrl_assign, end - start)
+        return
+
+    # similarly to _assignment_heuristic, a greedy algorithm
+    candidates = [
+        (schedule.worker2task_overhead[w][t], component.core.value[t], w, t)
+        for w in gpu_workers
+        for t in gpu_tasks
+    ]
+    candidates.sort(key=lambda e: (e[0], e[1]))
+    for _, _, worker, task in candidates:
+        if task in gpu_tasks and worker in gpu_workers:
+            if task not in component.computable:
+                # it may be that some fusing for previous task already assigned this
+                continue
+            end = perf_counter_ns()
+            trace(Microtrace.ctrl_assign, end - start)
+            assignment = build_assignment(worker, task, context, component.core)
+            yield assignment
+            start = perf_counter_ns()
+            _postproc_assignment(assignment, component, schedule, context)
+            gpu_tasks.remove(task)
+            gpu_workers.remove(worker)
+    if gpu_tasks:
+        raise ValueError(f"expected to assign all gang gpu tasks, yet {gpu_tasks} remain")
+
+    all_workers = cpu_workers.union(gpu_workers)
+    candidates = [
+        (schedule.worker2task_overhead[w][t], component.core.value[t], w, t)
+        for w in all_workers
+        for t in cpu_tasks
+    ]
+    candidates.sort(key=lambda e: (e[0], e[1]))
+    for _, _, worker, task in candidates:
+        if task in cpu_tasks and worker in all_workers:
+            if task not in component.computable:
+                # it may be that some fusing for previous task already assigned this
+                continue
+            end = perf_counter_ns()
+            trace(Microtrace.ctrl_assign, end - start)
+            assignment = build_assignment(worker, task, context, component.core)
+            yield assignment
+            start = perf_counter_ns()
+            _postproc_assignment(assignment, component, schedule, context)
+            cpu_tasks.remove(task)
+            all_workers.remove(worker)
+    if cpu_tasks:
+        raise ValueError(f"expected to assign all gang cpu tasks, yet {cpu_tasks} remain")
+
+    end = perf_counter_ns()
+    trace(Microtrace.ctrl_assign, end - start)
+
 
 def _assignment_heuristic(
     schedule: Schedule,
@@ -105,18 +198,6 @@ def _assignment_heuristic(
     """Finds a reasonable assignment within a single component. Does not migrate hosts to a different component."""
     start = perf_counter_ns()
     component = schedule.components[component_id]
-
-    def postproc_assignment(assignment: Assignment) -> None:
-        for assigned in assignment.tasks:
-            if assigned in component.computable:
-                component.computable.pop(assigned)
-                component.worker2task_values.remove(assigned)
-                schedule.computable -= 1
-            else:
-                # shortcut for fused-in tasks
-                component.is_computable_tracker[assigned] = set()
-        context.idle_workers.remove(worker)
-        component.weight -= len(assignment.tasks)
 
     # first, attempt optimum-distance assignment
     unassigned: list[TaskId] = []
@@ -133,7 +214,7 @@ def _assignment_heuristic(
                 assignment = build_assignment(worker, task, context, component.core)
                 yield assignment
                 start = perf_counter_ns()
-                postproc_assignment(assignment)
+                _postproc_assignment(assignment, component, schedule, context)
                 workers.pop(idx)
                 was_assigned = True
                 break
@@ -159,7 +240,7 @@ def _assignment_heuristic(
             assignment = build_assignment(worker, task, context, component.core)
             yield assignment
             start = perf_counter_ns()
-            postproc_assignment(assignment)
+            _postproc_assignment(assignment, component, schedule, context)
             remaining_t.remove(task)
             remaining_w.remove(worker)
 
@@ -173,14 +254,27 @@ def assign_within_component(
     component_id: ComponentId,
     context: JobExecutionContext,
 ) -> Iterator[Assignment]:
-    """We first handle tasks requiring a gpu, then tasks whose child requires a gpu, last cpu only tasks, using the same algorithm for either case"""
-    # TODO employ a more systematic solution and handle all multicriterially at once -- ideally together with adding support for multi-gpu-groups
-    # NOTE this is getting even more important as we started considering gpu fused distance
-    # NOTE the concept of "strategic wait" is completely missing here (eg dont assign a gpu worker to a cpu task because there will come a gpu task in a few secs)
+    """We hardcode order of handling task groups:
+        1/ ready gangs,
+        2/ tasks requiring a gpu,
+        3/ tasks whose fusable child requires a gpu,
+        4/ all other tasks,
+    using the same algorithm for cases 2-4 and a naive for case 1
+    """
+    # TODO rework into a more systematic multicriterial opt solution that is able to consider all groups
+    # at once, using a generic value/cost framework and matching algorithm. It should additionally be able
+    # to issue a "strategic wait" command -- eg if we could assign a task to an idle worker with high cost,
+    # or wait until a better-equipped busy worker finished, etc.
+    component = schedule.components[component_id]
+
+    # gangs
+    for gang in component.gang_preparation.ready:
+        yield from _try_assign_gang(schedule, gang, list(context.idle_workers), component_id, context)
+
+    # the other cases: build them first
     cpu_t: list[TaskId] = []
     gpu_t: list[TaskId] = []
     opu_t: list[TaskId] = []
-    component = schedule.components[component_id]
     for task in component.computable.keys():
         if context.job_instance.tasks[task].definition.needs_gpu:
             gpu_t.append(task)
@@ -188,12 +282,18 @@ def assign_within_component(
             opu_t.append(task)
         else:
             cpu_t.append(task)
+
+    # tasks immediately needing a gpu
     eligible_w = [
-        worker for worker in workers if context.environment.workers[worker].gpu > 0
+        worker
+        for worker in workers
+        if context.environment.workers[worker].gpu > 0 and worker in context.idle_workers
     ]
     yield from _assignment_heuristic(schedule, gpu_t, eligible_w, component_id, context)
+    # tasks whose fusing opportunity needs a gpu
     eligible_w = [worker for worker in eligible_w if worker in context.idle_workers]
     yield from _assignment_heuristic(schedule, opu_t, eligible_w, component_id, context)
+    # remaining tasks
     eligible_w = [worker for worker in workers if worker in context.idle_workers]
     yield from _assignment_heuristic(schedule, cpu_t, eligible_w, component_id, context)
 

--- a/src/cascade/scheduler/assign.py
+++ b/src/cascade/scheduler/assign.py
@@ -276,7 +276,10 @@ def assign_within_component(
     gpu_t: list[TaskId] = []
     opu_t: list[TaskId] = []
     for task in component.computable.keys():
-        if context.job_instance.tasks[task].definition.needs_gpu:
+        if component.gang_preparation.lookup[task]:
+            # no gang participation in a single-task scheduling
+            continue
+        elif context.job_instance.tasks[task].definition.needs_gpu:
             gpu_t.append(task)
         elif component.core.gpu_fused_distance[task] is not None:
             opu_t.append(task)

--- a/src/cascade/scheduler/assign.py
+++ b/src/cascade/scheduler/assign.py
@@ -18,7 +18,13 @@ from typing import Iterable, Iterator
 from cascade.low.core import DatasetId, HostId, TaskId, WorkerId
 from cascade.low.execution_context import DatasetStatus, JobExecutionContext
 from cascade.low.tracing import Microtrace, trace
-from cascade.scheduler.core import Assignment, ComponentCore, ComponentId, ComponentSchedule, Schedule
+from cascade.scheduler.core import (
+    Assignment,
+    ComponentCore,
+    ComponentId,
+    ComponentSchedule,
+    Schedule,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,9 +98,16 @@ def build_assignment(
         tasks=assigned,
         prep=prep,
         outputs=trimmed_outputs,
+        extra_env={},
     )
 
-def _postproc_assignment(assignment: Assignment, component: ComponentSchedule, schedule: Schedule, context: JobExecutionContext) -> None:
+
+def _postproc_assignment(
+    assignment: Assignment,
+    component: ComponentSchedule,
+    schedule: Schedule,
+    context: JobExecutionContext,
+) -> None:
     for assigned in assignment.tasks:
         if assigned in component.computable:
             component.computable.pop(assigned)
@@ -107,6 +120,14 @@ def _postproc_assignment(assignment: Assignment, component: ComponentSchedule, s
     component.weight -= len(assignment.tasks)
 
 
+# TODO this is not particularly systematic! We cant bind dynamically at the host as we send this
+# in advance, so we need to hardcode. Ideally we centrallize all port opening into a single module,
+# in particular unify this with the portBase from benchmarks/__main__ and then derived ports from
+# executor/executor.py etc. As is, we have a single global variable that we increment, to ensure
+# no port collision happens gang-wise -- we dont really expect many gangs per a workflow
+gang_port = 12355
+
+
 def _try_assign_gang(
     schedule: Schedule,
     gang: frozenset[TaskId],
@@ -115,6 +136,7 @@ def _try_assign_gang(
     context: JobExecutionContext,
 ) -> Iterator[Assignment]:
     """We greedily assign by descending worker-task distance"""
+    global gang_port
     if len(gang) > len(workers):
         return
     start = perf_counter_ns()
@@ -138,6 +160,10 @@ def _try_assign_gang(
         trace(Microtrace.ctrl_assign, end - start)
         return
 
+    world_size = len(gang)
+    rank = 0
+    coordinator = None
+
     # similarly to _assignment_heuristic, a greedy algorithm
     candidates = [
         (schedule.worker2task_overhead[w][t], component.core.value[t], w, t)
@@ -153,13 +179,23 @@ def _try_assign_gang(
             end = perf_counter_ns()
             trace(Microtrace.ctrl_assign, end - start)
             assignment = build_assignment(worker, task, context, component.core)
+            if not coordinator:
+                coordinator = (
+                    f"{context.environment.host_url_base[worker.host]}:{gang_port}"
+                )
+            assignment.extra_env["CASCADE_GANG_WORLD_SIZE"] = world_size
+            assignment.extra_env["CASCADE_GANG_RANK"] = rank
+            assignment.extra_env["CASCADE_GANG_COORDINATOR"] = coordinator
+            rank += 1
             yield assignment
             start = perf_counter_ns()
             _postproc_assignment(assignment, component, schedule, context)
             gpu_tasks.remove(task)
             gpu_workers.remove(worker)
     if gpu_tasks:
-        raise ValueError(f"expected to assign all gang gpu tasks, yet {gpu_tasks} remain")
+        raise ValueError(
+            f"expected to assign all gang gpu tasks, yet {gpu_tasks} remain"
+        )
 
     all_workers = cpu_workers.union(gpu_workers)
     candidates = [
@@ -176,16 +212,27 @@ def _try_assign_gang(
             end = perf_counter_ns()
             trace(Microtrace.ctrl_assign, end - start)
             assignment = build_assignment(worker, task, context, component.core)
+            if not coordinator:
+                coordinator = (
+                    f"{context.environment.host_url_base[worker.host]}:{gang_port}"
+                )
+            assignment.extra_env["CASCADE_GANG_WORLD_SIZE"] = world_size
+            assignment.extra_env["CASCADE_GANG_RANK"] = rank
+            assignment.extra_env["CASCADE_GANG_COORDINATOR"] = coordinator
+            rank += 1
             yield assignment
             start = perf_counter_ns()
             _postproc_assignment(assignment, component, schedule, context)
             cpu_tasks.remove(task)
             all_workers.remove(worker)
     if cpu_tasks:
-        raise ValueError(f"expected to assign all gang cpu tasks, yet {cpu_tasks} remain")
+        raise ValueError(
+            f"expected to assign all gang cpu tasks, yet {cpu_tasks} remain"
+        )
 
     end = perf_counter_ns()
     trace(Microtrace.ctrl_assign, end - start)
+    gang_port += 1
 
 
 def _assignment_heuristic(
@@ -269,7 +316,9 @@ def assign_within_component(
 
     # gangs
     for gang in component.gang_preparation.ready:
-        yield from _try_assign_gang(schedule, gang, list(context.idle_workers), component_id, context)
+        yield from _try_assign_gang(
+            schedule, gang, list(context.idle_workers), component_id, context
+        )
 
     # the other cases: build them first
     cpu_t: list[TaskId] = []
@@ -290,7 +339,8 @@ def assign_within_component(
     eligible_w = [
         worker
         for worker in workers
-        if context.environment.workers[worker].gpu > 0 and worker in context.idle_workers
+        if context.environment.workers[worker].gpu > 0
+        and worker in context.idle_workers
     ]
     yield from _assignment_heuristic(schedule, gpu_t, eligible_w, component_id, context)
     # tasks whose fusing opportunity needs a gpu

--- a/src/cascade/scheduler/assign.py
+++ b/src/cascade/scheduler/assign.py
@@ -130,14 +130,17 @@ gang_port = 12355
 
 def _try_assign_gang(
     schedule: Schedule,
-    gang: frozenset[TaskId],
+    gang: list[frozenset[TaskId]],
     workers: list[WorkerId],
     component_id: ComponentId,
     context: JobExecutionContext,
+    fail_acc: list[frozenset[TaskId]],
 ) -> Iterator[Assignment]:
     """We greedily assign by descending worker-task distance"""
     global gang_port
     if len(gang) > len(workers):
+        logger.debug(f"not enough workers ({len(workers)}) for {gang=}")
+        fail_acc.append(gang)
         return
     start = perf_counter_ns()
     component = schedule.components[component_id]
@@ -156,6 +159,8 @@ def _try_assign_gang(
         else:
             cpu_workers.add(worker)
     if len(gpu_tasks) > len(gpu_workers):
+        logger.debug(f"not enough gpu workers ({len(workers)}) for {gang=}")
+        fail_acc.append(gang)
         end = perf_counter_ns()
         trace(Microtrace.ctrl_assign, end - start)
         return
@@ -183,8 +188,8 @@ def _try_assign_gang(
                 coordinator = (
                     f"{context.environment.host_url_base[worker.host]}:{gang_port}"
                 )
-            assignment.extra_env["CASCADE_GANG_WORLD_SIZE"] = world_size
-            assignment.extra_env["CASCADE_GANG_RANK"] = rank
+            assignment.extra_env["CASCADE_GANG_WORLD_SIZE"] = str(world_size)
+            assignment.extra_env["CASCADE_GANG_RANK"] = str(rank)
             assignment.extra_env["CASCADE_GANG_COORDINATOR"] = coordinator
             rank += 1
             yield assignment
@@ -216,8 +221,8 @@ def _try_assign_gang(
                 coordinator = (
                     f"{context.environment.host_url_base[worker.host]}:{gang_port}"
                 )
-            assignment.extra_env["CASCADE_GANG_WORLD_SIZE"] = world_size
-            assignment.extra_env["CASCADE_GANG_RANK"] = rank
+            assignment.extra_env["CASCADE_GANG_WORLD_SIZE"] = str(world_size)
+            assignment.extra_env["CASCADE_GANG_RANK"] = str(rank)
             assignment.extra_env["CASCADE_GANG_COORDINATOR"] = coordinator
             rank += 1
             yield assignment
@@ -315,10 +320,13 @@ def assign_within_component(
     component = schedule.components[component_id]
 
     # gangs
+    fail_acc: list[frozenset[TaskId]] = []
     for gang in component.gang_preparation.ready:
+        logger.debug(f"trying to assign a {gang=}")
         yield from _try_assign_gang(
-            schedule, gang, list(context.idle_workers), component_id, context
+            schedule, gang, list(context.idle_workers), component_id, context, fail_acc
         )
+    component.gang_preparation.ready = fail_acc
 
     # the other cases: build them first
     cpu_t: list[TaskId] = []

--- a/src/cascade/scheduler/core.py
+++ b/src/cascade/scheduler/core.py
@@ -43,11 +43,18 @@ Worker2TaskDistance = dict[WorkerId, dict[TaskId, int]]
 
 ComponentId = int
 
+
 @dataclass
 class GangPreparation:
-    ready: list[frozenset[TaskId]] # used by scheduler to see if any gangs can be assigned/started
-    countdown: dict[frozenset[TaskId], set[TaskId]] # used to check after a task completion whether a gang can be moved to ready
-    lookup: dict[TaskId, list[frozenset[TaskId]]] # used to decrease countdown after a task completion
+    ready: list[
+        frozenset[TaskId]
+    ]  # used by scheduler to see if any gangs can be assigned/started
+    countdown: dict[
+        frozenset[TaskId], set[TaskId]
+    ]  # used to check after a task completion whether a gang can be moved to ready
+    lookup: dict[
+        TaskId, list[frozenset[TaskId]]
+    ]  # used to decrease countdown after a task completion
 
 
 @dataclass
@@ -86,3 +93,4 @@ class Assignment:
     tasks: list[TaskId]
     prep: list[tuple[DatasetId, HostId]]
     outputs: set[DatasetId]
+    extra_env: list[tuple[str, str]]

--- a/src/cascade/scheduler/core.py
+++ b/src/cascade/scheduler/core.py
@@ -43,6 +43,12 @@ Worker2TaskDistance = dict[WorkerId, dict[TaskId, int]]
 
 ComponentId = int
 
+@dataclass
+class GangPreparation:
+    ready: list[frozenset[TaskId]] # used by scheduler to see if any gangs can be assigned/started
+    countdown: dict[frozenset[TaskId], set[TaskId]] # used to check after a task completion whether a gang can be moved to ready
+    lookup: dict[TaskId, list[frozenset[TaskId]]] # used to decrease countdown after a task completion
+
 
 @dataclass
 class ComponentSchedule:
@@ -58,6 +64,7 @@ class ComponentSchedule:
     worker2task_distance: Worker2TaskDistance
     # eligible values -- a cached value. Used when migrating new workers to the component, inserted whenever a parent of this task gets `preparing`, removed when this task is made computable
     worker2task_values: set[TaskId]
+    gang_preparation: GangPreparation
 
 
 @dataclass

--- a/src/cascade/scheduler/precompute.py
+++ b/src/cascade/scheduler/precompute.py
@@ -225,7 +225,7 @@ def precompute(job_instance: JobInstance) -> Preschedule:
     }
     gangs = {
         task_id
-        for constraint in job_instance.scheduling_constraints
+        for constraint in job_instance.constraints
         for task_id in constraint.gang
     }
 

--- a/src/cascade/scheduler/precompute.py
+++ b/src/cascade/scheduler/precompute.py
@@ -112,6 +112,7 @@ def _enrich(
     edge_i: dict[TaskId, set[TaskId]],
     edge_o: dict[TaskId, set[TaskId]],
     needs_gpu: set[TaskId],
+    gangs: set[TaskId],
 ) -> ComponentCore:
     nodes, sources = plain_component
     logger.debug(
@@ -170,7 +171,7 @@ def _enrich(
         while layer:
             gpu_distance = None
             head = layer.pop(0)
-            if head in fused:
+            if head in fused or head in gangs:
                 continue
             chain = []
             fused.add(head)
@@ -183,7 +184,7 @@ def _enrich(
                 gpu_fused_distance[head] = gpu_distance
                 found = False
                 for edge in edge_i[head]:
-                    if edge not in fused:
+                    if edge not in fused and edge not in gangs:
                         chain.insert(0, head)
                         head = edge
                         fused.add(head)
@@ -222,11 +223,16 @@ def precompute(job_instance: JobInstance) -> Preschedule:
         for task_id, task in job_instance.tasks.items()
         if task.definition.needs_gpu
     }
+    gangs = {
+        task_id
+        for constraint in job_instance.scheduling_constraints
+        for task_id in constraint.gang
+    }
 
     with ThreadPoolExecutor(max_workers=4) as tp:
         # TODO if coptrs is not used, then this doesnt make sense
         f = lambda plain_component: timer(_enrich, Microtrace.presched_enrich)(
-            plain_component, edge_i_proj, edge_o_proj, needs_gpu
+            plain_component, edge_i_proj, edge_o_proj, needs_gpu, gangs
         )
         plain_components = (
             plain_component

--- a/tests/cascade/controller/test_run.py
+++ b/tests/cascade/controller/test_run.py
@@ -8,9 +8,18 @@
 
 """For a given graph and instant executor, check that things complete"""
 
+# NOTE this is a very bulky test, prone to flakyness, interference, incompatible
+# with xdist etc. Consider removing from pytest altogether, and reframing
+# as integration test script or smth. Until then, we execute it only manually
+# by setting RUN_ALL_TESTS=1, as on CI is particularly flaky and incompatible
+# with xdist etc
+
+
+
 import os
 from logging.config import dictConfig
 from multiprocessing import Process
+from time import sleep
 
 from cascade.controller.impl import run
 from cascade.executor.bridge import Bridge
@@ -23,6 +32,8 @@ from cascade.low.core import JobInstance
 from cascade.scheduler.core import Preschedule
 from cascade.scheduler.precompute import precompute
 
+# see the comment above
+run_all_tests = int(os.environ.get("RUN_ALL_TESTS", "0")) == 1
 
 def _payload(a: int, b: int) -> int:
     return a + b
@@ -74,12 +85,6 @@ def run_cluster(
         raise
 
 
-# TODO there is some race condition, so far observed only on CI without any
-# clue what is exactly happening, freezing this test. Fix one day
-# NOTE additionally, this is not really compatible with xdist!!!
-run_all_tests = int(os.environ.get("RUN_ALL_TESTS", "0")) == 1
-
-
 def test_simple():
     if not run_all_tests:
         return
@@ -95,6 +100,7 @@ def test_simple():
         .get_or_raise()
     )
     run_cluster(job, 12000, 1)
+    sleep(1) # improves stability
 
 
 def get_job() -> JobInstance:
@@ -140,6 +146,7 @@ def test_para2():
         return
     job = get_job()
     run_cluster(job, 12200, 2)
+    sleep(1) # improves stability
 
 
 def test_para4():
@@ -147,6 +154,7 @@ def test_para4():
         return
     job = get_job()
     run_cluster(job, 12400, 4)
+    sleep(1) # improves stability
 
 
 def test_fusing():
@@ -183,3 +191,4 @@ def test_fusing():
     ]
     # TODO we currently dont check that those actually *got fused* -- fix
     run_cluster(job, 12600, 2, preschedule)
+    sleep(1) # improves stability

--- a/tests/cascade/controller/test_run.py
+++ b/tests/cascade/controller/test_run.py
@@ -15,7 +15,6 @@
 # with xdist etc
 
 
-
 import os
 from logging.config import dictConfig
 from multiprocessing import Process
@@ -35,6 +34,7 @@ from cascade.scheduler.precompute import precompute
 # see the comment above
 run_all_tests = int(os.environ.get("RUN_ALL_TESTS", "0")) == 1
 
+
 def _payload(a: int, b: int) -> int:
     return a + b
 
@@ -47,7 +47,14 @@ def launch_executor(
 ):
     dictConfig(logging_config)
     executor = Executor(
-        job_instance, controller_address, 2, f"test_executor{i}", portBase
+        job_instance,
+        controller_address,
+        2,
+        f"test_executor{i}",
+        portBase,
+        None,
+        None,
+        "tcp://localhost",
     )
     executor.register()
     executor.recv_loop()
@@ -100,7 +107,7 @@ def test_simple():
         .get_or_raise()
     )
     run_cluster(job, 12000, 1)
-    sleep(1) # improves stability
+    sleep(1)  # improves stability
 
 
 def get_job() -> JobInstance:
@@ -146,7 +153,7 @@ def test_para2():
         return
     job = get_job()
     run_cluster(job, 12200, 2)
-    sleep(1) # improves stability
+    sleep(1)  # improves stability
 
 
 def test_para4():
@@ -154,7 +161,7 @@ def test_para4():
         return
     job = get_job()
     run_cluster(job, 12400, 4)
-    sleep(1) # improves stability
+    sleep(1)  # improves stability
 
 
 def test_fusing():
@@ -191,4 +198,4 @@ def test_fusing():
     ]
     # TODO we currently dont check that those actually *got fused* -- fix
     run_cluster(job, 12600, 2, preschedule)
-    sleep(1) # improves stability
+    sleep(1)  # improves stability

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -52,7 +52,16 @@ def launch_executor(
     job_instance: JobInstance, controller_address: BackboneAddress, portBase: int
 ):
     dictConfig(logging_config)
-    executor = Executor(job_instance, controller_address, 4, "test_executor", portBase)
+    executor = Executor(
+        job_instance,
+        controller_address,
+        4,
+        "test_executor",
+        portBase,
+        None,
+        None,
+        "tcp://localhost",
+    )
     executor.register()
     executor.recv_loop()
 
@@ -114,6 +123,7 @@ def test_executor():
                 )
                 for i in range(4)
             ],
+            url_base="tcp://localhost",
         )
         assert len(ms) >= 1
         for m in ms:
@@ -123,7 +133,10 @@ def test_executor():
         # submit graph
         w0 = WorkerId("test_executor", "w0")
         callback(
-            m1, TaskSequence(worker=w0, tasks=["source", "sink"], publish={sink_o})
+            m1,
+            TaskSequence(
+                worker=w0, tasks=["source", "sink"], publish={sink_o}, extra_env={}
+            ),
         )
         # NOTE we need to expect source_o dataset too, because of no finegraining for host-wide and worker-only
         expected = {
@@ -177,7 +190,9 @@ def test_executor():
             for m in ms:
                 logger.debug(f"about to remove received message {m}")
                 expected.remove(m)
-        callback(m1, TaskSequence(worker=w0, tasks=["sink"], publish={sink_o}))
+        callback(
+            m1, TaskSequence(worker=w0, tasks=["sink"], publish={sink_o}, extra_env={})
+        )
         expected = [
             DatasetPublished(w0, ds=sink_o, transmit_idx=None),
         ]

--- a/tests/cascade/executor/test_runner.py
+++ b/tests/cascade/executor/test_runner.py
@@ -80,6 +80,7 @@ def test_runner(monkeypatch):
         worker=worker,
         tasks=[],
         publish=set(),
+        extra_env={},
     )
     emptyRc = entrypoint.RunnerContext(
         workerId=worker,
@@ -113,6 +114,7 @@ def test_runner(monkeypatch):
         worker=worker,
         tasks=["t2"],
         publish={t2ds},
+        extra_env={},
     )
     oneTaskJob = JobInstance(tasks={"t2": t2}, edges=[])
     oneTaskRc = entrypoint.RunnerContext(
@@ -148,6 +150,7 @@ def test_runner(monkeypatch):
         worker=worker,
         tasks=["t3a", "t3b"],
         publish={t3o},
+        extra_env={},
     )
     twoTaskJob = JobInstance(
         tasks={"t3a": t3a, "t3b": t3b},
@@ -208,6 +211,7 @@ def test_runner(monkeypatch):
         worker=worker,
         tasks=["t4g"] + [f"t4c{i}" for i in range(N)],
         publish=set(t4pOutputs),
+        extra_env={},
     )
     t4Job = JobInstance(
         tasks={**{"t4g": t4g}, **{f"t4c{i}": t4c for i in range(N)}},

--- a/tests/cascade/scheduler/test_api.py
+++ b/tests/cascade/scheduler/test_api.py
@@ -37,6 +37,7 @@ def test_job0():
             tasks=["source"],
             prep=[],
             outputs={DatasetId(task="source", output="0")},
+            extra_env={},
         )
     ]
 
@@ -61,6 +62,7 @@ def test_job1():
             tasks=["source"],
             prep=[],
             outputs={DatasetId(task="source", output="0")},
+            extra_env={},
         )
     ]
 

--- a/tests/cascade/scheduler/test_graph.py
+++ b/tests/cascade/scheduler/test_graph.py
@@ -64,7 +64,7 @@ def test_enrich():
     edge_i = _oedge2iedge(edge_o)
     component = (list(set(edge_o.keys()).union(set(edge_i.keys()))), ["v0", "v3", "v4"])
 
-    res = _enrich(component, edge_i, edge_o, set())
+    res = _enrich(component, edge_i, edge_o, set(), set())
 
     assert res.nodes == component[0]
     assert res.sources == component[1]

--- a/tests/cascade/scheduler/util.py
+++ b/tests/cascade/scheduler/util.py
@@ -159,5 +159,6 @@ def get_env(hosts: int, workers_per_host: int) -> Environment:
             WorkerId(f"h{h}", f"w{w}"): Worker(cpu=1, gpu=0, memory_mb=1000)
             for h in range(hosts)
             for w in range(workers_per_host)
-        }
+        },
+        host_url_base={f"h{h}": "tcp://localhost" for h in range(hosts)},
     )


### PR DESCRIPTION
Implements basic gang scheduling, ie, the ability to constraint the scheduler that a given set of DAG nodes (a gang) must be executed exactly at the same time, in a way that allows for mutual communication

We include a benchmark job that demonstrates the above by having a gang utilizing torch.distributed to exchange a message

The scheduling implementation is minimalistic -- we extend the current heuristic to check as the very first thing "is there a schedulable gang" and if so do it at any cost. This assumes there won't be too many gangs, and that they will be the heaviest jobs.

Should be compatible with gpu requirements. Exclusive with fusing -- gangs cannot be fused nor initiate any fusing themselves, to keep it simpler.

Job declaration API is miminamlistic as well -- user specifies, at the JobInstance level, lists of TaskIds that form gangs.