### PR TITLE
[cascade.executor] robust fqdn wrt macos

### DIFF
--- a/src/cascade/benchmarks/__main__.py
+++ b/src/cascade/benchmarks/__main__.py
@@ -28,12 +28,12 @@ import os
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from socket import getfqdn
 from time import perf_counter_ns
 
 import fire
 import orjson
 
+import cascade.executor.platform as platform
 import cascade.low.into
 from cascade.controller.impl import run
 from cascade.executor.bridge import Bridge
@@ -295,7 +295,7 @@ def main_dist(
             idx,
             shm_vol_gb,
             gpu_count,
-            f"tcp://{getfqdn()}",
+            f"tcp://{platform.get_bindabble_self()}",
         )
 
 

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -18,11 +18,11 @@ the tasks themselves.
 import atexit
 import logging
 import os
-import socket
 from multiprocessing import get_context
 from multiprocessing.process import BaseProcess
 from typing import Iterable
 
+import cascade.executor.platform as platform
 import cascade.shm.api as shm_api
 import cascade.shm.client as shm_client
 from cascade.executor.comms import GraceWatcher, Listener, ReliableSender, callback
@@ -58,7 +58,7 @@ heartbeat_grace_ms = 2 * comms_default_timeout_ms
 
 
 def address_of(port: int) -> BackboneAddress:
-    return f"tcp://{socket.gethostname()}:{port}"
+    return f"tcp://{platform.get_bindabble_self()}:{port}"
 
 
 class Executor:

--- a/src/cascade/executor/platform.py
+++ b/src/cascade/executor/platform.py
@@ -1,0 +1,24 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Macos-vs-Linux specific code"""
+
+import socket
+import sys
+
+
+def get_bindabble_self():
+    """Returns a hostname such that zmq can bind to it"""
+
+    if sys.platform == "darwin":
+        # NOTE on macos, getfqdn usually returns like '66246.local', which can't then be bound to
+        # This is a stopper for running a cluster of macos devices -- but we don't plan that yet
+        return "localhost"
+    else:
+        # NOTE not sure if fqdn or hostname is better -- all we need is for it to be resolvable within cluster
+        return socket.gethostname()  # socket.getfqdn()

--- a/src/cascade/gateway/router.py
+++ b/src/cascade/gateway/router.py
@@ -14,12 +14,12 @@ import os
 import subprocess
 import uuid
 from dataclasses import dataclass
-from socket import getfqdn
 from typing import Iterable
 
 import orjson
 import zmq
 
+import cascade.executor.platform as platform
 from cascade.controller.report import JobId, JobProgress, JobProgressStarted
 from cascade.executor.comms import get_context
 from cascade.gateway.api import JobSpec
@@ -131,11 +131,7 @@ class JobRouter:
 
     def spawn_job(self, job_spec: JobSpec) -> JobId:
         job_id = next_uuid(self.jobs.keys(), lambda: str(uuid.uuid4()))
-        if job_spec.use_slurm:
-            base_addr = f"tcp://{getfqdn()}"
-        else:
-            # NOTE on macos, it seems getfqdn does not give zmq-bindable addr
-            base_addr = "tcp://localhost"
+        base_addr = f"tcp://{platform.get_bindabble_self()}"
         socket = get_context().socket(zmq.PULL)
         port = socket.bind_to_random_port(base_addr)
         full_addr = f"{base_addr}:{port}"

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -11,12 +11,12 @@ get sent out. In essence, we build a pseudo-controller in this test.
 """
 
 import logging
-import socket
 from logging.config import dictConfig
 from multiprocessing import Process
 
 import numpy as np
 
+import cascade.executor.platform as platform
 import cascade.executor.serde as serde
 from cascade.executor.comms import Listener, callback, send_data
 from cascade.executor.config import logging_config
@@ -100,8 +100,8 @@ def test_executor():
 
     # cluster setup
     c1 = "tcp://localhost:12545"
-    m1 = f"tcp://{socket.gethostname()}:12546"
-    d1 = f"tcp://{socket.gethostname()}:12547"
+    m1 = f"tcp://{platform.get_bindabble_self()}:12546"
+    d1 = f"tcp://{platform.get_bindabble_self()}:12547"
     l = Listener(c1)  # controller
     p = Process(target=launch_executor, args=(job, c1, 12546))
 


### PR DESCRIPTION
Should address the failure discovered in https://github.com/ecmwf/forecast-in-a-box/actions/runs/16672048906/job/47190352722?pr=83. We did have one place where we used `socket.fqdn()` instead of `localhost` on macos

No idea why it is a race condition -- it should have torn down all macos runs