### PR TITLE
[cascade.executor] Add stderr prop in uv failure

### DIFF
--- a/src/cascade/executor/runner/packages.py
+++ b/src/cascade/executor/runner/packages.py
@@ -24,6 +24,30 @@ from typing import Literal
 logger = logging.getLogger(__name__)
 
 
+class Commands:
+    venv_command = lambda name: ["uv", "venv", name]
+    install_command = lambda name: [
+        "uv",
+        "pip",
+        "install",
+        "--prefix",
+        name,
+        "--prerelease",
+        "explicit",
+    ]
+
+
+def run_command(command: list[str]) -> None:
+    try:
+        result = subprocess.run(command, check=False, capture_output=True)
+    except FileNotFoundError as ex:
+        raise ValueError(f"command failure: {ex}")
+    if result.returncode != 0:
+        msg = f"command failed with {result.returncode}. Stderr: {result.stderr}, Stdout: {result.stdout}, Args: {result.args}"
+        logger.error(msg)
+        raise ValueError(msg)
+
+
 class PackagesEnv(AbstractContextManager):
     def __init__(self) -> None:
         self.td: tempfile.TemporaryDirectory | None = None
@@ -32,31 +56,22 @@ class PackagesEnv(AbstractContextManager):
         if not packages:
             return
         if self.td is None:
-            logger.debug("creating a new venv")
             self.td = tempfile.TemporaryDirectory()
-            venv_command = ["uv", "venv", self.td.name]
+            logger.debug(f"creating a new venv at {self.td.name}")
+            run_command(Commands.venv_command(self.td.name))
             # NOTE we create a venv instead of just plain directory, because some of the packages create files
             # outside of site-packages. Thus we then install with --prefix, not with --target
-            subprocess.run(venv_command, check=True)
 
         logger.debug(
             f"installing {len(packages)} packages: {','.join(packages[:3])}{',...' if len(packages) > 3 else ''}"
         )
-        install_command = [
-            "uv",
-            "pip",
-            "install",
-            "--prefix",
-            self.td.name,
-            "--prerelease",
-            "allow",
-        ]
+        install_command = Commands.install_command(self.td.name)
         if os.environ.get("VENV_OFFLINE", "") == "YES":
             install_command += ["--offline"]
         if cache_dir := os.environ.get("VENV_CACHE", ""):
             install_command += ["--cache-dir", cache_dir]
         install_command.extend(set(packages))
-        subprocess.run(install_command, check=True)
+        run_command(install_command)
         # NOTE not sure if getsitepackages was intended for this -- if issues, attempt replacing
         # with something like f"{self.td.name}/lib/python*/site-packages" + globbing
         extra_sp = site.getsitepackages(prefixes=[self.td.name])

--- a/tests/cascade/executor/test_packages.py
+++ b/tests/cascade/executor/test_packages.py
@@ -1,0 +1,24 @@
+import re
+
+import pytest
+
+from cascade.executor.runner.packages import run_command
+
+
+def test_run_command() -> None:
+    succ_command = ["echo", "you", "shall", "pass"]
+    bad1_command = ["you", "shall", "not", "pass"]
+    bad2_command = ["uv", "pip", "install", "nonexistentpackagename"]
+
+    run_command(succ_command)
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape("command failure: [Errno 2] No such file or directory: 'you'"),
+    ):
+        run_command(bad1_command)
+    with pytest.raises(
+        ValueError,
+        match=r"nonexistentpackagename was not found in the package registry",
+    ):
+        run_command(bad2_command)


### PR DESCRIPTION
before: when uv install failed, we propagated to the top only CalledProcessError(args) without the err details

now: the full stderr and stdout and errcode are propagated, as well as logged

sideeffect: no more logging to stdout in case of a successful run -- may be undesired, would then need a fix later. Or do a pip freeze in case of a task failure, etc

