### PR TITLE
[cascade.executor] remove false macos gpu warning

### DIFF
--- a/src/cascade/executor/platform.py
+++ b/src/cascade/executor/platform.py
@@ -8,6 +8,7 @@
 
 """Macos-vs-Linux specific code"""
 
+import os
 import socket
 import sys
 
@@ -22,3 +23,14 @@ def get_bindabble_self():
     else:
         # NOTE not sure if fqdn or hostname is better -- all we need is for it to be resolvable within cluster
         return socket.gethostname()  # socket.getfqdn()
+
+
+def gpu_init(worker_num: int):
+    if sys.platform != "darwin":
+        # TODO there is implicit coupling with executor.executor and benchmarks.main -- make it cleaner!
+        gpus = int(os.environ.get("CASCADE_GPU_COUNT", "0"))
+        os.environ["CUDA_VISIBLE_DEVICES"] = (
+            str(worker_num) if worker_num < gpus else ""
+        )
+    else:
+        pass  # no macos specific gpu init due to unified mem model

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -11,11 +11,11 @@
 import logging
 import logging.config
 import os
-import sys
 from dataclasses import dataclass
 
 import zmq
 
+import cascade.executor.platform as platform
 import cascade.executor.serde as serde
 from cascade.executor.comms import callback
 from cascade.executor.config import logging_config, logging_config_filehandler
@@ -134,16 +134,8 @@ def entrypoint(runnerContext: RunnerContext):
     ):
         label("worker", repr(runnerContext.workerId))
         worker_num = runnerContext.workerId.worker_num()
-        gpus = int(os.environ.get("CASCADE_GPU_COUNT", "0"))
-        if sys.platform != "darwin":
-            os.environ["CUDA_VISIBLE_DEVICES"] = (
-                str(worker_num) if worker_num < gpus else ""
-            )
-            # NOTE check any(task.definition.needs_gpu) anywhere?
-            # TODO configure OMP_NUM_THREADS, blas, mkl, etc -- not clear how tho
-        else:
-            if gpus != 1:
-                logger.warning("unexpected absence of gpu on darwin")
+        platform.gpu_init(worker_num)
+        # TODO configure OMP_NUM_THREADS, blas, mkl, etc -- not clear how tho
 
         for serdeTypeEnc, (serdeSer, serdeDes) in runnerContext.job.serdes.items():
             serde.SerdeRegistry.register(type_dec(serdeTypeEnc), serdeSer, serdeDes)


### PR DESCRIPTION
refactor the gpu init code to happen in the platform module

dont warn for "unexpected gpu count on macos" -- that warning was misplaced
