### PR TITLE
[cascade.packages] eccodes package breaks installs, we hotfix

### DIFF
--- a/src/cascade/executor/runner/packages.py
+++ b/src/cascade/executor/runner/packages.py
@@ -197,8 +197,20 @@ def _maybe_module_dist(module_name: str) -> str | None:
 
 
 def _maybe_module_version(mod_name: str) -> Version | None:
+    # NOTE do *not* rely on importlib.metadat.version, because that
+    # reports what pip installed recently, not what is imported!
     # TODO presumably cacheable, unless None
     if mod_name in sys.modules:
+        if mod_name in ("eccodes", "gribapi"):
+            # the eccodes/gribapi __version__ is wrong, reporting that of eccodes
+            # we must go to the importlib. This *invalidates* the post install
+            # check -- TODO after eccodes wheel fixed, remove this
+            dist_name = _maybe_module_dist(mod_name)
+            if dist_name is not None:
+                try:
+                    return Version(importlib.metadata.version(dist_name))
+                except importlib.metadata.PackageNotFoundError:
+                    pass
         mod = sys.modules[mod_name]
         if hasattr(mod, "__version__"):
             try:


### PR DESCRIPTION
Sadly there is no good solution which would simultaneously make the pre-install pin and post-install check work for eccodes

We thus opt for reliability on pre-install, and cross fingers for post install match on eccodes