### PR TITLE
[cascade.shm] Shm basic benchmarks + socket option

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,7 @@
+At the moment just an adhoc collection of scripts, utils and scenarios.
+
+# Scenario: SHM Throughput
+It seems that `AF_UNIX` + `SOCK_STREAM` and `AF_INET` + `SOCK_DGRAM` are, performance-wise, indistinguishable at the `shm` scale.
+That leads us to prefer the former, because:
+ - `SOCK_STREAM` is more reliable in general (though should not be noticeable in the localhost case),
+ - it is easier to pick a random file name than a random *non-occupied* port number, and it's easier to free it after usage.

--- a/benchmarks/scenario-shm_throughput.py
+++ b/benchmarks/scenario-shm_throughput.py
@@ -1,0 +1,114 @@
+"""Benchmark shm in isolation (without cascade) by just invoking a lot of reads and writes in a limited memory setting"""
+
+import multiprocessing as mp
+import random
+import sys
+from time import perf_counter_ns
+
+import numpy as np
+
+import cascade.shm.client as c
+from cascade.executor.config import logging_config_filehandler
+from cascade.shm.api import publish_socket_addr
+from cascade.shm.server import entrypoint
+
+# addr = 12345 + random.randint(0, 1000) # due to freeing of port taking time
+addr = "/tmp/comm"
+publish_socket_addr(addr)
+
+
+class Context:
+    shm_process: mp.process.BaseProcess  # cls var
+    steps: list[tuple[(str, int)]] = []
+
+    @classmethod
+    def track(cls, label: str):
+        cls.steps.append((label, perf_counter_ns()))
+
+    @classmethod
+    def report(cls):
+        rpt = (
+            lambda t1, t2: f"from {t1[0]} to {t2[0]} took {(t2[1]-t1[1]) / 1e6:.3f} ms"
+        )
+        print(rpt(cls.steps[0], cls.steps[-1]))
+        for i in range(len(cls.steps) - 1):
+            print(rpt(cls.steps[i], cls.steps[i + 1]))
+
+
+def start_shm(capacity_mb: int):
+    capacity = capacity_mb * 1024**2
+    logging_config = logging_config_filehandler("/tmp/shmlog.txt")
+    Context.shm_process = mp.get_context("fork").Process(
+        target=entrypoint,
+        kwargs={"capacity": capacity, "logging_config": logging_config},
+    )
+    Context.shm_process.start()
+
+
+def shutdown():
+    p = Context.shm_process
+    if p is None:
+        return
+    if p.is_alive():
+        p.terminate()
+        p.join(1)
+    if p.is_alive():
+        p.kill()
+        p.join(1)
+    if p.is_alive():
+        print("SHM process failed to terminate in time!")
+
+
+def scenario1():
+    """Start 128MB shm, allocate 8 * 32MB (so half should get paged out), then access them in sequence
+    This should incurr 4 pageouts on write, and then 4+ pageins and 4 pageouts on read.
+    """
+    start_shm(128)
+    c.ensure()
+
+    L = 32 * 1024**2
+    Z = np.zeros(L, dtype=np.int8).tobytes()
+    Context.track("start")
+    for i in range(8):
+        buf = c.allocate(f"k{i}", L, "whatever")
+        buf.view()[:L] = Z
+        buf.close()
+        Context.track(f"alloc{i}")
+    for i in range(8):
+        buf = c.get(f"k{i}")
+        buf.view()
+        buf.close()
+        Context.track(f"get{i}")
+    Context.track("end")
+    Context.report()
+
+
+def scenario2():
+    """Start 1024MB shm, allocate 128 * 8MB (so that all fits), then 128 ** 2 gets to simulate high load"""
+    start_shm(1024)
+    c.ensure()
+
+    L = 8 * 1024**2
+    Z = np.zeros(L, dtype=np.int8).tobytes()
+    Context.track("start")
+    for i in range(128):
+        buf = c.allocate(f"k{i}", L, "whatever")
+        buf.view()[:L] = Z
+        buf.close()
+    Context.track("allocs")
+    for _ in range(128 * 4):
+        buf = c.get(f"k{random.randint(0, 127)}")
+        buf.view()
+        buf.close()
+    Context.track("end")
+    Context.report()
+
+
+if __name__ == "__main__":
+    func = globals().get(sys.argv[1], None)
+    if not func:
+        raise NotImplementedError(sys.argv[1])
+    try:
+        func()
+    finally:
+        shutdown()

--- a/src/cascade/benchmarks/tests.py
+++ b/src/cascade/benchmarks/tests.py
@@ -1,0 +1,173 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Module for simplifying writing tests
+
+Similar to util, but not enough to unify
+
+It is capable, for a single given task, to spin an shm server, put all task's inputs into it, execute the task, store outputs in memory, and retrieve the result.
+See the `demo()` function at the very end
+"""
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass
+from time import perf_counter_ns
+from typing import Any, Callable
+
+import cloudpickle
+
+import cascade.executor.platform as platform
+import cascade.shm.api as shm_api
+import cascade.shm.client as shm_client
+from cascade.executor.comms import Listener as ZmqListener
+from cascade.executor.config import logging_config
+from cascade.executor.msg import BackboneAddress, DatasetPublished
+from cascade.executor.runner.memory import Memory, ds2shmid
+from cascade.executor.runner.packages import PackagesEnv
+from cascade.executor.runner.runner import ExecutionContext, run
+from cascade.low.builders import TaskBuilder
+from cascade.low.core import DatasetId
+from cascade.shm.server import entrypoint as shm_server
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def setup_shm(testId: str):
+    mp_ctx = platform.get_mp_ctx("executor-aux")
+    shm_socket = f"/tmp/tcShm-{testId}"
+    shm_api.publish_socket_addr(shm_socket)
+    shm_process = mp_ctx.Process(
+        target=shm_server,
+        kwargs={
+            "logging_config": logging_config,
+            "shm_pref": f"tc{testId}",
+        },
+    )
+    shm_process.start()
+    shm_client.ensure()
+    try:
+        yield
+    except Exception as e:
+        # NOTE we log like this in case shm shutdown freezes
+        logger.exception(f"gotten {repr(e)}, proceed with shm shutdown")
+        raise
+    finally:
+        shm_client.shutdown(timeout_sec=1.0)
+        shm_process.join(1)
+        if shm_process.is_alive():
+            shm_process.terminate()
+            shm_process.join(1)
+        if shm_process.is_alive():
+            shm_process.kill()
+            shm_process.join(1)
+
+
+def simple_runner(callback: BackboneAddress, executionContext: ExecutionContext):
+    tasks = list(executionContext.tasks.keys())
+    if len(tasks) != 1:
+        raise ValueError(f"expected 1 task, gotten {len(tasks)}")
+    taskId = tasks[0]
+    taskInstance = executionContext.tasks[taskId]
+    with Memory(callback, "testWorker") as memory, PackagesEnv() as pckg:
+        # for key, value in taskSequence.extra_env.items():
+        #    os.environ[key] = value
+
+        pckg.extend(taskInstance.definition.environment)
+        run(taskId, executionContext, memory)
+        memory.flush()
+
+
+@dataclass
+class CallableInstance:
+    func: Callable
+    kwargs: dict[str, Any]
+    args: list[tuple[int, Any]]
+    env: list[str]
+    exp_output: Any
+
+
+def callable2ctx(
+    callableInstance: CallableInstance, callback: BackboneAddress
+) -> ExecutionContext:
+    taskInstance = TaskBuilder.from_callable(
+        callableInstance.func, callableInstance.env
+    )
+    param_source = {}
+    params = [
+        (key, DatasetId("taskId", f"kwarg.{key}"), value)
+        for key, value in callableInstance.kwargs.items()
+    ] + [
+        (key, DatasetId("taskId", f"pos.{key}"), value)
+        for key, value in callableInstance.args
+    ]
+    for key, ds_key, value in params:
+        raw = cloudpickle.dumps(value)
+        L = len(raw)
+        buf = shm_client.allocate(ds2shmid(ds_key), L, "cloudpickle.loads")
+        buf.view()[:L] = raw
+        buf.close()
+        param_source[key] = (ds_key, "Any")
+
+    return ExecutionContext(
+        tasks={"taskId": taskInstance},
+        param_source={"taskId": param_source},
+        callback=callback,
+        publish={
+            DatasetId("taskId", output)
+            for output, _ in taskInstance.definition.output_schema
+        },
+    )
+
+
+def run_test(
+    callableInstance: CallableInstance, testId: str, max_runtime_sec: int
+) -> Any:
+    with setup_shm(testId):
+        addr = f"ipc:///tmp/tc{testId}"
+        listener = ZmqListener(addr)
+        ec_ctx = callable2ctx(callableInstance, addr)
+        mp_ctx = platform.get_mp_ctx("executor-aux")
+        runner = mp_ctx.Process(target=simple_runner, args=(addr, ec_ctx))
+        runner.start()
+        output = DatasetId("taskId", "0")
+
+        end = perf_counter_ns() + max_runtime_sec * int(1e9)
+        while perf_counter_ns() < end:
+            mess = listener.recv_messages()
+            if mess == [
+                DatasetPublished(origin="testWorker", ds=output, transmit_idx=None)
+            ]:
+                break
+            elif not mess:
+                continue
+            else:
+                raise ValueError(mess)
+
+        runner.join()
+        output_buf = shm_client.get(ds2shmid(output))
+        output_des = cloudpickle.loads(output_buf.view())
+        output_buf.close()
+    assert output_des == callableInstance.exp_output
+
+
+def demo():
+    def myfunc(l: int) -> float:
+        import numpy as np
+
+        return np.arange(l).sum()
+
+    ci = CallableInstance(
+        func=myfunc, kwargs={"l": 4}, args=[], env=["numpy"], exp_output=6
+    )
+    run_test(ci, "numpyTest1", 2)
+
+
+if __name__ == "__main__":
+    demo()

--- a/src/cascade/executor/data_server.py
+++ b/src/cascade/executor/data_server.py
@@ -20,7 +20,6 @@ from concurrent.futures import Executor as PythonExecutor
 from concurrent.futures import Future, ThreadPoolExecutor, wait
 from time import time_ns
 
-import cascade.shm.api as shm_api
 import cascade.shm.client as shm_client
 from cascade.executor.comms import Listener, callback, send_data
 from cascade.executor.msg import (
@@ -48,7 +47,6 @@ class DataServer:
         maddress: BackboneAddress,
         daddress: BackboneAddress,
         host: str,
-        shm_port: int,
         logging_config: dict,
     ):
         logging.config.dictConfig(logging_config)
@@ -58,7 +56,6 @@ class DataServer:
         self.daddress = daddress
         self.dlistener = Listener(daddress)
         self.terminating = False
-        shm_api.publish_client_port(shm_port)
         self.cap = 2
         self.ds_proc_tp: PythonExecutor = ThreadPoolExecutor(max_workers=self.cap)
         self.futs_in_progress: dict[
@@ -305,8 +302,7 @@ def start_data_server(
     maddress: BackboneAddress,
     daddress: BackboneAddress,
     host: str,
-    shm_port: int,
     logging_config: dict,
 ):
-    server = DataServer(maddress, daddress, host, shm_port, logging_config)
+    server = DataServer(maddress, daddress, host, logging_config)
     server.recv_loop()

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -18,6 +18,7 @@ the tasks themselves.
 import atexit
 import logging
 import os
+import uuid
 from multiprocessing.process import BaseProcess
 from typing import Iterable
 
@@ -94,8 +95,8 @@ class Executor:
         self.sender = ReliableSender(self.mlistener.address, resend_grace_ms)
         self.sender.add_host("controller", controller_address)
         # TODO make the shm server params configurable
-        shm_port = portBase + 2
-        shm_api.publish_client_port(shm_port)
+        shm_port = f"/tmp/cascShmSock-{uuid.uuid4()}"  # portBase + 2
+        shm_api.publish_socket_addr(shm_port)
         ctx = platform.get_mp_ctx("executor-aux")
         if log_base:
             shm_logging = logging_config_filehandler(f"{log_base}.shm.txt")
@@ -104,12 +105,11 @@ class Executor:
         logger.debug("about to start an shm process")
         self.shm_process = ctx.Process(
             target=shm_server,
-            args=(
-                shm_port,
-                shm_vol_gb * (1024**3) if shm_vol_gb else None,
-                shm_logging,
-                f"sCasc{host}",
-            ),
+            kwargs={
+                "capacity": shm_vol_gb * (1024**3) if shm_vol_gb else None,
+                "logging_config": shm_logging,
+                "shm_pref": f"sCasc{host}",
+            },
         )
         self.shm_process.start()
         self.daddress = address_of(portBase + 1)
@@ -124,7 +124,6 @@ class Executor:
                 self.mlistener.address,
                 self.daddress,
                 self.host,
-                shm_port,
                 dsr_logging,
             ),
         )

--- a/src/cascade/shm/api.py
+++ b/src/cascade/shm/api.py
@@ -6,12 +6,16 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import logging
 import os
+import socket
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Protocol, Type, runtime_checkable
 
 from typing_extensions import Self
+
+logger = logging.getLogger(__name__)
 
 # TODO too much manual serde... either automate it based on dataclass field inspection, or just pickle it
 # (mind the server.recv/client.recv comment tho)
@@ -244,15 +248,52 @@ def deser(data: bytes) -> Comm:
     return b2c[data[:1]].deser(data[1:])
 
 
-client_port_envvar = "CASCADE_SHM_PORT"
+client_socket_envvar = "CASCADE_SHM_SOCKET"
 
 
-def publish_client_port(port: int) -> None:
-    os.environ[client_port_envvar] = str(port)
+def publish_socket_addr(sock: int | str) -> None:
+    if isinstance(sock, int):
+        ssock = f"port:{sock}"
+    else:
+        ssock = f"file:{sock}"
+    os.environ[client_socket_envvar] = ssock
 
 
-def get_client_port() -> int:
-    port = os.getenv(client_port_envvar)
-    if not port:
-        raise ValueError("missing port")
-    return int(port)
+def get_socket_addr() -> tuple[socket.socket, int | str]:
+    ssock = os.getenv(client_socket_envvar)
+    if not ssock:
+        raise ValueError(f"missing sock addr in {client_socket_envvar}")
+    kind, addr = ssock.split(":", 1)
+    if kind == "port":
+        addr = int(addr)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    elif kind == "file":
+        # TODO can we support SOCK_DGRAM too? Problem with response address
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    else:
+        raise NotImplementedError(kind)
+    return sock, addr
+
+
+def get_client_socket():
+    sock, addr = get_socket_addr()
+    if isinstance(addr, int):
+        sock.connect(("localhost", addr))
+    else:
+        sock.connect(addr)
+    return sock
+
+
+def get_server_socket():
+    sock, addr = get_socket_addr()
+    if isinstance(addr, int):
+        sock.bind(("0.0.0.0", addr))
+    else:
+        try:
+            os.unlink(addr)
+            logger.warning(f"unlinking at {addr}")
+        except FileNotFoundError:
+            pass
+        sock.bind(addr)
+        sock.listen(32)
+    return sock

--- a/src/cascade/shm/client.py
+++ b/src/cascade/shm/client.py
@@ -8,7 +8,6 @@
 
 import logging
 import multiprocessing.resource_tracker
-import socket
 import time
 from multiprocessing.shared_memory import SharedMemory
 from typing import Callable, Type, TypeVar
@@ -80,9 +79,7 @@ def _send_command(comm: api.Comm, resp_class: Type[T], timeout_sec: float = 60.0
     # timeout_i and coeff determine rate of busy-waits: coeff=1 is additive, =2 is exponential
     # eventually this busy-waits will go away as we switch to event driven behaviour
     while timeout_sec > 0:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        client_port = api.get_client_port()
-        sock.connect(("localhost", client_port))
+        sock = api.get_client_socket()
         logger.debug(f"sending message {comm}")
         sock.send(api.ser(comm))
         response_raw = sock.recv(1024)  # TODO or recv(4) + recv(int.from_bytes)?
@@ -161,7 +158,7 @@ def ensure() -> None:
         try:
             _send_command(comm, api.OkResponse)
             logger.debug("shm server responds ok, leaving ensure loop")
-        except ConnectionRefusedError:
+        except (ConnectionRefusedError, FileNotFoundError):
             time.sleep(0.1)
             continue
         break

--- a/src/cascade/shm/client.py
+++ b/src/cascade/shm/client.py
@@ -82,6 +82,7 @@ def _send_command(comm: api.Comm, resp_class: Type[T], timeout_sec: float = 60.0
         sock = api.get_client_socket()
         logger.debug(f"sending message {comm}")
         sock.send(api.ser(comm))
+        # TODO rewrite to poller with timeout
         response_raw = sock.recv(1024)  # TODO or recv(4) + recv(int.from_bytes)?
         sock.close()
         response_com = api.deser(response_raw)
@@ -145,9 +146,9 @@ def status(key: str) -> api.DatasetStatus:
     return response.status
 
 
-def shutdown() -> None:
+def shutdown(timeout_sec: float = 2.0) -> None:
     comm = api.ShutdownCommand()
-    _send_command(comm, api.OkResponse)
+    _send_command(comm, api.OkResponse, timeout_sec)
 
 
 def ensure() -> None:

--- a/src/cascade/shm/server.py
+++ b/src/cascade/shm/server.py
@@ -10,7 +10,7 @@ import logging
 import logging.config
 import signal
 import socket
-from typing import Any
+from typing import Any, cast
 
 import cascade.shm.api as api
 import cascade.shm.dataset as dataset
@@ -21,20 +21,35 @@ logger = logging.getLogger(__name__)
 class LocalServer:
     """Handles the socket communication, and the invocation of dataset.Manager which has the business logic"""
 
-    def __init__(self, port: int, shm_pref: str, capacity: int | None = None):
-        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        server = ("0.0.0.0", port)
-        self.sock.bind(server)
+    def __init__(self, shm_pref: str, capacity: int | None = None):
+        self.sock = api.get_server_socket()
+        logger.info(
+            f"shm server starting with {self.sock=} with {capacity=} and prefix {shm_pref}"
+        )
         self.manager = dataset.Manager(shm_pref, capacity)
         signal.signal(signal.SIGINT, self.atexit)
         signal.signal(signal.SIGTERM, self.atexit)
 
-    def receive(self) -> tuple[api.Comm, str]:
-        b, addr = self.sock.recvfrom(1024)  # TODO or recv(4) + recv(int.from_bytes)?
-        return api.deser(b), addr
+    def receive(self) -> tuple[api.Comm, str | socket.socket]:
+        # TODO recv(1024) or recv(4) + recv(int.from_bytes)?
+        if self.sock.type == socket.SOCK_DGRAM:
+            b, resp = self.sock.recvfrom(1024)
+        elif self.sock.type == socket.SOCK_STREAM:
+            resp, _addr = self.sock.accept()
+            b = resp.recv(1024)
+        else:
+            raise NotImplementedError(self.sock.type)
+        return api.deser(b), resp
 
-    def respond(self, comm: api.Comm, address: str) -> None:
-        self.sock.sendto(api.ser(comm), address)
+    def respond(self, comm: api.Comm, address: str | socket.socket) -> None:
+        m = api.ser(comm)
+        if self.sock.type == socket.SOCK_DGRAM:
+            self.sock.sendto(m, address)
+        elif self.sock.type == socket.SOCK_STREAM:
+            logger.debug(f"will send to {address} message {m}")
+            cast(socket.socket, address).send(m)
+        else:
+            raise NotImplementedError(self.sock.type)
 
     def atexit(self, signum: int, frame: Any) -> None:
         self.manager.atexit()
@@ -43,6 +58,7 @@ class LocalServer:
     def start(self):
         while True:
             payload, client = self.receive()
+            logger.debug(f"gotten {payload=}")
             try:
                 if isinstance(payload, api.AllocateRequest):
                     shmid, error = self.manager.add(
@@ -96,21 +112,18 @@ class LocalServer:
             except Exception as e:
                 logger.exception(f"failure during handling of {payload}")
                 response = api.OkResponse(error=repr(e))
+            logger.debug(f"sending {response=} to {client}")
             self.respond(response, client)
 
 
 def entrypoint(
-    port: int,
     capacity: int | None = None,
     logging_config: dict | None = None,
     shm_pref: str = "shm",
 ):
     if logging_config:
         logging.config.dictConfig(logging_config)
-    server = LocalServer(port, shm_pref, capacity)
-    logger.info(
-        f"shm server starting on {port=} with {capacity=} and prefix {shm_pref}"
-    )
+    server = LocalServer(shm_pref, capacity)
     try:
         server.start()
     except Exception as e:

--- a/tests/cascade/executor/test_callables.py
+++ b/tests/cascade/executor/test_callables.py
@@ -1,0 +1,29 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Intended to test that various 3rd-party callables work under cascade
+
+Similar modules will be found among earthkit-workflows plugins, all utilizing the
+cascade.benchmarks.tests module
+"""
+
+from cascade.benchmarks.tests import CallableInstance, run_test
+
+
+def test_numpy():
+
+    def myfunc(l: int) -> float:
+        import numpy as np
+
+        return np.arange(l).sum()
+
+    ci = CallableInstance(
+        func=myfunc, kwargs={"l": 4}, args=[], env=["numpy"], exp_output=6
+    )
+
+    run_test(ci, "numpyTest1", 2)

--- a/tests/cascade/shm/test_shm.py
+++ b/tests/cascade/shm/test_shm.py
@@ -14,12 +14,17 @@ import pytest
 import cascade.shm.api as api
 import cascade.shm.client as client
 import cascade.shm.server as server
+from cascade.executor.config import logging_config
 
 
-def test_shm_simple():
-    port = 12345
-    api.publish_client_port(port)
-    serverP = Process(target=server.entrypoint, args=(port,))
+@pytest.mark.parametrize("shm_addr", [12345, "/tmp/shmport12345"])
+def test_shm_simple(shm_addr):
+    api.publish_socket_addr(shm_addr)
+    pref = f"cTi{shm_addr%10}" if isinstance(shm_addr, int) else f"cTu{shm_addr[-1]}"
+    serverP = Process(
+        target=server.entrypoint,
+        kwargs={"logging_config": logging_config, "shm_pref": pref},
+    )
     serverP.start()
     try:
         client.ensure()
@@ -46,11 +51,19 @@ def test_shm_simple():
         serverP.terminate()
 
 
-def test_shm_disk():
-    port = 12346
+@pytest.mark.parametrize("shm_addr", [12346, "/tmp/shmport12346"])
+def test_shm_disk(shm_addr):
     capacity = 4
-    api.publish_client_port(port)
-    serverP = Process(target=server.entrypoint, args=(port, capacity))
+    pref = f"cTi{shm_addr%10}" if isinstance(shm_addr, int) else f"cTu{shm_addr[-1]}"
+    api.publish_socket_addr(shm_addr)
+    serverP = Process(
+        target=server.entrypoint,
+        kwargs={
+            "capacity": capacity,
+            "logging_config": logging_config,
+            "shm_pref": pref,
+        },
+    )
     serverP.start()
     try:
         client.ensure()


### PR DESCRIPTION
We add an option for shm to utilize AF_UNIX instead of AF_INET. The benefits thereof are descibed in benchmarks/README.md, mostly on reliability tho.

We add some basic benchmarks to benchmarks/scenario-shm. These will be used later as we change diskread implementation, algorithms, and possibly rust implementation.

We extend tests to consider both scenarios, and add parallel-run robustness.