### PR TITLE
[cascade] fix runner restarts and publishes

### DIFF
--- a/integration_tests/job_numpyTrivial.py
+++ b/integration_tests/job_numpyTrivial.py
@@ -1,0 +1,31 @@
+"""
+A line of numpy operations
+"""
+
+from base import JobSpec  # ty:ignore[unresolved-import]
+
+from cascade.low.builders import JobBuilder, TaskBuilder
+from cascade.low.core import JobInstance, JobInstanceRich
+
+
+def job() -> JobInstanceRich:
+    fac = lambda version: TaskBuilder.from_entrypoint(
+        "runtime.check_numpy_version",
+        {"expected": "str"},
+        "bool",
+        [f"numpy=={version}"],
+    ).with_values(expected=version)
+
+    b = JobBuilder()
+    b = b.with_node("source", TaskBuilder.from_entrypoint("runtime.source_numpy", {}, "numpy.ndarray", ["numpy"]))
+    b = b.with_node(
+        "t1", TaskBuilder.from_entrypoint("runtime.transform_numpy", {"a": "numpy.ndarray"}, "numpy.ndarray", ["numpy"])
+    ).with_edge("source", "t1", "a")
+    b = b.with_node(
+        "t2", TaskBuilder.from_entrypoint("runtime.transform_numpy", {"a": "numpy.ndarray"}, "numpy.ndarray", ["numpy==2.0.0"])
+    ).with_edge("t1", "t2", "a")
+    return JobInstanceRich(jobInstance=b.build().get_or_raise(), checkpointSpec=None)
+
+
+def spc() -> JobSpec:
+    return JobSpec(workers=1, hosts=1)

--- a/integration_tests/runtime/__init__.py
+++ b/integration_tests/runtime/__init__.py
@@ -39,3 +39,13 @@ def source_tensor() -> "torch.Tensor":  # ty: ignore
 
 def transform_tensorsum(t: "torch.Tensor") -> int:  # ty: ignore
     return int(t.sum())
+
+
+def source_numpy() -> "numpy.ndarray":  # ty: ignore
+    import numpy
+
+    return numpy.array([1])
+
+
+def transform_numpy(a: "numpy.ndarray") -> "numpy.ndarray":  # ty: ignore
+    return a + 1

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -323,11 +323,15 @@ class Executor:
                         if not m.worker in self.worker_awaits:
                             logger.warning(f"unexpectedly gotten WorkerReady from {m.worker}, assuming double send")
                         else:
+                            handle = self.workers[m.worker]
+                            if handle is None:
+                                raise CascadeInternalError(f"worker {m.worker} is alive but has no handle")
+                            for ds in self.datasets:
+                                # populate worker with all available datasets
+                                dsm = DatasetPublished(ds=ds, origin=self.host, transmit_idx=None)
+                                callback(worker_address(m.worker, handle.attempt_cnt), dsm)
                             maybe_seq = self.worker_awaits.pop(m.worker)
                             if maybe_seq is not None:
-                                handle = self.workers[m.worker]
-                                if handle is None:
-                                    raise CascadeInternalError(f"worker {m.worker} is alive but has no handle")
                                 address = worker_address(m.worker, handle.attempt_cnt)
                                 logger.debug(f"worker {m.worker} ready, sending task sequence {maybe_seq} to {address}")
                                 callback(address, maybe_seq)

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -238,6 +238,7 @@ def entrypoint(runnerContextClpkl: bytes):
                     DatasetId(task, key) for task in mDes.tasks for key, _ in runnerContext.job.tasks[task].definition.output_schema
                 }
                 missing_ds = required - availab_ds
+                logger.debug(f"received task sequence {mDes}, and missing {missing_ds}")
                 if Config.pretask_flush:
                     extraneous_ds = availab_ds - required
                     memory.flush(extraneous_ds)

--- a/src/cascade/executor/runner/memory.py
+++ b/src/cascade/executor/runner/memory.py
@@ -41,7 +41,15 @@ class Memory(AbstractContextManager):
         self.callback = callback
         self.worker = worker
 
-    def _publish(self, outputId: DatasetId, outputSchema: str, outputValue: Any):
+    def _build_publish_message(self, outputId: DatasetId, isTaskCompletion: bool) -> DatasetPublished:
+        # TODO we should fine-grain host-wide
+        # and worker-only publishes at the `controller.notify` level, to not cause
+        # incorrect shm.purge calls at worklow end, which log an annoying key error
+        # In the case of local publishes due to runner restart during a task sequence,
+        # we even need to hotfix transmit_idx=-1 to not *crash* the controller with a double completion!
+        return DatasetPublished(ds=outputId, origin=self.worker, transmit_idx=None if isTaskCompletion else -1)
+
+    def _publish(self, outputId: DatasetId, outputSchema: str, outputValue: Any, isTaskCompletion: bool):
         logger.debug(f"publishing {outputId}")
         shmid = ds2shmid(outputId)
         result_ser, deser_fun = timer(serde.ser_output, Microtrace.wrk_ser)(outputValue, outputSchema)
@@ -49,17 +57,14 @@ class Memory(AbstractContextManager):
         rbuf = shm_client.allocate(shmid, l, deser_fun)
         rbuf.view()[:l] = result_ser
         rbuf.close()
-        callback(
-            self.callback,
-            DatasetPublished(ds=outputId, origin=self.worker, transmit_idx=None),
-        )
+        callback(self.callback, self._build_publish_message(outputId, isTaskCompletion))
 
     def additional_publish_local(self, outputIds: Iterable[tuple[DatasetId, str]]):
         # if eg due to a runner crash we need to interrupt a task sequence, it may
         # trigger a publish of datasets which originally were not published
         for outputId, outputSchema in outputIds:
             outputValue = self.local[outputId]  # KeyError here is *not* expected
-            self._publish(outputId, outputSchema, outputValue)
+            self._publish(outputId, outputSchema, outputValue, False)
 
     def handle(self, outputId: DatasetId, outputSchema: str, outputValue: Any, isPublish: bool) -> None:
         if outputId == NO_OUTPUT_PLACEHOLDER:
@@ -72,19 +77,14 @@ class Memory(AbstractContextManager):
         self.local[outputId] = outputValue
 
         if isPublish:
-            self._publish(outputId, outputSchema, outputValue)
+            self._publish(outputId, outputSchema, outputValue, True)
         else:
             # NOTE even if its not actually published, we send the message to allow for
             # marking the task itself as completed -- its odd, but arguably better than
-            # introducing a TaskCompleted message. TODO we should fine-grain host-wide
-            # and worker-only publishes at the `controller.notify` level, to not cause
-            # incorrect shm.purge calls at worklow end, which log an annoying key error
+            # introducing a TaskCompleted message.
             logger.debug(f"fake publish of {outputId} for the sake of task completion")
             shmid = ds2shmid(outputId)
-            callback(
-                self.callback,
-                DatasetPublished(ds=outputId, origin=self.worker, transmit_idx=None),
-            )
+            callback(self.callback, self._build_publish_message(outputId, True))
 
     def provide(self, inputId: DatasetId, annotation: str) -> Any:
         if inputId not in self.local:


### PR DESCRIPTION
two things happening here:
1. When we get a runnerrestart due to a task crash in the middle of a sequence, this issues a second dataset publish, which causes the controller to crash. We fix it by relying on the current hack of transmit_idx != None => not a task-finishing-publish
2. When a worker is restarted, it does not have any datasets populated. We fix it by issuing targeted publishes right after restarted worker reports readiness

lastly, we add an integration test which previously failed and now suceeds
