### PR TITLE
[cascade.executor] make mp ctx platform dependent

### DIFF
--- a/src/cascade/benchmarks/util.py
+++ b/src/cascade/benchmarks/util.py
@@ -12,7 +12,6 @@
 
 import logging
 import logging.config
-import multiprocessing
 import os
 import subprocess
 import sys
@@ -177,7 +176,7 @@ def run_locally(
             gpu_count = get_gpu_count(i, workers)
             # NOTE forkserver/spawn seem to forget venv, we need fork
             logger.debug(f"forking into executor on host {i}")
-            p = multiprocessing.get_context("fork").Process(
+            p = platform.get_mp_ctx("executor-loc").Process(
                 target=launch_executor,
                 args=(
                     job,

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -18,7 +18,6 @@ the tasks themselves.
 import atexit
 import logging
 import os
-from multiprocessing import get_context
 from multiprocessing.process import BaseProcess
 from typing import Iterable
 
@@ -97,12 +96,12 @@ class Executor:
         # TODO make the shm server params configurable
         shm_port = portBase + 2
         shm_api.publish_client_port(shm_port)
-        ctx = get_context("fork")
+        ctx = platform.get_mp_ctx("executor-aux")
         if log_base:
             shm_logging = logging_config_filehandler(f"{log_base}.shm.txt")
         else:
             shm_logging = logging_config
-        logger.debug("about to fork into shm process")
+        logger.debug("about to start an shm process")
         self.shm_process = ctx.Process(
             target=shm_server,
             args=(
@@ -118,7 +117,7 @@ class Executor:
             dsr_logging = logging_config_filehandler(f"{log_base}.dsr.txt")
         else:
             dsr_logging = logging_config
-        logger.debug("about to fork into data server")
+        logger.debug("about to start a data server process")
         self.data_server = ctx.Process(
             target=start_data_server,
             args=(
@@ -190,7 +189,7 @@ class Executor:
     def start_workers(self, workers: Iterable[WorkerId]) -> None:
         # TODO this method assumes no other message will arrive to mlistener! Thus cannot be used for workers now
         # NOTE fork would be better but causes issues on macos+torch with XPC_ERROR_CONNECTION_INVALID
-        ctx = get_context("forkserver")
+        ctx = platform.get_mp_ctx("worker")
         for worker in workers:
             runnerContext = RunnerContext(
                 workerId=worker,

--- a/src/cascade/executor/platform.py
+++ b/src/cascade/executor/platform.py
@@ -8,9 +8,11 @@
 
 """Macos-vs-Linux specific code"""
 
+import multiprocessing as mp
 import os
 import socket
 import sys
+import typing
 
 
 def get_bindabble_self():
@@ -34,3 +36,28 @@ def gpu_init(worker_num: int):
         )
     else:
         pass  # no macos specific gpu init due to unified mem model
+
+
+MpSituation = typing.Literal[
+    "worker", "executor-loc", "executor-aux", "gateway", "other"
+]
+_MpSituation = typing.get_args(MpSituation)
+
+
+def get_mp_ctx(situation: MpSituation) -> mp.context.BaseContext:
+    """Generally, forking is safe everywhere as we try to be careful not to
+    initialize non-safe objects prior to forking. However, combination of
+    mac + mps + anemoi + pickled callables causes xpc_error_connection_invalid,
+    thus we stick to spawn on darwin platforms. Setting
+    OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES helps some but not fully.
+
+    We distinguish in which situation is this method called, as fine graining
+    may be (eventually) possible
+    """
+
+    if situation not in _MpSituation:
+        raise TypeError(f"{situation=} is not in {_MpSituation}")
+    if sys.platform == "darwin":
+        return mp.get_context("spawn")
+    else:
+        return mp.get_context("fork")


### PR DESCRIPTION
due to prevailing issues on macos, I'm bruting all mp context to spawn there. A bit robustly -- all mp ctx obtaining is now centralized in the platform module, and we can control for each platform/situation combination how we are going to create processes

tested with regular pytest + manual macos bigtest and linux bigtest