### PR TITLE
Feat/fix dep installs

### DIFF
--- a/integration_tests/job_torchTrivial.py
+++ b/integration_tests/job_torchTrivial.py
@@ -1,0 +1,28 @@
+"""
+A trivial job with torch tensor sum over two steps
+"""
+
+from base import JobSpec  # ty:ignore[unresolved-import]
+from runtime import sink_file, source_tensor, transform_tensorsum  # ty:ignore[unresolved-import]
+
+from cascade.low.core import JobInstanceRich
+from earthkit.workflows.compilers import graph2job
+from earthkit.workflows.fluent import Action, Payload, from_source
+
+
+def job() -> JobInstanceRich:
+    source = from_source(source_tensor)
+    trans = source.map(transform_tensorsum)
+    sink = trans.map(Payload(sink_file, kwargs={"fname": "/tmp/file.txt"}))
+
+    graph = sink.graph()
+    ji = graph2job(graph)
+    for task in ji.tasks:
+        if "tensor" in task:
+            ji.tasks[task].definition.environment = ["torch"]
+
+    return JobInstanceRich(jobInstance=ji, checkpointSpec=None)
+
+
+def spc() -> JobSpec:
+    return JobSpec(workers=1, hosts=1)

--- a/integration_tests/runtime/__init__.py
+++ b/integration_tests/runtime/__init__.py
@@ -31,11 +31,11 @@ def sink_file(data, fname: str) -> None:
     pathlib.Path(fname).write_text(str(data))
 
 
-def source_tensor() -> "torch.Tensor":
-    import torch
+def source_tensor() -> "torch.Tensor":  # ty: ignore
+    import torch  # ty: ignore
 
     return torch.tensor([1, 2, 3])
 
 
-def transform_tensorsum(t: "torch.Tensor") -> int:
+def transform_tensorsum(t: "torch.Tensor") -> int:  # ty: ignore
     return int(t.sum())

--- a/integration_tests/runtime/__init__.py
+++ b/integration_tests/runtime/__init__.py
@@ -29,3 +29,13 @@ def sink_file(data, fname: str) -> None:
     import pathlib
 
     pathlib.Path(fname).write_text(str(data))
+
+
+def source_tensor() -> "torch.Tensor":
+    import torch
+
+    return torch.tensor([1, 2, 3])
+
+
+def transform_tensorsum(t: "torch.Tensor") -> int:
+    return int(t.sum())

--- a/justfile
+++ b/justfile
@@ -18,4 +18,5 @@ val:
 fmt:
     uv run prek --all-files
 integration testname:
+    # testname is the importible module, so eg job_ekwTrivial
     cd integration_tests && uv run python harness.py {{testname}}

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -343,6 +343,7 @@ class Executor:
                         self.workers[m.worker] = self._start_worker(m.worker, handle.attempt_cnt + 1, m.remainder)
                         self.to_controller(m)
                     elif isinstance(m, TaskFailure):
+                        logger.debug(f"Forwarding task failure {m}")
                         self.to_controller(m)
                     elif isinstance(m, DatasetPublished):
                         for worker in self.workers:

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -33,10 +33,10 @@ from cascade.executor.msg import (
     WorkerShutdown,
 )
 from cascade.executor.runner.memory import Memory
-from cascade.executor.runner.packages import PackagesEnv, PostinstallException
+from cascade.executor.runner.packages import PackagesEnv, PkgInstallException
 from cascade.executor.runner.runner import ExecutionContext, run
 from cascade.low.core import DatasetId, JobInstance, TaskId, WorkerId, type_dec
-from cascade.low.exceptions import CascadeError, CascadeInfrastructureError, CascadeInternalError, ser
+from cascade.low.exceptions import CascadeError, CascadeInfrastructureError, CascadeInternalError, CascadeUserError, ser
 from cascade.low.tracing import label
 
 logger = logging.getLogger(__name__)
@@ -155,8 +155,15 @@ def execute_sequence(
             # NOTE we should in principle restore the previous value, but we dont expect collisions
             del os.environ[key]
         return True
-    except PostinstallException as e:
-        logger.error(f"postinstall validation failed, will send RunnerRestartRequest: {repr(e)}")
+    except PkgInstallException as e:
+        if e.was_clean:
+            logger.error(f"pkg install failed on a clean env, crashing with user error")
+            callback(
+                runnerContext.callback,
+                TaskFailure(worker=taskSequence.worker, task=taskId, detail=ser(CascadeUserError(repr(e)))),
+            )
+            return False
+        logger.error(f"pkg install failed, will send RunnerRestartRequest: {repr(e)}")
         if not taskId:
             raise CascadeInternalError("Postinstall should not have been raised in the absence of active task")
         additionalPublish = task_sequence_postmortem(runnerContext, taskSequence, taskId)

--- a/src/cascade/executor/runner/packages.py
+++ b/src/cascade/executor/runner/packages.py
@@ -35,8 +35,11 @@ from cascade.low.exceptions import CascadeInternalError, CascadeUserError
 logger = logging.getLogger(__name__)
 
 
+_python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+
+
 class Commands:
-    venv_command = lambda name: ["uv", "venv", name]
+    venv_command = lambda name: ["uv", "venv", "--python", _python_version, name]
     install_command = lambda name: [
         "uv",
         "pip",
@@ -110,6 +113,7 @@ def _parse_pip_install(pip_output: str) -> dict[str, Version]:
 
 
 def _get_dist_modules(dist_name: str) -> list[str]:
+    """From package name like 'earthkit-workflows' get the top level importible like 'earthkit', 'cascade'"""
     # TODO presumably cacheable
     try:
         handle = importlib.metadata.distribution(dist_name)
@@ -124,6 +128,17 @@ def _get_dist_modules(dist_name: str) -> list[str]:
     except Exception as e:
         logging.warning(f"Could not find metadata for installed package: {dist_name} due to {repr(e)} -- ignoring")
         return []
+
+
+def _maybe_module_dist(module_name: str) -> str | None:
+    """From a module name like 'cascade' get the pip installable like 'earthkit-workflows'"""
+    # TODO cacheable, but will need to handle growth
+    lookup = importlib.metadata.packages_distributions()
+    maybe = lookup.get(module_name, [])
+    if len(maybe) >= 1:
+        return maybe[0]
+    else:
+        return None
 
 
 def _maybe_module_version(mod_name: str) -> Version | None:
@@ -153,8 +168,7 @@ class PostinstallException(BaseException):
         self.issues = issues
 
     def __str__(self) -> str:
-        msg = repr(self.issues)
-        return f"failed to install correctly: {msg[:1024]}{'...' if len(msg) > 1024 else ''}"
+        return f"failed to install correctly: {repr(self.issue)}"
 
 
 def _postinstall_verify(pip_output) -> list[InstallIssue]:
@@ -180,8 +194,13 @@ def _prefer_installed(packages: list[str]) -> Iterator[str]:
     we will inspect pip freeze to see if it is already installed, and inject
     the pin otherwise. This is default `uv` behaviour, but remember we
     override --prefix, thus uv has no way of knowing. We thus have to explicate.
+
+    Furthermore, we will extend the list with already-imported packages. This
+    moves some PostInstall verify issues into the Install phase, and importantly,
+    for fresh workers and unavoidable dependencies (like orjson or pydantic),
+    forces a pin to prevent unbound resolution infinite loops.
     """
-    # NOTE this does not work for transitive dependencies. We may
+    # NOTE the pip-freeze thing doesnt work for transitive dependencies. We may
     # decide to drop the whole --prefix business, and completely switch
     # over to the new venv even before doing any install
 
@@ -227,6 +246,24 @@ def _prefer_installed(packages: list[str]) -> Iterator[str]:
             logger.warning(f"failed to discern preference for package {package} -- continuing")
             yield package
 
+    def _is_ignorable(top_level: str):
+        is_stdlib = top_level in sys.stdlib_module_names
+        is_local = top_level.startswith("_")  # for __main__, __editable, _distutils_hack, etc
+        return is_stdlib or is_local
+
+    imported = set(name.split(".")[0] for name in sys.modules)
+    for name in imported:
+        if not _is_ignorable(name):
+            maybe_version = _maybe_module_version(name)
+            maybe_dist = _maybe_module_dist(name)
+            if maybe_version is None or maybe_dist is None:
+                logger.warning(f"failed to provide install pin for imported: {name=}, {maybe_dist=}, {maybe_version=}")
+            else:
+                # NOTE we do base_version for like torch 2.11.0+cu130 -> 2.11.0
+                # That way, we still resolve to the installed package, and if
+                # we didnt it would actually fail to be resolved
+                yield f"{maybe_dist}=={maybe_version.base_version}"
+
 
 class PackagesEnv(AbstractContextManager):
     def __init__(self) -> None:
@@ -251,11 +288,14 @@ class PackagesEnv(AbstractContextManager):
         _, install_output = run_command(install_command)
         logger.debug(f"install result: {install_output}")
 
-        # NOTE this is wrong because we would need to reliably unload modules, but that apparently aint possible in python
-        # importlib.invalidate_caches()
         install_issues = _postinstall_verify(install_output)
         if install_issues:
             raise PostinstallException(install_issues)
+
+        # NOTE do *not* invalidate caches before postinstall verify, that could
+        # hide some issues. But afterwards this is important to actually allow
+        # importing the modules
+        importlib.invalidate_caches()
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> Literal[False]:
         sys.path = [p for p in sys.path if self.td is None or not p.startswith(self.td.name)]

--- a/src/cascade/executor/runner/packages.py
+++ b/src/cascade/executor/runner/packages.py
@@ -25,10 +25,11 @@ import sys
 import tempfile
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from typing import Iterator, Literal, cast
+from typing import Callable, Iterator, Literal, cast
 
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
+from typing_extensions import Self
 
 from cascade.low.exceptions import CascadeInternalError, CascadeUserError
 
@@ -52,23 +53,77 @@ class Commands:
     freeze_command = ["uv", "pip", "freeze"]
 
 
-def run_command(command: list[str]) -> tuple[str, str]:
+@dataclass
+class PostverifyIssue:
+    """Coming from post-install check of installed modules"""
+
+    dist_name: str
+    desired_version: Version
+    mod_issues: list[tuple[str, Version]]
+
+
+@dataclass
+class ResolutionIssue:
+    """Coming from pip when receiving conflicting instructions"""
+
+    because: str
+
+
+class PkgInstallException(BaseException):
+    issues: list[PostverifyIssue | ResolutionIssue]
+    was_clean: bool
+
+    def __init__(self, issues: list[PostverifyIssue | ResolutionIssue], was_clean: bool) -> None:
+        self.issues = issues
+        self.was_clean = was_clean
+
+    def __str__(self) -> str:
+        return f"failed to install correctly: {repr(self.issues)}, {self.was_clean=}"
+
+    @classmethod
+    def from_pip(cls, pip_stderr: str, was_clean: bool) -> Self | None:
+        # TODO improve
+        intro = "No solution found when resolving dependencies"
+        pref = "Because "
+        suff = ", we can conclude"
+        if intro in pip_stderr and pref in pip_stderr:
+            p1 = pip_stderr.split(pref, 1)[1]
+            if suff in p1:
+                l = ResolutionIssue(p1.split(suff, 1)[0])
+                return cls([l], was_clean)
+        return None
+
+
+def run_command(command: list[str], checker: Callable[[subprocess.CompletedProcess], None]) -> subprocess.CompletedProcess:
     try:
         result = subprocess.run(command, check=False, capture_output=True, text=True)
     except FileNotFoundError as ex:
         # either badly deployed or code bug of calling bad command -> InternalError
         raise CascadeInternalError(f"command failure: {ex}", parent=ex) from ex
+    checker(result)
+    return result
+
+
+def check_run_result(result: subprocess.CompletedProcess) -> None:
     if result.returncode != 0:
         msg = f"command failed with {result.returncode}. Stderr: {result.stderr}, Stdout: {result.stdout}, Args: {result.args}"
         logger.error(msg)
+        raise CascadeInternalError(msg)
 
+
+def check_install_result(result: subprocess.CompletedProcess, was_clean: bool) -> None:
+    if result.returncode != 0:
+        msg = f"command failed with {result.returncode}. Stderr: {result.stderr}, Stdout: {result.stdout}, Args: {result.args}"
+        logger.error(msg)
         if "was not found in the package registry" in result.stderr:
             # presumably bad job env -> UserError
             raise CascadeUserError(msg)
+        elif (ex := PkgInstallException.from_pip(result.stderr, was_clean)) is not None:
+            # possibly conflict of user req with installed
+            raise ex
         else:
             # no idea -> InternalError
             raise CascadeInternalError(msg)
-    return result.stdout, result.stderr
 
 
 def new_venv() -> tempfile.TemporaryDirectory:
@@ -79,7 +134,7 @@ def new_venv() -> tempfile.TemporaryDirectory:
     td = tempfile.TemporaryDirectory(prefix="cascade_runner_venv_")
     # NOTE we create a venv instead of just plain directory, because some of the packages create files
     # outside of site-packages. Thus we then install with --prefix, not with --target
-    run_command(Commands.venv_command(td.name))
+    run_command(Commands.venv_command(td.name), check_run_result)
 
     # NOTE not sure if getsitepackages was intended for this -- if issues, attempt replacing
     # with something like f"{td.name}/lib/python*/site-packages" + globbing
@@ -149,29 +204,12 @@ def _maybe_module_version(mod_name: str) -> Version | None:
             try:
                 return Version(mod.__version__)
             except Exception as e:
-                logger.warning(f"failed to parse module {mod_name} version {mod.__version__} due to {repr(e)}-- ignoring!")
+                logger.debug(f"failed to parse module {mod_name} version {mod.__version__} due to {repr(e)}-- ignoring!")
         else:
-            logging.warning(f"Module '{mod_name}' is loaded, but has no __version__ attribute -- ignoring")
+            logging.debug(f"Module '{mod_name}' is loaded, but has no __version__ attribute -- ignoring")
 
 
-@dataclass
-class InstallIssue:
-    dist_name: str
-    desired_version: Version
-    mod_issues: list[tuple[str, Version]]
-
-
-class PostinstallException(BaseException):
-    issues: list[InstallIssue]
-
-    def __init__(self, issues: list[InstallIssue]) -> None:
-        self.issues = issues
-
-    def __str__(self) -> str:
-        return f"failed to install correctly: {repr(self.issue)}"
-
-
-def _postinstall_verify(pip_output) -> list[InstallIssue]:
+def _postinstall_verify(pip_output) -> list[PostverifyIssue]:
     installed_packages = _parse_pip_install(pip_output)
     rv = []
 
@@ -184,7 +222,7 @@ def _postinstall_verify(pip_output) -> list[InstallIssue]:
         # that checkpoints et cetera won't ever depend on this particular build discriminator => .base_version
         mod_issues = [(m, v) for m, v in versions if v and v.base_version != desired_version.base_version]
         if mod_issues:
-            rv.append(InstallIssue(dist_name=dist_name, desired_version=desired_version, mod_issues=mod_issues))
+            rv.append(PostverifyIssue(dist_name=dist_name, desired_version=desired_version, mod_issues=mod_issues))
 
     return rv
 
@@ -204,7 +242,7 @@ def _prefer_installed(packages: list[str]) -> Iterator[str]:
     # decide to drop the whole --prefix business, and completely switch
     # over to the new venv even before doing any install
 
-    installed_raw, _ = run_command(Commands.freeze_command)
+    installed_raw = run_command(Commands.freeze_command, check_run_result).stdout
 
     def maybe_tuple(kv: str) -> None | tuple[str, str]:
         if kv.startswith("-e"):
@@ -257,7 +295,7 @@ def _prefer_installed(packages: list[str]) -> Iterator[str]:
             maybe_version = _maybe_module_version(name)
             maybe_dist = _maybe_module_dist(name)
             if maybe_version is None or maybe_dist is None:
-                logger.warning(f"failed to provide install pin for imported: {name=}, {maybe_dist=}, {maybe_version=}")
+                logger.debug(f"failed to provide install pin for imported: {name=}, {maybe_dist=}, {maybe_version=}")
             else:
                 # NOTE we do base_version for like torch 2.11.0+cu130 -> 2.11.0
                 # That way, we still resolve to the installed package, and if
@@ -268,6 +306,7 @@ def _prefer_installed(packages: list[str]) -> Iterator[str]:
 class PackagesEnv(AbstractContextManager):
     def __init__(self) -> None:
         self.td: tempfile.TemporaryDirectory | None = None
+        self.clean = True
 
     def extend(self, packages: list[str]) -> None:
         if not packages:
@@ -285,17 +324,19 @@ class PackagesEnv(AbstractContextManager):
             install_command += ["--cache-dir", cache_dir]
         install_command.extend(set(packages))
         logger.debug(f"running install command: {' '.join(install_command)}")
-        _, install_output = run_command(install_command)
+        install_output = run_command(install_command, lambda r: check_install_result(r, self.clean)).stderr
         logger.debug(f"install result: {install_output}")
 
         install_issues = _postinstall_verify(install_output)
         if install_issues:
-            raise PostinstallException(install_issues)
+            install_issues = cast(list[PostverifyIssue | ResolutionIssue], install_issues)
+            raise PkgInstallException(install_issues, self.clean)
 
         # NOTE do *not* invalidate caches before postinstall verify, that could
         # hide some issues. But afterwards this is important to actually allow
         # importing the modules
         importlib.invalidate_caches()
+        self.clean = False
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> Literal[False]:
         sys.path = [p for p in sys.path if self.td is None or not p.startswith(self.td.name)]

--- a/tests/cascade/executor/test_packages.py
+++ b/tests/cascade/executor/test_packages.py
@@ -80,14 +80,18 @@ def test_postinstall_verify() -> None:
 
 def test_prefer_installed() -> None:
     import numpy
+    import packaging
+    import pytest
 
-    assert list(_prefer_installed(["numpy"])) == [f"numpy=={numpy.__version__}"], (
-        "unrestricted spec of installed pkg didnt resolve to installed pkg"
-    )
-    assert list(_prefer_installed(["numpy==1.0.0"])) == ["numpy==1.0.0"], (
+    assert set(_prefer_installed(["numpy"])) >= {
+        f"numpy=={numpy.__version__}",
+        f"packaging=={packaging.__version__}",
+        f"pytest=={pytest.__version__}",
+    }, "unrestricted spec of installed pkg didnt resolve to installed pkg"
+    assert set(_prefer_installed(["numpy==1.0.0"])) >= {"numpy==1.0.0"}, (
         "exact pin spec of installed pkg which is compatible didnt match installed version"
     )
-    assert list(_prefer_installed([f"numpy>={numpy.__version__}"])) == [f"numpy=={numpy.__version__}"], (
+    assert set(_prefer_installed([f"numpy>={numpy.__version__}"])) >= {f"numpy=={numpy.__version__}"}, (
         "range spec of installed pkg which is compatible didnt match installed version"
     )
-    assert list(_prefer_installed(["grumpy==42.0.0"])) == ["grumpy==42.0.0"], "spec of uninstalled package got dropped"
+    assert set(_prefer_installed(["grumpy==42.0.0"])) >= {"grumpy==42.0.0"}, "spec of uninstalled package got dropped"

--- a/tests/cascade/executor/test_packages.py
+++ b/tests/cascade/executor/test_packages.py
@@ -4,12 +4,14 @@ import pytest
 from packaging.version import Version
 
 from cascade.executor.runner.packages import (
-    InstallIssue,
+    PostverifyIssue,
     _get_dist_modules,
     _maybe_module_version,
     _parse_pip_install,
     _postinstall_verify,
     _prefer_installed,
+    check_install_result,
+    check_run_result,
     run_command,
 )
 from cascade.low.exceptions import CascadeInternalError, CascadeUserError
@@ -20,7 +22,7 @@ def test_run_command() -> None:
     bad1_command = ["you", "shall", "not", "pass"]
     bad2_command = ["uv", "pip", "install", "nonexistentpackagename"]
 
-    run_command(succ_command)
+    run_command(succ_command, check_run_result)
 
     with pytest.raises(
         CascadeInternalError,
@@ -28,12 +30,12 @@ def test_run_command() -> None:
             "command failure: [Errno 2] No such file or directory: 'you' (caused by FileNotFoundError(2, 'No such file or directory'))"
         ),
     ):
-        run_command(bad1_command)
+        run_command(bad1_command, check_run_result)
     with pytest.raises(
         CascadeUserError,
         match=r"nonexistentpackagename was not found in the package registry",
     ):
-        run_command(bad2_command)
+        run_command(bad2_command, lambda e: check_install_result(e, True))
 
 
 def test_parse_pip_install() -> None:
@@ -42,7 +44,7 @@ def test_parse_pip_install() -> None:
     assert _parse_pip_install(assumed) == expected, "failed to parse assumed uv output"
     import numpy
 
-    _, actual = run_command(["uv", "pip", "install", f"numpy=={numpy.__version__}"])
+    actual = run_command(["uv", "pip", "install", f"numpy=={numpy.__version__}"], lambda e: check_install_result(e, True)).stderr
     expected = {}
     assert _parse_pip_install(actual) == expected, "failed to parse actual uv output"
     # TODO it would be nice to actually do some pip install here, but im reluctant to do that in a unit test. Some for test_postinstall_verify
@@ -75,7 +77,9 @@ def test_postinstall_verify() -> None:
     assert not issues
     baddie = "Using Python 3.11.8 environment at: <venv>\nResolved 1 package in 5ms\nUninstalled 1 package in 12ms\nInstalled 1 package in 18ms\n - numpy==2.4.2\n + numpy==1.0.0\n"
     issues = _postinstall_verify(baddie)
-    assert issues == [InstallIssue(dist_name="numpy", desired_version=Version("1.0.0"), mod_issues=[("numpy", Version(numpy.__version__))])]
+    assert issues == [
+        PostverifyIssue(dist_name="numpy", desired_version=Version("1.0.0"), mod_issues=[("numpy", Version(numpy.__version__))])
+    ]
 
 
 def test_prefer_installed() -> None:


### PR DESCRIPTION
1/ adds a trivial torch integration test with two steps to verify we install correctly
2/ pins already imported modules to the pip install command, to handle installs going rogue with transitive dependencies. As a side effect some post-install issues now happen during install
3/ changes the reporting of install issues to also handle eg asking for a non-existent package correctly
4/ creates the temporary venv for prefix with the correct python version
5/ prevents a crash-loop in case a clean venv install fails