### PR TITLE
feat: give each worker its own dedicated venv

### DIFF
--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -29,4 +29,5 @@ jobs:
           echo "uv version is $(uv --version)"
           uv sync --python "${{ matrix.python_version }}"
           just fmt
-          just val
+          # linux hosted runners have tmp mounted with noexec or smth like that
+          if [[ "${{ matrix.arch_type }}" == "linux"* ]] ; then CASCADE_VENV_ROOT=$(pwd) just val ; else just val ; fi

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -16,16 +16,19 @@ the tasks themselves.
 # have their own zmq server as well as run the callables themselves
 
 import atexit
+import base64
 import logging
 import os
+import subprocess
+import tempfile
 import uuid
 from dataclasses import dataclass
-from multiprocessing.process import BaseProcess
 from typing import Iterable
 
 import cloudpickle
 
 import cascade.executor.platform as platform
+import cascade.executor.runner.setup as runner_setup
 import cascade.shm.api as shm_api
 import cascade.shm.client as shm_client
 from cascade.deployment.logging import LoggingConfig, as_dict_config
@@ -56,7 +59,7 @@ from cascade.executor.msg import (
     WorkerReady,
     WorkerShutdown,
 )
-from cascade.executor.runner.entrypoint import RunnerContext, entrypoint, worker_address
+from cascade.executor.runner.entrypoint import RunnerContext, worker_address
 from cascade.low.core import DatasetId, HostId, JobInstance, TaskId, WorkerId
 from cascade.low.exceptions import CascadeError, CascadeInfrastructureError, CascadeInternalError, CascadeUserError, ser
 from cascade.low.tracing import TaskLifecycle, mark
@@ -76,8 +79,9 @@ def address_of(port: int) -> BackboneAddress:
 
 @dataclass
 class WorkerHandle:
-    process: BaseProcess
+    process: subprocess.Popen[bytes]
     attempt_cnt: int
+    venv_dir: tempfile.TemporaryDirectory[str]
 
 
 class Executor:
@@ -100,7 +104,7 @@ class Executor:
         self.workers: dict[WorkerId, WorkerHandle | None] = {WorkerId(host, f"w{i}"): None for i in range(workers)}
         self.worker_awaits: dict[WorkerId, None | TaskSequence] = {}
         self.loggingConfig = loggingConfig
-        self.old_processes: list[BaseProcess] = []
+        self.old_workers: list[tuple[subprocess.Popen[bytes], tempfile.TemporaryDirectory[str]]] = []
 
         self.datasets: set[DatasetId] = set()
         self.heartbeat_watcher = GraceWatcher(grace_ms=heartbeat_grace_ms)
@@ -171,15 +175,20 @@ class Executor:
             try:
                 if (handle := self.workers[worker]) is not None:
                     callback(worker_address(worker, handle.attempt_cnt), WorkerShutdown())
-                    handle.process.join()
+                    handle.process.wait()
+                    try:
+                        handle.venv_dir.cleanup()
+                    except Exception as e:
+                        logger.warning(f"failed to cleanup venv for {worker}: {repr(e)}")
             except Exception as e:
                 logger.warning(f"gotten {repr(e)} when shutting down {worker}")
-        for proc in self.old_processes:
+        for proc, venv in self.old_workers:
             logger.debug(f"cleanup old process {proc.pid}")
             try:
-                proc.join()
+                proc.wait()
+                venv.cleanup()
             except Exception as e:
-                logger.warning(f"gotten {repr(e)} when shutting down {proc.pid}")
+                logger.warning(f"gotten {repr(e)} when shutting down old worker {proc.pid}")
         if hasattr(self, "shm_process") and self.shm_process is not None and self.shm_process.is_alive():
             try:
                 shm_client.shutdown()
@@ -194,7 +203,6 @@ class Executor:
         self.sender.send(HostId("controller"), m)
 
     def _start_worker(self, worker: WorkerId, attempt_cnt: int, seq: None | TaskSequence) -> WorkerHandle:
-        ctx = platform.get_mp_ctx("worker")
         runnerContext = RunnerContext(
             workerId=worker,
             workerAttemptCnt=attempt_cnt,
@@ -205,15 +213,18 @@ class Executor:
             schema_lookup=self.schema_lookup,
         )
         # NOTE we need to cloudpickle because runnerContext contains some lambdas
-        p = ctx.Process(
-            target=entrypoint,
-            kwargs={"runnerContextClpkl": cloudpickle.dumps(runnerContext)},
+        runnerContextClpkl = cloudpickle.dumps(runnerContext)
+        encoded = base64.b64encode(runnerContextClpkl).decode()
+        venv_td = runner_setup.create_venv()
+        p = runner_setup.launch_in_venv(
+            "cascade.executor.runner.entrypoint",
+            venv_td.name,
+            {runner_setup.CONTEXT_ENVVAR: encoded},
         )
-        p.start()
         if worker in self.worker_awaits:
             raise CascadeInternalError(f"{worker=} was already awaiting")
         self.worker_awaits[worker] = seq
-        return WorkerHandle(process=p, attempt_cnt=attempt_cnt)
+        return WorkerHandle(process=p, attempt_cnt=attempt_cnt, venv_dir=venv_td)
 
     def start_workers(self, workers: Iterable[WorkerId]) -> None:
         # NOTE fork would be better but causes issues on macos+torch with XPC_ERROR_CONNECTION_INVALID
@@ -254,9 +265,9 @@ class Executor:
             if e is None:
                 # this should not really be happening -> InternalError
                 raise CascadeInternalError(f"process on {k} is not alive")
-            elif procFail(e.process.exitcode):
+            elif procFail(e.process.poll()):
                 # we assume low memory setting or callable issue -> UserError
-                raise CascadeUserError(f"process on {k} failed to terminate correctly: {e.process.pid} -> {e.process.exitcode}")
+                raise CascadeUserError(f"process on {k} failed to terminate correctly: {e.process.pid} -> {e.process.poll()}")
         if procFail(self.shm_process.exitcode):
             # possibly low memory setting but this is system config -> InfrastructureError
             raise CascadeInfrastructureError(f"shm server {self.shm_process.pid} failed with {self.shm_process.exitcode}")
@@ -270,10 +281,14 @@ class Executor:
             # NOTE we send registration in place of heartbeat -- it makes the startup more reliable,
             # and the registration's size overhead is negligible
             self.to_controller(self.registration)
-        if self.old_processes and not self.old_processes[0].is_alive():
+        if self.old_workers and self.old_workers[0][0].poll() is not None:
             # we check just the first one for simplicity
-            self.old_processes[0].join()
-            self.old_processes.pop(0)
+            proc, venv = self.old_workers.pop(0)
+            proc.wait()
+            try:
+                venv.cleanup()
+            except Exception as e:
+                logger.warning(f"failed to cleanup old worker venv: {repr(e)}")
 
     def recv_loop(self) -> None:
         logger.debug("entering recv loop")
@@ -292,7 +307,7 @@ class Executor:
                                 }
                             )
                         handle = self.workers[m.worker]
-                        if handle is None or handle.process.exitcode is not None:
+                        if handle is None or handle.process.poll() is not None:
                             # unexpected exit -> InfrastructureError
                             raise CascadeInfrastructureError(f"worker process {m.worker} is not alive")
                         if m.worker in self.worker_awaits:
@@ -342,7 +357,7 @@ class Executor:
                         if handle is None:
                             raise CascadeInternalError("unexpected restart from worker without handle")
                         callback(worker_address(m.worker, handle.attempt_cnt), WorkerShutdown())
-                        self.old_processes.append(handle.process)
+                        self.old_workers.append((handle.process, handle.venv_dir))
                         logger.debug(f"will restart worker {m.worker} with attempt {handle.attempt_cnt + 1}")
                         self.workers[m.worker] = self._start_worker(m.worker, handle.attempt_cnt + 1, m.remainder)
                         self.to_controller(m)

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -377,6 +377,7 @@ class Executor:
                         for worker, handle in self.workers.items():
                             if handle is not None:
                                 callback(worker_address(worker, handle.attempt_cnt), availability_notification)
+                        self.datasets.add(m.ds)
                         self.to_controller(m)
                     elif isinstance(m, JustForwardToController):
                         self.to_controller(m)

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -39,7 +39,7 @@ from cascade.low.core import DatasetId, JobInstance, TaskId, WorkerId, type_dec
 from cascade.low.exceptions import CascadeError, CascadeInfrastructureError, CascadeInternalError, CascadeUserError, ser
 from cascade.low.tracing import label
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__ if __name__ != "__main__" else "cascade.executor.runner.entrypoint")
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -184,7 +184,7 @@ def execute_sequence(
         return False
 
 
-def entrypoint(runnerContextClpkl: bytes):
+def entrypoint(runnerContextClpkl: bytes) -> None:
     """runnerContext is a cloudpickled instance of RunnerContext -- needed for forkserver mp context due to defautdicts"""
     runnerContext = cloudpickle.loads(runnerContextClpkl)
     init_from_obj(runnerContext.loggingConfig, f"worker_{runnerContext.workerId.worker}")
@@ -250,3 +250,13 @@ def entrypoint(runnerContextClpkl: bytes):
                     isTerminating = not execute_sequence(mDes, memory, pckg, runnerContext)
             else:
                 raise CascadeInternalError(f"unexpected message received: {type(mDes)}")
+
+
+if __name__ == "__main__":
+    import base64
+
+    from cascade.executor.runner.setup import CONTEXT_ENVVAR
+
+    _encoded = os.environ[CONTEXT_ENVVAR]
+    _runnerContextClpkl = base64.b64decode(_encoded)
+    entrypoint(_runnerContextClpkl)

--- a/src/cascade/executor/runner/packages.py
+++ b/src/cascade/executor/runner/packages.py
@@ -19,10 +19,8 @@ import importlib.metadata
 import logging
 import os
 import re
-import site
 import subprocess
 import sys
-import tempfile
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import Callable, Iterator, Literal, cast
@@ -41,12 +39,10 @@ _python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.versi
 
 class Commands:
     venv_command = lambda name: ["uv", "venv", "--python", _python_version, name]
-    install_command = lambda name: [
+    install_command = [
         "uv",
         "pip",
         "install",
-        "--prefix",
-        name,
         "--prerelease",
         "explicit",
     ]
@@ -124,27 +120,6 @@ def check_install_result(result: subprocess.CompletedProcess, was_clean: bool) -
         else:
             # no idea -> InternalError
             raise CascadeInternalError(msg)
-
-
-def new_venv() -> tempfile.TemporaryDirectory:
-    """1. Creates a new temporary directory with a venv inside.
-    2. Extends sys.path so that packages in that venv can be imported.
-    """
-    logger.debug("creating a new venv")
-    td = tempfile.TemporaryDirectory(prefix="cascade_runner_venv_")
-    # NOTE we create a venv instead of just plain directory, because some of the packages create files
-    # outside of site-packages. Thus we then install with --prefix, not with --target
-    run_command(Commands.venv_command(td.name), check_run_result)
-
-    # NOTE not sure if getsitepackages was intended for this -- if issues, attempt replacing
-    # with something like f"{td.name}/lib/python*/site-packages" + globbing
-    extra_sp = site.getsitepackages(prefixes=[td.name])
-    # NOTE this makes the explicit packages go first, in case of a different version
-    logger.debug(f"extending sys.path with {extra_sp}")
-    sys.path = extra_sp + sys.path
-    logger.debug(f"new sys.path: {sys.path}")
-
-    return td
 
 
 def _parse_pip_install(pip_output: str) -> dict[str, Version]:
@@ -331,19 +306,16 @@ def _prefer_installed(packages: list[str]) -> Iterator[str]:
 
 class PackagesEnv(AbstractContextManager):
     def __init__(self) -> None:
-        self.td: tempfile.TemporaryDirectory | None = None
         self.clean = True
 
     def extend(self, packages: list[str]) -> None:
         if not packages:
             return
-        if self.td is None:
-            self.td = new_venv()
         packages = list(_prefer_installed(packages))
 
         logger.debug(f"installing {len(packages)} packages")
         logger.debug(f"installing packages: {','.join(packages)}")
-        install_command = Commands.install_command(self.td.name)
+        install_command = list(Commands.install_command)
         if os.environ.get("VENV_OFFLINE", "") == "YES":
             install_command += ["--offline"]
         if cache_dir := os.environ.get("VENV_CACHE", ""):
@@ -365,7 +337,4 @@ class PackagesEnv(AbstractContextManager):
         self.clean = False
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> Literal[False]:
-        sys.path = [p for p in sys.path if self.td is None or not p.startswith(self.td.name)]
-        if self.td is not None:
-            self.td.cleanup()
         return False

--- a/src/cascade/executor/runner/setup.py
+++ b/src/cascade/executor/runner/setup.py
@@ -27,6 +27,10 @@ from cascade.executor.runner.packages import check_run_result, run_command
 logger = logging.getLogger(__name__)
 
 CONTEXT_ENVVAR = "CASCADE_RUNNER_CONTEXT"
+# NOTE on some systems, default /tmp can be mounted with noexec, leading to issues at runtime
+# like 'failed to map segment from shared object' for binary dependencies like zmq
+# Thus override this envvar to some exec-mounted filesystem
+venv_root = os.environ.get("CASCADE_VENV_ROOT", None)
 
 _python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 
@@ -55,8 +59,8 @@ def _earthkit_install_spec() -> str:
 
 def create_venv() -> tempfile.TemporaryDirectory:  # type: ignore[type-arg]
     """Creates a new temporary venv with earthkit-workflows installed at the same version as the parent process."""
-    logger.debug("creating a new worker venv")
-    td: tempfile.TemporaryDirectory = tempfile.TemporaryDirectory(prefix="cascade_worker_venv_")  # type: ignore[type-arg]
+    td = tempfile.TemporaryDirectory(prefix="cascade_worker_venv_", dir=venv_root)
+    logger.debug(f"creating a new worker venv at {td}")
     run_command(["uv", "venv", "--python", _python_version, td.name], check_run_result)
     python = _venv_python(td.name)
     install_spec = _earthkit_install_spec()
@@ -92,7 +96,7 @@ def launch_in_venv(module: str, venv_dir: str, envvars: dict[str, str]) -> "subp
     return subprocess.Popen([python, "-m", module], env=env)
 
 
-def terminate_worker(process: "subprocess.Popen[bytes]", venv_dir: "tempfile.TemporaryDirectory[str]") -> None:
+def terminate_worker(process: subprocess.Popen[bytes], venv_dir: tempfile.TemporaryDirectory[str]) -> None:
     """Terminates the worker process and cleans up its venv directory."""
     if process.poll() is None:
         process.terminate()

--- a/src/cascade/executor/runner/setup.py
+++ b/src/cascade/executor/runner/setup.py
@@ -1,0 +1,107 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Worker venv creation and process launching.
+
+Each worker owns its own temporary venv. This module handles:
+ - creation of a temporary venv with the same Python version and an initial earthkit-workflows install
+ - launching a Python module as a subprocess inside that venv
+ - cleanup/termination of both the process and the venv directory
+"""
+
+import importlib.metadata
+import json
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+
+from cascade.executor.runner.packages import check_run_result, run_command
+
+logger = logging.getLogger(__name__)
+
+CONTEXT_ENVVAR = "CASCADE_RUNNER_CONTEXT"
+
+_python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+
+
+def _earthkit_install_spec() -> str:
+    """Returns the install spec for earthkit-workflows suitable for uv pip install.
+
+    For editable/source installs (dev mode), uses the local source path directly.
+    Otherwise, pins to the currently installed version.
+    """
+    ek_version = importlib.metadata.version("earthkit-workflows")
+    try:
+        dist = importlib.metadata.distribution("earthkit-workflows")
+        direct_url_text = dist.read_text("direct_url.json")
+        if direct_url_text:
+            info = json.loads(direct_url_text)
+            url = info.get("url", "")
+            if url.startswith("file://") and info.get("dir_info", {}).get("editable", False):
+                path = url[len("file://") :]
+                logger.debug(f"earthkit-workflows is an editable install at {path}")
+                return path
+    except Exception as e:
+        logger.debug(f"could not read direct_url.json for earthkit-workflows: {repr(e)}")
+    return f"earthkit-workflows=={ek_version}"
+
+
+def create_venv() -> tempfile.TemporaryDirectory:  # type: ignore[type-arg]
+    """Creates a new temporary venv with earthkit-workflows installed at the same version as the parent process."""
+    logger.debug("creating a new worker venv")
+    td: tempfile.TemporaryDirectory = tempfile.TemporaryDirectory(prefix="cascade_worker_venv_")  # type: ignore[type-arg]
+    run_command(["uv", "venv", "--python", _python_version, td.name], check_run_result)
+    python = _venv_python(td.name)
+    install_spec = _earthkit_install_spec()
+    logger.debug(f"installing {install_spec} into worker venv")
+    run_command(
+        ["uv", "pip", "install", "--python", python, install_spec],
+        check_run_result,
+    )
+    return td
+
+
+def _venv_python(venv_dir: str) -> str:
+    return os.path.join(venv_dir, "bin", "python")
+
+
+def launch_in_venv(module: str, venv_dir: str, envvars: dict[str, str]) -> "subprocess.Popen[bytes]":
+    """Launches `python -m module` inside the given venv with the provided environment variables.
+
+    The parent process's non-venv sys.path entries are forwarded via PYTHONPATH so that
+    cloudpickle-serialized callables referencing caller-side modules (e.g. test modules,
+    editable source trees) can be unpickled in the worker.
+    """
+    python = _venv_python(venv_dir)
+    # Forward non-venv paths so cloudpickle can resolve module references from the parent
+    parent_venv = sys.prefix
+    extra_paths = [p for p in sys.path if p and not p.startswith(parent_venv)]
+    pythonpath = os.pathsep.join(extra_paths)
+    env = {**os.environ, **envvars, "VIRTUAL_ENV": venv_dir}
+    if pythonpath:
+        existing = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = f"{pythonpath}{os.pathsep}{existing}" if existing else pythonpath
+    logger.debug(f"launching {module} in {venv_dir}")
+    return subprocess.Popen([python, "-m", module], env=env)
+
+
+def terminate_worker(process: "subprocess.Popen[bytes]", venv_dir: "tempfile.TemporaryDirectory[str]") -> None:
+    """Terminates the worker process and cleans up its venv directory."""
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+    try:
+        venv_dir.cleanup()
+    except Exception as e:
+        logger.warning(f"failed to cleanup worker venv: {repr(e)}")

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -175,8 +175,9 @@ def test_executor():
         while expected:
             ms = l.recv_messages()
             for m in ms:
-                logger.debug(f"about to remove received message {m}")
-                expected.remove(m)
+                if not isinstance(m, ExecutorRegistration):  # there may be extra due to retries
+                    logger.debug(f"about to remove received message {m}")
+                    expected.remove(m)
         callback(m1, TaskSequence(worker=w0, tasks=[TaskId("sink")], publish={sink_o}, extra_env=[]))
         expected = [
             DatasetPublished(w0, ds=sink_o, transmit_idx=None),


### PR DESCRIPTION
We switch from --prefix venvs + parent venv into a dedicated venv per each worker. Not optimal, more like a hotfix

We fix one race condition for the checkpoint test (made more likely due to the slowdown here), and make tests more robust