### PR TITLE
[cascade.low] basic dask convertor

### DIFF
--- a/src/cascade/benchmarks/dask.py
+++ b/src/cascade/benchmarks/dask.py
@@ -1,0 +1,33 @@
+import dask.dataframe as dd
+from dask._task_spec import convert_legacy_graph
+
+from cascade.low.core import JobInstance
+from cascade.low.dask import graph2job
+
+
+def get_job(job: str) -> JobInstance:
+
+    if job == "add":
+
+        def add(x, y):
+            result = x + y
+            print(f"da {result=}")
+            return result
+
+        dl = {"a": 1, "b": 2, "c": (add, "a", "b")}
+        dn = convert_legacy_graph(dl)
+        job = graph2job(dn)
+        job.ext_outputs = [
+            dataset for task in job.tasks for dataset in job.outputs_of(task)
+        ]
+        return job
+    elif job == "groupby":
+        df = dd.DataFrame.from_dict({"x": [0, 0, 1, 1], "y": [1, 2, 3, 4]})
+        df = df.groupby("x").sum()
+        job = graph2job(df.__dask_graph__())
+        job.ext_outputs = [
+            dataset for task in job.tasks for dataset in job.outputs_of(task)
+        ]
+        return job
+    else:
+        raise NotImplementedError(job)

--- a/src/cascade/benchmarks/util.py
+++ b/src/cascade/benchmarks/util.py
@@ -71,6 +71,10 @@ def get_job(benchmark: str | None, instance_path: str | None) -> JobInstance:
             import cascade.benchmarks.dist as dist
 
             return dist.get_job()
+        elif benchmark.startswith("dask"):
+            import cascade.benchmarks.dask as dask
+
+            return dask.get_job(benchmark[len("dask.") :])
         else:
             raise NotImplementedError(benchmark)
     else:
@@ -156,7 +160,7 @@ def run_locally(
     portBase: int = 12345,
     log_base: str | None = None,
     report_address: str | None = None,
-):
+) -> None:
     if log_base is not None:
         log_path = f"{log_base}.controller.txt"
         logging.config.dictConfig(logging_config_filehandler(log_path))
@@ -205,11 +209,14 @@ def run_locally(
         logger.debug("starting bridge")
         b = Bridge(c, hosts)
         start = perf_counter_ns()
-        run(job, b, preschedule, report_address=report_address)
+        result = run(job, b, preschedule, report_address=report_address)
         end = perf_counter_ns()
         print(
             f"compute took {(end-start)/1e9:.3f}s, including startup {(end-launch)/1e9:.3f}s"
         )
+        if os.environ.get("CASCADE_DEBUG_PRINT"):
+            for key, value in result.outputs.items():
+                print(f"{key} => {value}")
     except Exception:
         # NOTE we log this to get the stacktrace into the logfile
         logger.exception("controller failure, proceed with executor shutdown")

--- a/src/cascade/low/dask.py
+++ b/src/cascade/low/dask.py
@@ -1,0 +1,99 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Experimental module to convert dask graphs into cascade jobs. May not preserve
+all semantics.
+
+We don't explicitly support legacy dask graph -- you need to invoke
+`dask._task_spec.convert_legacy_graph` yourself.
+For higher level dask objects, extract the graph via `__dask_graph__()` (defined
+eg on dd.DataFrame or dask.delayed objects).
+"""
+
+import logging
+from typing import Any
+
+from dask._task_spec import Alias, DataNode, Task, TaskRef
+
+from cascade.low.builders import TaskBuilder
+from cascade.low.core import DatasetId, JobInstance, Task2TaskEdge, TaskInstance
+from earthkit.workflows.graph import Node
+
+logger = logging.getLogger(__name__)
+
+
+def daskKeyRepr(key: str | int | float | tuple) -> str:
+    return repr(key)
+
+
+def task2task(key: str, task: Task) -> tuple[TaskInstance, list[Task2TaskEdge]]:
+    instance = TaskBuilder.from_callable(task.func)
+    edges: list[Task2TaskEdge] = []
+
+    for i, v in enumerate(task.args):
+        if isinstance(v, Alias | TaskRef):
+            edge = Task2TaskEdge(
+                source=DatasetId(task=daskKeyRepr(v.key), output=Node.DEFAULT_OUTPUT),
+                sink_task=key,
+                sink_input_ps=str(i),
+                sink_input_kw=None,
+            )
+            edges.append(edge)
+        elif isinstance(v, Task):
+            # TODO
+            raise NotImplementedError
+        else:
+            instance.static_input_ps[f"{i}"] = v
+    for k, v in task.kwargs.items():
+        if isinstance(v, Alias | TaskRef):
+            edge = Task2TaskEdge(
+                source=DatasetId(task=daskKeyRepr(v.key), output=Node.DEFAULT_OUTPUT),
+                sink_task=key,
+                sink_input_kw=k,
+                sink_input_ps=None,
+            )
+            edges.append(edge)
+        elif isinstance(v, Task):
+            # TODO
+            raise NotImplementedError
+        else:
+            instance.static_input_kw[k] = v
+
+    return instance, edges
+
+
+def graph2job(dask: dict) -> JobInstance:
+    task_nodes = {}
+    edges = []
+
+    for node, value in dask.items():
+        key = daskKeyRepr(node)
+        if isinstance(value, DataNode):
+
+            def provider() -> Any:
+                return value.value
+
+            task_nodes[key] = TaskBuilder.from_callable(provider)
+        elif isinstance(value, Task):
+            node, _edges = task2task(key, value)
+            task_nodes[key] = node
+            edges.extend(_edges)
+        elif isinstance(value, list | tuple | set):
+            # TODO implement, consult further:
+            # https://docs.dask.org/en/stable/spec.html
+            # https://docs.dask.org/en/stable/custom-graphs.html
+            # https://github.com/dask/dask/blob/main/dask/_task_spec.py#L829
+            logger.warning("encountered nested container => confused ostrich")
+            continue
+        else:
+            raise NotImplementedError
+
+    return JobInstance(
+        tasks=task_nodes,
+        edges=edges,
+    )

--- a/src/cascade/low/into.py
+++ b/src/cascade/low/into.py
@@ -6,7 +6,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Lowering of the cascade.graph structures into cascade.low representation"""
+"""Lowering of the earthkit.workflows.graph structures into cascade.low representation"""
 
 import logging
 from typing import Any, Callable, cast


### PR DESCRIPTION
basic dask convertor + benchmark example to demonstrate

we support both explicit dask graphs as well as high level objects like dask.DataFrame computations

unlike previous implementation of this thing, we use the "new" dask graphs, not the legacy dask graphs