### PR TITLE
[runner] Yield package_spec instead of package for missing packages

### DIFF
--- a/src/cascade/executor/runner/packages.py
+++ b/src/cascade/executor/runner/packages.py
@@ -205,7 +205,7 @@ def _prefer_installed(packages: list[str]) -> Iterator[str]:
             parts = re.split(r"([<>=!~].*)", package_spec)
             package = parts[0]
             if package not in installed:
-                yield package
+                yield package_spec
             elif len(parts) == 1:
                 if installed[package] == "--editable" or installed[package] == "--git":
                     continue

--- a/tests/cascade/executor/test_packages.py
+++ b/tests/cascade/executor/test_packages.py
@@ -81,6 +81,13 @@ def test_postinstall_verify() -> None:
 def test_prefer_installed() -> None:
     import numpy
 
-    assert list(_prefer_installed(["numpy"])) == [f"numpy=={numpy.__version__}"]
-    assert list(_prefer_installed(["numpy==1.0.0"])) == ["numpy==1.0.0"]
-    assert list(_prefer_installed([f"numpy>={numpy.__version__}"])) == [f"numpy=={numpy.__version__}"]
+    assert list(_prefer_installed(["numpy"])) == [f"numpy=={numpy.__version__}"], (
+        "unrestricted spec of installed pkg didnt resolve to installed pkg"
+    )
+    assert list(_prefer_installed(["numpy==1.0.0"])) == ["numpy==1.0.0"], (
+        "exact pin spec of installed pkg which is compatible didnt match installed version"
+    )
+    assert list(_prefer_installed([f"numpy>={numpy.__version__}"])) == [f"numpy=={numpy.__version__}"], (
+        "range spec of installed pkg which is compatible didnt match installed version"
+    )
+    assert list(_prefer_installed(["grumpy==42.0.0"])) == ["grumpy==42.0.0"], "spec of uninstalled package got dropped"


### PR DESCRIPTION
### Description
When a package was being installed, but not already installed, it's version was being dropped

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 