### PR TITLE
[ci] add macos test action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,8 @@ jobs:
           repository: private-downstream-ci
           event_type: downstream-ci-hpc
           payload: '{"earthkit-workflows": "ecmwf/earthkit-workflows@${{ github.event.pull_request.head.sha || github.sha }}"}'
+
+# TODO enable once tested
+#  macos-pytest:
+#    uses: ./.github/workflows/macos-test.yml
+#    secrets: inherit

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -1,0 +1,28 @@
+name: macos-test
+
+on:
+  # Trigger the workflow manually
+  workflow_dispatch: ~
+
+  # Call from other workflows
+  workflow_call: ~
+
+jobs:
+  macos-pytest:
+    strategy:
+      fail-fast: true
+      matrix:
+        arch_type: [ARM64] # [ARM64, X64]
+        python_version: ["3.11"] # ["3.10", "3.11", "3.12", "3.13"]
+    runs-on: [self-hosted, macOS, "${{ matrix.arch_type }}"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: 0.7.19
+      - run: |
+          uv pip install '.[tests]'
+          pytest


### PR DESCRIPTION
Seems to me EKW releases were happening without running a pytest on a mac -- those are done later in fiab, but thats too late

Adding an action to facilitate and merging right away so that I can run & troubleshoot. Later PR will enable it in the `ci.yml`, I'll await an approval for that one and include any change requests; cc @HCookie 