### PR TITLE
[cascade.gateway] add max jobs optional param

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     -   id: python-check-blanket-noqa # Check for # noqa: all
     -   id: python-no-log-warn # Check for log.warn
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 24.8.0
+  rev: 25.1.0
   hooks:
   - id: black
     # args: [--line-length=120]

--- a/src/cascade/controller/report.py
+++ b/src/cascade/controller/report.py
@@ -27,6 +27,7 @@ JobId = str
 
 @dataclass
 class JobProgress:
+    started: bool
     completed: bool
     pct: (
         str | None
@@ -35,19 +36,20 @@ class JobProgress:
 
     @classmethod
     def failed(cls, failure: str) -> Self:
-        return cls(True, None, failure)
+        return cls(True, True, None, failure)
 
     @classmethod
     def progressed(cls, pct: float) -> Self:
         progress = "{:.2%}".format(pct)[:-1]
-        return cls(False, progress, None)
+        return cls(True, False, progress, None)
 
     @classmethod
     def succeeded(cls) -> Self:
-        return cls(True, None, None)
+        return cls(True, True, None, None)
 
 
-JobProgressStarted = JobProgress(False, "0.00", None)
+JobProgressStarted = JobProgress(True, False, "0.00", None)
+JobProgressEnqueued = JobProgress(False, False, None, None)
 
 
 @dataclass

--- a/src/cascade/gateway/__main__.py
+++ b/src/cascade/gateway/__main__.py
@@ -15,14 +15,17 @@ from cascade.gateway.server import serve
 
 
 def main(
-    url: str, log_base: str | None = None, troika_config: str | None = None
+    url: str,
+    log_base: str | None = None,
+    troika_config: str | None = None,
+    max_jobs: int | None = None,
 ) -> None:
     if log_base:
         log_path = f"{log_base}/gateway.txt"
         logging.config.dictConfig(logging_config_filehandler(log_path))
     else:
         logging.config.dictConfig(logging_config)
-    serve(url, log_base, troika_config)
+    serve(url, log_base, troika_config, max_jobs)
 
 
 if __name__ == "__main__":

--- a/src/cascade/gateway/api.py
+++ b/src/cascade/gateway/api.py
@@ -62,8 +62,9 @@ class JobProgressRequest(CascadeGatewayAPI):
 
 
 class JobProgressResponse(CascadeGatewayAPI):
-    progresses: dict[JobId, JobProgress]
+    progresses: dict[JobId, JobProgress | None]
     datasets: dict[JobId, list[DatasetId]]
+    queue_length: int
     error: str | None  # top level error
 
 

--- a/src/cascade/gateway/router.py
+++ b/src/cascade/gateway/router.py
@@ -15,6 +15,7 @@ import os
 import stat
 import subprocess
 import uuid
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Iterable
 
@@ -22,7 +23,12 @@ import orjson
 import zmq
 
 import cascade.executor.platform as platform
-from cascade.controller.report import JobId, JobProgress, JobProgressStarted
+from cascade.controller.report import (
+    JobId,
+    JobProgress,
+    JobProgressEnqueued,
+    JobProgressStarted,
+)
 from cascade.executor.comms import get_context
 from cascade.gateway.api import JobSpec, TroikaSpec
 from cascade.low.core import DatasetId
@@ -202,16 +208,29 @@ def _spawn_subprocess(
 
 class JobRouter:
     def __init__(
-        self, poller: zmq.Poller, log_base: str | None, troika_config: str | None
+        self,
+        poller: zmq.Poller,
+        log_base: str | None,
+        troika_config: str | None,
+        max_jobs: int | None,
     ):
         self.poller = poller
         self.jobs: dict[str, Job] = {}
+        self.active_jobs = 0
+        self.max_jobs = max_jobs
+        self.jobs_queue: OrderedDict[JobId, JobSpec] = OrderedDict()
         self.procs: dict[str, subprocess.Popen] = {}
         self.log_base = log_base
         self.troika_config = troika_config
 
-    def spawn_job(self, job_spec: JobSpec) -> JobId:
-        job_id = next_uuid(self.jobs.keys(), lambda: str(uuid.uuid4()))
+    def maybe_spawn(self) -> None:
+        if not self.jobs_queue:
+            return
+        if self.max_jobs is not None and self.active_jobs >= self.max_jobs:
+            logger.debug(f"already running {self.active_jobs}, no spawn")
+            return
+
+        job_id, job_spec = self.jobs_queue.popitem(False)
         base_addr = f"tcp://{platform.get_bindabble_self()}"
         socket = get_context().socket(zmq.PULL)
         port = socket.bind_to_random_port(base_addr)
@@ -222,18 +241,37 @@ class JobRouter:
         self.procs[job_id] = _spawn_subprocess(
             job_spec, full_addr, job_id, self.log_base, self.troika_config
         )
+        self.active_jobs += 1
+        return job_id
+
+    def enqueue_job(self, job_spec: JobSpec) -> JobId:
+        job_id = next_uuid(
+            set(self.jobs.keys()).union(self.jobs_queue.keys()),
+            lambda: str(uuid.uuid4()),
+        )
+        self.jobs_queue[job_id] = job_spec
+        self.maybe_spawn()
         return job_id
 
     def progress_of(
         self, job_ids: Iterable[JobId]
-    ) -> tuple[dict[JobId, JobProgress], dict[JobId, list[DatasetId]]]:
+    ) -> tuple[dict[JobId, JobProgress], dict[JobId, list[DatasetId]], int]:
         if not job_ids:
-            job_ids = self.jobs.keys()
-        progresses = {job_id: self.jobs[job_id].progress for job_id in job_ids}
+            job_ids = set(self.jobs.keys()).union(self.jobs_queue.keys())
+        progresses = {}
+        for job_id in job_ids:
+            if job_id in self.jobs:
+                progresses[job_id] = self.jobs[job_id].progress
+            elif job_id in self.jobs_queue:
+                progresses[job_id] = JobProgressEnqueued
+            else:
+                progresses[job_id] = None
         datasets = {
-            job_id: list(self.jobs[job_id].results.keys()) for job_id in job_ids
+            job_id: list(self.jobs[job_id].results.keys())
+            for job_id in job_ids
+            if job_id in self.jobs
         }
-        return progresses, datasets
+        return progresses, datasets, len(self.jobs_queue)
 
     def get_result(self, job_id: JobId, dataset_id: DatasetId) -> bytes:
         return self.jobs[job_id].results[dataset_id]
@@ -246,6 +284,8 @@ class JobRouter:
         job = self.jobs[job_id]
         if progress.completed:
             self.poller.unregister(job.socket)
+            self.active_jobs -= 1
+            self.maybe_spawn()
         if progress.failure is not None and job.progress.failure is None:
             job.progress = progress
         elif job.last_seen >= timestamp or job.progress.failure is not None:

--- a/src/cascade/gateway/server.py
+++ b/src/cascade/gateway/server.py
@@ -31,16 +31,19 @@ def handle_fe(socket: zmq.Socket, jobs: JobRouter) -> bool:
     rv: api.CascadeGatewayAPI
     if isinstance(m, api.SubmitJobRequest):
         try:
-            job_id = jobs.spawn_job(m.job)
+            job_id = jobs.enqueue_job(m.job)
             rv = api.SubmitJobResponse(job_id=job_id, error=None)
         except Exception as e:
             logger.exception(f"failed to spawn a job: {m}")
             rv = api.SubmitJobResponse(job_id=None, error=repr(e))
     elif isinstance(m, api.JobProgressRequest):
         try:
-            progresses, datasets = jobs.progress_of(m.job_ids)
+            progresses, datasets, queue_length = jobs.progress_of(m.job_ids)
             rv = api.JobProgressResponse(
-                progresses=progresses, datasets=datasets, error=None
+                progresses=progresses,
+                datasets=datasets,
+                error=None,
+                queue_length=queue_length,
             )
         except Exception as e:
             logger.exception(f"failed to get progress of: {m}")
@@ -80,7 +83,10 @@ def handle_controller(socket: zmq.Socket, jobs: JobRouter) -> None:
 
 
 def serve(
-    url: str, log_base: str | None = None, troika_config: str | None = None
+    url: str,
+    log_base: str | None = None,
+    troika_config: str | None = None,
+    max_jobs: int | None = None,
 ) -> None:
     ctx = get_context()
     poller = zmq.Poller()
@@ -88,7 +94,7 @@ def serve(
     fe = ctx.socket(zmq.REP)
     fe.bind(url)
     poller.register(fe, flags=zmq.POLLIN)
-    jobs = JobRouter(poller, log_base, troika_config)
+    jobs = JobRouter(poller, log_base, troika_config, max_jobs)
 
     logger.debug("entering recv loop")
     is_break = False

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -9,6 +9,7 @@ from cascade.low.core import DatasetId, JobInstance, TaskDefinition, TaskInstanc
 
 init_value = 10
 job_func = lambda i: i * 2
+slow_func = lambda a: time.sleep(0.5) or a**2
 
 
 def get_job_succ() -> JobInstance:
@@ -52,15 +53,26 @@ def get_job_fail() -> JobInstance:
     return ji
 
 
-def spawn_gateway() -> tuple[str, Process]:
+def get_job_slow() -> JobInstance:
+    td = TaskDefinition(
+        func=TaskDefinition.func_enc(slow_func),
+        environment=[],
+        input_schema={"a": "int"},
+        output_schema=[("o", "int")],
+    )
+    ti = TaskInstance(definition=td, static_input_kw={"a": 4}, static_input_ps={})
+    return JobBuilder().with_node("t", ti).build().get_or_raise()
+
+
+def spawn_gateway(max_jobs: int | None = None) -> tuple[str, Process]:
     url = "tcp://localhost:12355"
-    p = Process(target=main, args=(url,))
+    p = Process(target=main, args=(url,), kwargs={"max_jobs": max_jobs})
     p.start()
     return url, p
 
 
 def test_job():
-    url, gw = spawn_gateway()
+    url, gw = spawn_gateway(1)
     try:
         # succ job
         ji = get_job_succ()
@@ -136,6 +148,45 @@ def test_job():
             if job_progress_res.progresses[job_id].failure is not None:
                 break
             else:
+                tries -= 1
+                time.sleep(1)
+        assert tries > 0
+
+        # two jobs at once
+        # TODO this is for manual test only, I dont have a good idea how to test, in a reliable & timely fashion,
+        # that the execution has in effect been serial. But just running it and checking for success is still worth
+        ji = get_job_slow()
+        js = api.JobSpec(
+            benchmark_name=None,
+            envvars={},
+            job_instance=ji,
+            workers_per_host=1,
+            hosts=1,
+            use_slurm=False,
+        )
+
+        req = api.SubmitJobRequest(job=js)
+        res1 = client.request_response(req, url)
+        res2 = client.request_response(req, url)
+        assert res1.error is None
+        assert res2.error is None
+        assert res1.job_id is not None
+        assert res2.job_id is not None
+
+        tries = 16
+        job_ids = [res1.job_id, res2.job_id]
+        job_progress_req = api.JobProgressRequest(job_ids=job_ids)
+        while tries > 0:
+            job_progress_res = client.request_response(job_progress_req, url)
+            assert job_progress_res.error is None
+            is_computed = (
+                lambda job_id: job_progress_res.progresses[job_id].pct == "100.00"
+            )
+            if all(is_computed(job_id) for job_id in job_ids):
+                break
+            else:
+                # NOTE not using logger, not properly configured in downstream-ci
+                print(f"current progress is {job_progress_res}")
                 tries -= 1
                 time.sleep(1)
         assert tries > 0


### PR DESCRIPTION
to limit overuse in case of a multitenant single host local deployments, we add a queue and conditional job starts

effective change is that the JobProgressResponse api message of gateway now additionally has `queue_length` top level item for the number of _waiting_ jobs, and each individual JobProgress has `started` bool element which tells whether it has already been spawned or is still in the queue

number of max jobs is configurable, default to None (ie no limit)

there is no queue length, liveness checking, cleanup, backpressure, etc -- won't really scale in a presence of a high load or downstream issues

first part of https://github.com/ecmwf/forecast-in-a-box/issues/115

the second part will expose the new data in the forecastbox backend API as well as set the max jobs param of gateway to 1 by default (when launched from fiab)