### PR TITLE
[cascade] logging refactor

### DIFF
--- a/src/cascade/deployment/__init__.py
+++ b/src/cascade/deployment/__init__.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Configuration and utilities pertaining to deployment. Currently handles: 
+ - logging.
+"""

--- a/src/cascade/deployment/logging/__init__.py
+++ b/src/cascade/deployment/logging/__init__.py
@@ -1,0 +1,91 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Logging setup and configuration for any process and deployment
+
+Assumed to propagate in a cascading manner:
+ - infrastructure operator configures gateway with logging as cli param,
+ - gateway spawns a launcher for each individual job
+   - logging config propagated via cli param / other means for troika,slurm,k8s,
+ - each launcher spawns procesess for controller and executors
+   - logging config propagated via proc kwarg
+ - each executor additionally spawns shm server, data server, individual runners
+   - only logging dict propagated, via proc kwarg
+
+This cascading manner accumulates context as it goes -- gateway adds jobId every
+time it launches a job, executor launcher adds workerId to each of worker processes,
+etc. This distinguishes individual log streams
+
+We currently use LoggingConfig pydantic model for all logging configs, and pass
+that through cli params via base64 of the json -- not human-practical, but safe
+
+We don't expose much config options -- but any addition to the LoggingConfig class
+gets propagated to all places that initiate logging. That is, any logging change
+can be implemented fully within this module
+"""
+
+import base64
+import logging
+import logging.config
+import os
+from typing import Literal
+
+import orjson
+from pydantic import BaseModel
+from typing_extensions import Self
+
+import cascade.deployment.logging.defaults as defaults
+
+
+class LoggingConfig(BaseModel):
+    formatter: Literal["line", "json"]
+    """Line is standard python logging, json uses structured logging"""
+    path_base: str|None
+    """If None log to stdout, otherwise log into files in path_base directory, with each process having its own files.
+    Expected to have been created beforehand"""
+
+    def ser_cliparam(self) -> str:
+        return base64.b64encode(self.model_dump_json().encode('utf-8')).decode('utf-8')
+
+    def withContext(self, context_kv: str) -> Self:
+        if self.path_base is not None:
+            return self.model_copy(update={'path_base': self.path_base + f"{context_kv}."})
+        else:
+            # TODO handle context in the stdout loggers. Not critical because all
+            # logs of zmq messages have context in them anyway
+            return self
+
+
+DefaultLoggingConfig = LoggingConfig(formatter="line", path_base=None)
+
+def as_dict_config(loggingConfig: LoggingConfig, hostAndRole: str) -> dict:
+    if loggingConfig.path_base:
+        filename = f"{loggingConfig.path_base}{hostAndRole}.txt"
+        handler = defaults.handlers['filename'](filename) # ty:ignore[call-non-callable] # sloppy typing on my side
+    else:
+        handler = defaults.handlers['stdout']
+    return {
+        **defaults.base,
+        **handler,
+        **defaults.formatters[loggingConfig.formatter],
+    }
+
+def init_from_obj(loggingConfig: LoggingConfig, hostAndRole: str) -> None:
+    dictConfig = as_dict_config(loggingConfig, hostAndRole)
+    logging.config.dictConfig(dictConfig)
+
+def init_from_cliparam(cliparam: str|None, hostAndRole: str) -> LoggingConfig:
+    if cliparam is not None:
+        loggingConfig = LoggingConfig(**orjson.loads(base64.b64decode(cliparam.encode('utf-8'))))
+    else:
+        loggingConfig = DefaultLoggingConfig
+        logging.getLogger(__name__).warning("using default config for logging at {hostAndRole}")
+
+    init_from_obj(loggingConfig, hostAndRole)
+    return loggingConfig

--- a/src/cascade/deployment/logging/defaults.py
+++ b/src/cascade/deployment/logging/defaults.py
@@ -1,0 +1,61 @@
+base = {
+    "version": 1,
+    "disable_existing_loggers": True,
+    "loggers": {
+        "uvicorn": {"level": "INFO"},
+        "forecastbox": {"level": "DEBUG"},
+        "forecastbox.worker": {"level": "DEBUG"},
+        "forecastbox.executor": {"level": "DEBUG"},
+        "cascade": {"level": "INFO"},
+        "cascade.main": {"level": "DEBUG"},
+        "cascade.low": {"level": "DEBUG"},
+        "cascade.shm": {"level": "DEBUG"},
+        "cascade.controller": {"level": "DEBUG"},
+        "cascade.executor": {"level": "DEBUG"},
+        "cascade.scheduler": {"level": "DEBUG"},
+        "cascade.gateway": {"level": "DEBUG"},
+        "earthkit.workflows": {"level": "DEBUG"},
+        "httpcore": {"level": "ERROR"},
+        "httpx": {"level": "ERROR"},
+        "": {"level": "WARNING", "handlers": ["default"]},
+    },
+}
+
+handlers = {
+    "stdout": {
+        "handlers": {
+            "default": {
+                "formatter": "default",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stderr",
+            },
+        },
+    },
+    "filename": lambda filename: {
+            "handlers": {
+                "default": {
+                    "formatter": "default",
+                    "class": "logging.FileHandler",
+                    "filename": filename,
+                },
+            },
+        },
+}
+
+formatters = {
+    "line": {
+        "formatters": {
+            "default": {
+                "format": "{asctime}:{levelname}:{name}:{process}:{message:1.10000}",
+                "style": "{",
+            },
+        },
+    },
+    "json": {
+        "formatters": {
+            "default": {
+               "()": "__main__.JSONFormatter", 
+            },
+        },
+    },
+}

--- a/src/cascade/deployment/logging/json_formatter.py
+++ b/src/cascade/deployment/logging/json_formatter.py
@@ -1,0 +1,37 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Custom json formatter, felt easier than struggling with another 3rd party lib"""
+
+import logging
+import logging.config
+
+import orjson
+
+
+class JSONFormatter(logging.Formatter):
+    def format(self, record):
+        log_data = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "process": record.process,
+            "message": record.getMessage(),
+        }
+        
+        # NOTE standard_attrs = {
+        #    'name', 'msg', 'args', 'levelname', 'levelno', 'pathname', 'filename',
+        #    'module', 'exc_info', 'exc_text', 'stack_info', 'lineno', 'funcName',
+        #    'created', 'msecs', 'relativeCreated', 'thread', 'threadName',
+        #    'processName', 'process', 'message', 'asctime', 'taskName',
+        #}
+        
+        if record.exc_info:
+            log_data["exception"] = self.formatException(record.exc_info)
+
+        return orjson.dumps(log_data).decode("utf-8")

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -28,6 +28,7 @@ import cloudpickle
 import cascade.executor.platform as platform
 import cascade.shm.api as shm_api
 import cascade.shm.client as shm_client
+from cascade.deployment.logging import LoggingConfig, as_dict_config
 from cascade.executor.comms import GraceWatcher, Listener, ReliableSender, callback
 from cascade.executor.comms import default_message_resend_ms as resend_grace_ms
 from cascade.executor.comms import default_timeout_ms as comms_default_timeout_ms
@@ -86,7 +87,7 @@ class Executor:
         host: HostId,
         portBase: int,
         shm_vol_gb: int | None,
-        log_base: str | None,
+        loggingConfig: LoggingConfig,
         url_base: str,
     ) -> None:
         self.job_instance = job_instance
@@ -98,7 +99,7 @@ class Executor:
             WorkerId(host, f"w{i}"): None for i in range(workers)
         }
         self.worker_awaits: dict[WorkerId, None|TaskSequence] = {}
-        self.log_base = log_base
+        self.loggingConfig = loggingConfig
         self.old_processes: list[BaseProcess] = []
 
         self.datasets: set[DatasetId] = set()
@@ -115,25 +116,17 @@ class Executor:
         shm_port = f"/tmp/cascShmSock-{uuid.uuid4()}"  # portBase + 2
         shm_api.publish_socket_addr(shm_port)
         ctx = platform.get_mp_ctx("executor-aux")
-        if log_base:
-            shm_logging = logging_config_filehandler(f"{log_base}.shm.txt")
-        else:
-            shm_logging = logging_config
         logger.debug("about to start an shm process")
         self.shm_process = ctx.Process(
             target=shm_server,
             kwargs={
                 "capacity": shm_vol_gb * (1024**3) if shm_vol_gb else None,
-                "logging_config": shm_logging,
+                "logging_config": as_dict_config(loggingConfig, "shm"),
                 "shm_pref": f"sCasc{host}",
             },
         )
         self.shm_process.start()
         self.daddress = address_of(portBase + 1)
-        if log_base:
-            dsr_logging = logging_config_filehandler(f"{log_base}.dsr.txt")
-        else:
-            dsr_logging = logging_config
         logger.debug("about to start a data server process")
         self.data_server = ctx.Process(
             target=start_data_server,
@@ -141,7 +134,7 @@ class Executor:
                 self.mlistener.address,
                 self.daddress,
                 self.host,
-                dsr_logging,
+                as_dict_config(loggingConfig, "dsr"),
             ),
         )
         self.data_server.start()
@@ -216,7 +209,7 @@ class Executor:
             job=self.job_instance,
             param_source=self.param_source,
             callback=self.mlistener.address,
-            log_base=self.log_base,
+            loggingConfig=self.loggingConfig,
             schema_lookup=self.schema_lookup,
         )
         # NOTE we need to cloudpickle because runnerContext contains some lambdas

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -20,8 +20,8 @@ from typing_extensions import Self
 
 import cascade.executor.platform as platform
 import cascade.executor.serde as serde
+from cascade.deployment.logging import LoggingConfig, init_from_obj
 from cascade.executor.comms import callback
-from cascade.executor.config import logging_config, logging_config_filehandler
 from cascade.executor.msg import (
     BackboneAddress,
     DatasetPublished,
@@ -41,7 +41,7 @@ from cascade.low.tracing import label
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RunnerContext:
     """The static runner configuration"""
 
@@ -50,7 +50,7 @@ class RunnerContext:
     job: JobInstance
     callback: BackboneAddress
     param_source: dict[TaskId, dict[int | str, DatasetId]]
-    log_base: str | None
+    loggingConfig: LoggingConfig
     schema_lookup: dict[DatasetId, str]
 
     @staticmethod
@@ -182,11 +182,7 @@ def execute_sequence(
 def entrypoint(runnerContextClpkl: bytes):
     """runnerContext is a cloudpickled instance of RunnerContext -- needed for forkserver mp context due to defautdicts"""
     runnerContext = cloudpickle.loads(runnerContextClpkl)
-    if runnerContext.log_base:
-        log_path = f"{runnerContext.log_base}.{runnerContext.workerId.worker}"
-        logging.config.dictConfig(logging_config_filehandler(log_path))
-    else:
-        logging.config.dictConfig(logging_config)
+    init_from_obj(runnerContext.loggingConfig, f"worker_{runnerContext.workerId.worker}")
     ctx = zmq.Context()
     socket = ctx.socket(zmq.PULL)
     address = worker_address(runnerContext.workerId, runnerContext.workerAttemptCnt)

--- a/src/cascade/gateway/__main__.py
+++ b/src/cascade/gateway/__main__.py
@@ -10,23 +10,18 @@ import logging.config
 
 import fire
 
-from cascade.executor.config import logging_config, logging_config_filehandler
-from cascade.gateway.server import serve
+from cascade.deployment.logging import init_from_cliparam
+from cascade.gateway.server import roleLoggingStr, serve
 
 
-def main(
+def main_cli(
     url: str,
-    log_base: str | None = None,
+    loggingConfigSer: str | None = None,
     troika_config: str | None = None,
     max_jobs: int | None = None,
 ) -> None:
-    if log_base:
-        log_path = f"{log_base}/gateway.txt"
-        logging.config.dictConfig(logging_config_filehandler(log_path))
-    else:
-        logging.config.dictConfig(logging_config)
-    serve(url, log_base, troika_config, max_jobs)
-
+    loggingConfig = init_from_cliparam(loggingConfigSer, roleLoggingStr())
+    serve(url, loggingConfig, troika_config, max_jobs)
 
 if __name__ == "__main__":
-    fire.Fire(main)
+    fire.Fire(main_cli)

--- a/src/cascade/gateway/router.py
+++ b/src/cascade/gateway/router.py
@@ -29,6 +29,7 @@ from cascade.controller.report import (
     JobProgressEnqueued,
     JobProgressStarted,
 )
+from cascade.deployment.logging import LoggingConfig
 from cascade.executor.comms import get_context
 from cascade.gateway.api import JobSpec
 from cascade.gateway.spawning import spawn_subprocess
@@ -50,7 +51,7 @@ class JobRouter:
     def __init__(
         self,
         poller: zmq.Poller,
-        log_base: str | None,
+        loggingConfig: LoggingConfig,
         troika_config: str | None,
         max_jobs: int | None,
     ):
@@ -60,7 +61,7 @@ class JobRouter:
         self.max_jobs = max_jobs
         self.jobs_queue: OrderedDict[JobId, JobSpec] = OrderedDict()
         self.procs: dict[str, subprocess.Popen] = {}
-        self.log_base = log_base
+        self.loggingConfig = loggingConfig
         self.troika_config = troika_config
 
     def maybe_spawn(self) -> None:
@@ -79,7 +80,7 @@ class JobRouter:
         self.poller.register(socket, flags=zmq.POLLIN)
         self.jobs[job_id] = Job(socket, JobProgressStarted, -1, {})
         self.procs[job_id] = spawn_subprocess(
-            job_spec, full_addr, job_id, self.log_base, self.troika_config
+            job_spec, full_addr, job_id, self.loggingConfig, self.troika_config
         )
         self.active_jobs += 1
 

--- a/src/cascade/gateway/server.py
+++ b/src/cascade/gateway/server.py
@@ -11,6 +11,7 @@ here we just match the right method of `gateway.router` based on what message we
 """
 
 import base64
+import datetime as dt
 import logging
 from typing import cast
 
@@ -18,6 +19,7 @@ import zmq
 
 import cascade.gateway.api as api
 from cascade.controller.report import JobProgress, deserialize
+from cascade.deployment.logging import LoggingConfig, init_from_obj
 from cascade.executor.comms import get_context
 from cascade.gateway.client import parse_request, serialize_response
 from cascade.gateway.router import JobRouter
@@ -85,7 +87,7 @@ def handle_controller(socket: zmq.Socket, jobs: JobRouter) -> None:
 
 def serve(
     url: str,
-    log_base: str | None = None,
+    loggingConfig: LoggingConfig,
     troika_config: str | None = None,
     max_jobs: int | None = None,
 ) -> None:
@@ -95,7 +97,7 @@ def serve(
     fe = ctx.socket(zmq.REP)
     fe.bind(url)
     poller.register(fe, flags=zmq.POLLIN)
-    jobs = JobRouter(poller, log_base, troika_config, max_jobs)
+    jobs = JobRouter(poller, loggingConfig, troika_config, max_jobs)
 
     logger.debug("entering recv loop")
     is_break = False
@@ -106,3 +108,15 @@ def serve(
                 is_break = handle_fe(socket, jobs)
             else:
                 handle_controller(socket, jobs)
+
+def roleLoggingStr() -> str:
+    # In case there are multiple gateway restarts etc, we dont want to collide.
+    # For other roles this matters not -- they are distinguished by jobId in the name, or by #attempt counter
+    now = dt.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    return f"gateway.{now}"
+
+
+def main_enp(url: str, loggingConfig: LoggingConfig, max_jobs: int | None) -> None:
+    # use when process is not __main__ but eg forked from another
+    init_from_obj(loggingConfig, roleLoggingStr())
+    serve(url, loggingConfig, None, max_jobs)

--- a/src/cascade/gateway/spawning.py
+++ b/src/cascade/gateway/spawning.py
@@ -18,6 +18,7 @@ import subprocess
 import orjson
 
 from cascade.controller.report import JobId
+from cascade.deployment.logging import LoggingConfig
 from cascade.gateway.api import JobSpec, TroikaSpec
 
 logger = logging.getLogger(__name__)
@@ -81,7 +82,7 @@ def _spawn_troika_singlehost(
 
 
 def _spawn_local(
-    job_spec: JobSpec, addr: str, job_id: JobId, log_base: str | None
+    job_spec: JobSpec, addr: str, job_id: JobId, loggingConfig: LoggingConfig,
 ) -> subprocess.Popen:
     base = [
         "python",
@@ -101,10 +102,7 @@ def _spawn_local(
         f"{job_spec.hosts}",
     ]
     report = ["--report_address", f"{addr},{job_id}"]
-    if log_base:
-        logs = ["--log_base", f"{log_base}/job.{job_id}"]
-    else:
-        logs = []
+    logs = ["--loggingConfigSer", loggingConfig.withContext(f"job_{job_id}").ser_cliparam()]
     global local_job_port
     portBase = ["--port_base", str(local_job_port)]
     local_job_port += 1 + job_spec.hosts * job_spec.workers_per_host * 10
@@ -139,12 +137,11 @@ def spawn_subprocess(
     job_spec: JobSpec,
     addr: str,
     job_id: JobId,
-    log_base: str | None,
+    loggingConfig: LoggingConfig,
     troika_config: str | None,
 ) -> subprocess.Popen:
     if job_spec.troika is not None:
-        if log_base is not None:
-            raise ValueError(f"unexpected {log_base=}")
+        # TODO support logging config properly
         if troika_config is None:
             raise ValueError("cant spawn troika job without troika config")
         if not job_spec.use_slurm:
@@ -156,8 +153,7 @@ def spawn_subprocess(
             raise NotImplementedError
 
     elif job_spec.use_slurm:
-        if log_base is not None:
-            raise ValueError(f"unexpected {log_base=}")
+        # TODO support logging config properly
         return _spawn_slurm(job_spec, addr, job_id)
     else:
-        return _spawn_local(job_spec, addr, job_id, log_base)
+        return _spawn_local(job_spec, addr, job_id, loggingConfig)

--- a/src/cascade/main.py
+++ b/src/cascade/main.py
@@ -22,6 +22,7 @@ import orjson
 
 import cascade.executor.platform as platform
 from cascade.controller.impl import run
+from cascade.deployment.logging import DefaultLoggingConfig, LoggingConfig, init_from_cliparam, init_from_obj
 from cascade.executor.bridge import Bridge
 from cascade.executor.comms import callback
 from cascade.executor.config import logging_config, logging_config_filehandler
@@ -76,15 +77,10 @@ def launch_executor(
     i: int,
     shm_vol_gb: int | None,
     gpu_count: int,
-    log_base: str | None,
+    loggingConfig: LoggingConfig,
     url_base: str,
 ):
-    if log_base is not None:
-        log_base = f"{log_base}.host{i}"
-        log_path = f"{log_base}.txt"
-        logging.config.dictConfig(logging_config_filehandler(log_path))
-    else:
-        logging.config.dictConfig(logging_config)
+    init_from_obj(loggingConfig, "executor")
     try:
         logger.info(f"will set {gpu_count} gpus on host {i}")
         os.environ["CASCADE_GPU_COUNT"] = str(gpu_count)
@@ -95,7 +91,7 @@ def launch_executor(
             f"h{i}",
             portBase,
             shm_vol_gb,
-            log_base,
+            loggingConfig,
             url_base,
         )
         executor.register()
@@ -111,16 +107,12 @@ def run_locally(
     hosts: int,
     workers: int,
     portBase: int = 12345,
-    log_base: str | None = None,
+    loggingConfigSer: str | None = None,
     report_address: str | None = None,
 ) -> dict[DatasetId, Any]:
     # NOTE the provided job may cary traces of imports we dont want to pollute executor with
     job = JobInstanceRich(**orjson.loads(job.model_dump_json().encode()))
-    if log_base is not None:
-        log_path = f"{log_base}.controller.txt"
-        logging.config.dictConfig(logging_config_filehandler(log_path))
-    else:
-        logging.config.dictConfig(logging_config)
+    loggingConfig = init_from_cliparam(loggingConfigSer, "controller")
     logger.debug(f"local run starting with {hosts=} and {workers=} on {portBase=}")
     launch = perf_counter_ns()
     c = f"tcp://localhost:{portBase}"
@@ -142,7 +134,7 @@ def run_locally(
                     i,
                     None,
                     gpu_count,
-                    log_base,
+                    loggingConfig.withContext(f"host_{i}"),
                     "tcp://localhost",
                 ),
             )
@@ -196,7 +188,7 @@ def main_local(
     hosts: int = 1,
     report_address: str | None = None,
     port_base: int = 12345,
-    log_base: str | None = None,
+    loggingConfigSer: str | None = None,
 ) -> None:
     jobInstanceRich = _deserialize(instance)
     run_locally(
@@ -205,7 +197,7 @@ def main_local(
         workers_per_host,
         report_address=report_address,
         portBase=port_base,
-        log_base=log_base,
+        loggingConfigSer=loggingConfigSer,
     )
 
 
@@ -248,7 +240,7 @@ def main_dist(
             idx,
             shm_vol_gb,
             gpu_count,
-            log_base = None, # TODO handle log collection for dist scenario
+            loggingConfig = DefaultLoggingConfig, # TODO handle logging for dist scenario
             url_base = f"tcp://{platform.get_bindabble_self()}",
         )
 

--- a/tests/cascade/controller/test_run.py
+++ b/tests/cascade/controller/test_run.py
@@ -23,6 +23,7 @@ import tempfile
 import pathlib
 import pickle
 
+from cascade.deployment.logging import DefaultLoggingConfig
 from cascade.controller.impl import run
 from cascade.executor.bridge import Bridge
 from cascade.executor.comms import callback
@@ -56,7 +57,7 @@ def launch_executor(
         f"test_executor{i}",
         portBase,
         None,
-        None,
+        DefaultLoggingConfig,
         "tcp://localhost",
     )
     executor.register()

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -16,6 +16,7 @@ from multiprocessing import Process
 
 import numpy as np
 
+from cascade.deployment.logging import DefaultLoggingConfig
 import cascade.executor.platform as platform
 import cascade.executor.serde as serde
 from cascade.executor.comms import Listener, callback, send_data
@@ -59,7 +60,7 @@ def launch_executor(
         "test_executor",
         portBase,
         None,
-        None,
+        DefaultLoggingConfig,
         "tcp://localhost",
     )
     executor.register()

--- a/tests/cascade/executor/test_runner.py
+++ b/tests/cascade/executor/test_runner.py
@@ -11,6 +11,7 @@
 from multiprocessing.shared_memory import SharedMemory
 from typing import Any
 
+from cascade.deployment.logging import DefaultLoggingConfig
 import cascade.executor.runner.entrypoint as entrypoint
 import cascade.executor.runner.memory as memory
 import cascade.executor.serde as serde
@@ -88,7 +89,7 @@ def test_runner(monkeypatch):
         callback=test_address,
         job=job,
         param_source={},
-        log_base=None,
+        loggingConfig=DefaultLoggingConfig,
         schema_lookup=entrypoint.RunnerContext.build_schema_lookup(job),
     )
 
@@ -127,7 +128,7 @@ def test_runner(monkeypatch):
         callback=test_address,
         job=oneTaskJob,
         param_source=param_source(oneTaskJob.edges),
-        log_base=None,
+        loggingConfig=DefaultLoggingConfig,
         schema_lookup=entrypoint.RunnerContext.build_schema_lookup(oneTaskJob),
     )
 
@@ -174,7 +175,7 @@ def test_runner(monkeypatch):
         callback=test_address,
         job=twoTaskJob,
         param_source=param_source(twoTaskJob.edges),
-        log_base=None,
+        loggingConfig=DefaultLoggingConfig,
         schema_lookup=entrypoint.RunnerContext.build_schema_lookup(twoTaskJob),
     )
 
@@ -243,7 +244,7 @@ def test_runner(monkeypatch):
         callback=test_address,
         job=t4Job,
         param_source=param_source(t4Job.edges),
-        log_base=None,
+        loggingConfig=DefaultLoggingConfig,
         schema_lookup=entrypoint.RunnerContext.build_schema_lookup(t4Job),
     )
 

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -3,7 +3,7 @@ from multiprocessing import Process
 
 import cascade.gateway.api as api
 import cascade.gateway.client as client
-from cascade.gateway.__main__ import main
+from cascade.gateway.__main__ import main_cli
 from cascade.low.builders import JobBuilder
 from cascade.low.core import DatasetId, JobInstanceRich, TaskDefinition, TaskInstance
 
@@ -68,7 +68,7 @@ def get_job_slow() -> JobInstanceRich:
 
 def spawn_gateway(max_jobs: int | None = None) -> tuple[str, Process]:
     url = "tcp://localhost:12355"
-    p = Process(target=main, args=(url,), kwargs={"max_jobs": max_jobs})
+    p = Process(target=main_cli, args=(url,), kwargs={"max_jobs": max_jobs})
     p.start()
     return url, p
 


### PR DESCRIPTION
redo logging configurability from log_base: str|None to a rich config object

refactor how the logging config is passed, and logging initialized, so that its long term more extensibile

add a new formatter for json struct based logging
