### PR TITLE
refactor(packages): replace pip freeze with cached module->dist mapping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ log_cli = true
 log_cli_level = "DEBUG"
 testpaths = ["tests/"]
 addopts = "-n8"
+markers = ["concurrency_filelock"]
 
 [tool.ruff]
 line-length = 140

--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -104,7 +104,18 @@ class Listener:
     def __init__(self, address: BackboneAddress):
         self.address = address
         self.socket = get_context().socket(zmq.PULL)
-        self.socket.bind(address)
+        attempts = 3
+        while attempts > 0:
+            try:
+                self.socket.bind(address)
+            except zmq.error.ZMQError as e:
+                if attempts == 0:
+                    raise
+                logger.warning(f"got {repr(e)}, half a sec nap")
+                attempts -= 1
+                time.sleep(0.5)
+                continue
+            break
         self.poller = zmq.Poller()
         self.poller.register(self.socket, flags=zmq.POLLIN)
         self.acked: set[Syn] = set()  # TODO eventually pop things from here (timestamp lapse?) to prevent mem growth

--- a/src/cascade/executor/runner/packages.py
+++ b/src/cascade/executor/runner/packages.py
@@ -31,7 +31,7 @@ import subprocess
 import sys
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from typing import Callable, Literal, cast
+from typing import Callable, Iterable, Literal, cast
 
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
@@ -250,12 +250,17 @@ class PackagesEnv(AbstractContextManager):
         # modules without a dist are typically oddities and gaining a dist post-install
         # is not a realistic scenario we need to handle.
         self._dist_name_cache: dict[str, str | None] = {}
+        # Pre-populate cache for the initially installed packages so that packages_distributions()
+        # is not needed for those modules when they are later imported.
+        self._cache_dist_modules(self._installed)
 
     def _populate_dist_cache(self, mod_names: set[str]) -> None:
         """Batch-populate the dist_name cache for a set of module names.
 
-        Calls packages_distributions() once for all uncached modules, avoiding
-        repeated expensive metadata scans.
+        Falls back to packages_distributions() for modules not already cached by
+        _cache_dist_modules(). packages_distributions() rescans all installed package
+        metadata (~130ms on a typical venv) so we only call it when there are truly
+        uncached modules that need lookup.
         """
         new_mods = {m for m in mod_names if m not in self._dist_name_cache and not _is_ignorable_module(m)}
         if not new_mods:
@@ -264,6 +269,32 @@ class PackagesEnv(AbstractContextManager):
         for mod in new_mods:
             maybe = pkg_dist.get(mod, [])
             self._dist_name_cache[mod] = maybe[0] if maybe else None
+
+    def _cache_dist_modules(self, dist_names: Iterable[str]) -> None:
+        """Pre-populate the dist_name cache from the dist->modules direction.
+
+        Cheaper than packages_distributions() when only a few dists are known:
+        each individual dist lookup takes ~0.5ms vs ~130ms for a full scan.
+        Called after each install for the newly installed dists, and at __init__
+        for the initially installed packages. This way, when those modules are later
+        imported and _populate_dist_cache() is called, they are already cached and
+        packages_distributions() is not invoked for them.
+        """
+        for dist_name in dist_names:
+            try:
+                handle = importlib.metadata.distribution(dist_name)
+                top_level = handle.read_text("top_level.txt")
+                if top_level:
+                    modules = top_level.split()
+                elif handle.files:
+                    modules = list({path.parts[0] for path in handle.files if path.suffix == ".py"})
+                else:
+                    modules = []
+                for mod in modules:
+                    if not _is_ignorable_module(mod):
+                        self._dist_name_cache[mod] = dist_name
+            except Exception:
+                pass
 
     def _import_pins(self) -> dict[str, Version]:
         """Return {dist_name: version} for all currently imported top-level modules.
@@ -437,6 +468,7 @@ class PackagesEnv(AbstractContextManager):
 
         newly_installed = _parse_pip_install(install_output)
         self._installed.update(newly_installed)
+        self._cache_dist_modules(newly_installed)
 
         install_issues = self._postinstall_verify(install_output)
         if install_issues:

--- a/src/cascade/executor/runner/packages.py
+++ b/src/cascade/executor/runner/packages.py
@@ -6,16 +6,24 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Extending venv with packages required by the executed job
+"""Runtime package management for worker processes.
 
-Note that venv itself is left untouched after the run finishes -- we extend sys path
-with a temporary directory and install in there
+Each worker runs in its own dedicated venv, created initially with earthkit-workflows
+installed. PackagesEnv manages additional runtime pip installs into that venv as
+requested by executed jobs.
 
-When extending, we check that none of the actually installed packages was not imported
-already with a different version
+The central challenge is that if a module is already imported in the process, a pip
+install of a different version of that same module cannot take effect (the old version
+stays loaded). PackagesEnv handles this in two ways:
+
+1. Prevention: before calling pip, it pins already-imported modules to their current
+   versions, and checks for spec conflicts up-front.
+2. Detection: after pip completes, it verifies that no imported module ended up at a
+   mismatched version.
 """
 
 import importlib.metadata
+import json
 import logging
 import os
 import re
@@ -141,23 +149,6 @@ def _parse_pip_install(pip_output: str) -> dict[str, Version]:
     return rv
 
 
-def _get_dist_modules(dist_name: str) -> list[str]:
-    """From package name like 'earthkit-workflows' get the top level importible like 'earthkit', 'cascade'"""
-    try:
-        handle = importlib.metadata.distribution(dist_name)
-        top_level = handle.read_text("top_level.txt")
-        if top_level:
-            return top_level.split()
-        elif handle.files:
-            return list({path.parts[0] for path in handle.files if path.suffix == ".py"})
-        else:
-            logger.warning(f"neither files nor top level for {dist_name} -- ignoring")
-            return []
-    except Exception as e:
-        logging.warning(f"Could not find metadata for installed package: {dist_name} due to {repr(e)} -- ignoring")
-        return []
-
-
 def _maybe_imported_version(mod_name: str) -> Version | None:
     if mod_name in ("eccodes", "gribapi"):
         # the eccodes/gribapi __version__ is wrong, reporting that of eccodeslib
@@ -174,6 +165,37 @@ def _maybe_imported_version(mod_name: str) -> Version | None:
         else:
             logging.debug(f"Module '{mod_name}' is loaded, but has no __version__ attribute -- ignoring")
     return None
+
+
+def _earthkit_install_spec() -> str:
+    """Returns the install spec for earthkit-workflows suitable for uv pip install.
+
+    For editable/source installs (dev mode), uses the local source path directly.
+    Otherwise, pins to the currently installed version.
+    """
+    ek_version = importlib.metadata.version("earthkit-workflows")
+    try:
+        dist = importlib.metadata.distribution("earthkit-workflows")
+        direct_url_text = dist.read_text("direct_url.json")
+        if direct_url_text:
+            info = json.loads(direct_url_text)
+            url = info.get("url", "")
+            if url.startswith("file://") and info.get("dir_info", {}).get("editable", False):
+                path = url[len("file://") :]
+                logger.debug(f"earthkit-workflows is an editable install at {path}")
+                return path
+    except Exception as e:
+        logger.debug(f"could not read direct_url.json for earthkit-workflows: {repr(e)}")
+    return f"earthkit-workflows=={ek_version}"
+
+
+def initial_venv_packages() -> list[str]:
+    """Returns the list of packages to install into a fresh worker venv.
+
+    Used by setup.py to create the initial venv, and by PackagesEnv to
+    pre-populate its installed-packages state.
+    """
+    return [_earthkit_install_spec()]
 
 
 def _is_ignorable_module(top_level: str) -> bool:
@@ -200,9 +222,10 @@ def _is_ignorable_dist(dist_name: str, dist_version: Version) -> bool:
 class PackagesEnv(AbstractContextManager):
     """Context manager responsible for runtime pip installs.
 
-    Tracks what we install and caches the module->dist_name mapping for imported
-    modules. This avoids repeated expensive packages_distributions() scans and
-    eliminates the need for a `pip freeze` call on every extend().
+    Tracks installed packages and caches the module->dist_name mapping for imported
+    modules. importlib.metadata.packages_distributions() is not cached by Python
+    itself (it rescans all package metadata on every call), so we maintain our own
+    permanent per-module cache to avoid repeated scans.
 
     We only protect already-imported modules from version changes: those are the
     only modules that cannot be safely re-loaded in a running process. Non-imported
@@ -211,10 +234,21 @@ class PackagesEnv(AbstractContextManager):
 
     def __init__(self) -> None:
         self.clean = True
-        # dist_name -> version, accumulated from parsed pip output of each extend() call
+        # dist_name -> version, tracks what has been installed into this venv
+        # (pre-populated with the initial earthkit-workflows install from venv creation)
         self._installed: dict[str, Version] = {}
-        # module_name -> dist_name (or None if no dist found), permanently cached per module.
-        # None entries are cleared after each install in case a new dist now provides them.
+        for spec in initial_venv_packages():
+            # parse "name==version" style specs; skip paths (editable installs have no "==")
+            if "==" in spec:
+                name, _, ver_str = spec.partition("==")
+                try:
+                    self._installed[name.strip()] = Version(ver_str.strip())
+                except Exception:
+                    pass
+        # module_name -> dist_name (or None if no dist found).
+        # Populated lazily via _populate_dist_cache(). None entries are kept permanently:
+        # modules without a dist are typically oddities and gaining a dist post-install
+        # is not a realistic scenario we need to handle.
         self._dist_name_cache: dict[str, str | None] = {}
 
     def _populate_dist_cache(self, mod_names: set[str]) -> None:
@@ -234,9 +268,11 @@ class PackagesEnv(AbstractContextManager):
     def _import_pins(self) -> dict[str, Version]:
         """Return {dist_name: version} for all currently imported top-level modules.
 
-        Version is fetched fresh from importlib.metadata (not from __version__),
-        which gives the installed dist version rather than the potentially-decorated
-        __version__ (eg torch adds +cu126, ecmwf libs add a 4th build counter).
+        Version is fetched from importlib.metadata rather than module.__version__,
+        because importlib.metadata gives the pip-installable dist version:
+        - for torch, __version__ adds a local +cu126 tag that is not in the wheel name
+        - for ecmwf libs, __version__ omits the 4th build counter that IS in the wheel name
+        Using importlib.metadata gives us the correct installable version in both cases.
         """
         imported = set(name.split(".")[0] for name in sys.modules)
         self._populate_dist_cache(imported)
@@ -261,9 +297,8 @@ class PackagesEnv(AbstractContextManager):
         """Pin user-requested packages to their currently-imported version where
         compatible, and append pins for all other imported distributions.
 
-        This replaces the old `uv pip freeze` approach. We only protect imported
-        modules because those are the only ones that cannot be safely changed in a
-        running process.
+        We only protect imported modules because those are the only ones that cannot
+        be safely changed in a running process.
         """
         import_pins = self._import_pins()
         result: list[str] = []
@@ -346,8 +381,8 @@ class PackagesEnv(AbstractContextManager):
     def _postinstall_verify(self, pip_output: str) -> list[PostverifyIssue]:
         """Check that no already-imported module has a version mismatch with what pip just installed.
 
-        Uses the dist_name cache (populated by _prefer_installed -> _import_pins) to
-        map module names to distributions without an extra _get_dist_modules() call.
+        Uses the dist_name cache to map module names to distributions, iterating
+        in the import->dist direction (rather than dist->modules) for efficiency.
 
         We compare base_version (stripping local/build parts like +cu126) because pip
         reports the base wheel version while __version__ may include build discriminators.
@@ -402,11 +437,6 @@ class PackagesEnv(AbstractContextManager):
 
         newly_installed = _parse_pip_install(install_output)
         self._installed.update(newly_installed)
-
-        # Clear None cache entries for modules that might now be provided by newly
-        # installed packages. Non-None entries are permanent (dist names don't change).
-        if newly_installed:
-            self._dist_name_cache = {k: v for k, v in self._dist_name_cache.items() if v is not None}
 
         install_issues = self._postinstall_verify(install_output)
         if install_issues:

--- a/src/cascade/executor/runner/packages.py
+++ b/src/cascade/executor/runner/packages.py
@@ -23,7 +23,7 @@ import subprocess
 import sys
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from typing import Callable, Iterator, Literal, cast
+from typing import Callable, Literal, cast
 
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
@@ -46,7 +46,6 @@ class Commands:
         "--prerelease",
         "explicit",
     ]
-    freeze_command = ["uv", "pip", "freeze"]
 
 
 @dataclass
@@ -144,7 +143,6 @@ def _parse_pip_install(pip_output: str) -> dict[str, Version]:
 
 def _get_dist_modules(dist_name: str) -> list[str]:
     """From package name like 'earthkit-workflows' get the top level importible like 'earthkit', 'cascade'"""
-    # TODO presumably cacheable
     try:
         handle = importlib.metadata.distribution(dist_name)
         top_level = handle.read_text("top_level.txt")
@@ -160,28 +158,7 @@ def _get_dist_modules(dist_name: str) -> list[str]:
         return []
 
 
-def _maybe_module_dist(module_name: str) -> tuple[str, Version] | None:
-    """From a module name like 'cascade' get the pip installable like 'earthkit-workflows' and version"""
-    # TODO presumably cacheable, unless None
-    # NOTE we dont rely on __version__, eg:
-    # - for torch it adds the +cu310
-    # - for mir it drops the fourth version
-    # and neither leads to an installable wheel.
-    # NOTE that because of the 4-number version of ecmwf libs, we dont use the base_version here
-    lookup = importlib.metadata.packages_distributions()
-    maybe = lookup.get(module_name, [])
-    if len(maybe) >= 1:
-        distName = maybe[0]
-        try:
-            return distName, Version(importlib.metadata.version(distName))
-        except importlib.metadata.PackageNotFoundError:
-            return None
-    else:
-        return None
-
-
 def _maybe_imported_version(mod_name: str) -> Version | None:
-    # TODO presumably cacheable, unless None
     if mod_name in ("eccodes", "gribapi"):
         # the eccodes/gribapi __version__ is wrong, reporting that of eccodeslib
         # => we must go to the importlib. This *invalidates* the post install
@@ -196,122 +173,220 @@ def _maybe_imported_version(mod_name: str) -> Version | None:
                 logger.debug(f"failed to parse module {mod_name} version {mod.__version__} due to {repr(e)}-- ignoring!")
         else:
             logging.debug(f"Module '{mod_name}' is loaded, but has no __version__ attribute -- ignoring")
+    return None
 
 
-def _postinstall_verify(pip_output) -> list[PostverifyIssue]:
-    installed_packages = _parse_pip_install(pip_output)
-    rv = []
-
-    for dist_name, desired_version in installed_packages.items():
-        modules = _get_dist_modules(dist_name)
-        versions = [(m, _maybe_imported_version(m)) for m in modules]
-        # NOTE eg torch is a bit of an issue here:
-        # pip reports + torch==2.7.1, but torch module version declares 2.7.1+cu126
-        # we have no real means of deciding whether this is correct or not -- but we make the assumption
-        # that checkpoints et cetera won't ever depend on this particular build discriminator => .base_version
-        # For ecmwf libs, this hides the 4th version which is the build counter -- but that is presumably
-        # legitimate as well, as it means the api of the underlying library being the same
-        mod_issues = [(m, v) for m, v in versions if v and v.base_version != desired_version.base_version]
-        if mod_issues:
-            rv.append(PostverifyIssue(dist_name=dist_name, desired_version=desired_version, mod_issues=mod_issues))
-
-    return rv
+def _is_ignorable_module(top_level: str) -> bool:
+    # stdlib modules and private/internal modules (eg __main__, _distutils_hack)
+    return top_level in sys.stdlib_module_names or top_level.startswith("_")
 
 
-def _prefer_installed(packages: list[str]) -> Iterator[str]:
-    """If a package is desired to be installed but is not exactly pinned,
-    we will inspect pip freeze to see if it is already installed, and inject
-    the pin otherwise. This is default `uv` behaviour, but remember we
-    override --prefix, thus uv has no way of knowing. We thus have to explicate.
-
-    Furthermore, we will extend the list with already-imported packages. This
-    moves some PostInstall verify issues into the Install phase, and importantly,
-    for fresh workers and unavoidable dependencies (like orjson or pydantic),
-    forces a pin to prevent unbound resolution infinite loops.
-    """
-    # NOTE the pip-freeze thing doesnt work for transitive dependencies. We may
-    # decide to drop the whole --prefix business, and completely switch
-    # over to the new venv even before doing any install
-
-    installed_raw = run_command(Commands.freeze_command, check_run_result).stdout
-
-    def maybe_tuple(kv: str) -> None | tuple[str, str]:
-        if kv.startswith("-e"):
-            return kv.rsplit("/", 1)[1], "--editable"
-        elif "@ git" in kv:
-            return kv.split("@", 1)[0], "--git"
-        elif "==" in kv:
-            return cast(tuple[str, str], kv.split("==", 1))
-        else:
-            logger.warning(f"unable to discern package install {kv}")
-            return None
-
-    _installed = (maybe_tuple(kv) for kv in installed_raw.splitlines() if kv)
-    installed = dict(tup_or_none for tup_or_none in _installed if tup_or_none)
-    for package_spec in packages:
-        try:
-            parts = re.split(r"([<>=!~].*)", package_spec)
-            package = parts[0]
-            if package not in installed:
-                yield package_spec
-            elif len(parts) == 1:
-                if installed[package] == "--editable" or installed[package] == "--git":
-                    continue
-                yield f"{package}=={installed[package]}"
-            else:
-                specifier = SpecifierSet(parts[1].strip())
-                # NOTE in case of mismatch we just warn because we dont know if the module was imported already
-                # NOTE we dont check for import because we need to after install *anyway*
-                # NOTE for editable + explicit constraint, we leave it to uv -- imo unclear
-                if installed[package] == "--editable" or installed[package] == "--git":
-                    logger.warning(f"will upgrade a package {package} -- may cause issues in post-verify")
-                    yield package_spec
-                elif Version(installed[package]) in specifier:
-                    yield f"{package}=={installed[package]}"
-                else:
-                    logger.warning(f"will upgrade a package {package} -- may cause issues in post-verify")
-                    yield package_spec
-        except Exception as e:
-            logger.warning(f"failed to discern preference for package {package} -- continuing")
-            yield package
-
-    def _is_ignorable_module(top_level: str):
-        is_stdlib = top_level in sys.stdlib_module_names
-        is_local = top_level.startswith("_")  # for __main__, __editable, _distutils_hack, etc
-        return is_stdlib or is_local
-
-    def _is_ignorable_dist(distName: str, distVersion: Version) -> bool:
-        # editable/local installs such as that of cascade itself should not be put to
-        # the pip command as that wont be resolvable! We need to rely on caching here
-        if distVersion.dev or distVersion.local:
+def _is_ignorable_dist(dist_name: str, dist_version: Version) -> bool:
+    # editable/local installs such as that of cascade itself should not be put to
+    # the pip command as that wont be resolvable! We need to rely on caching here
+    if dist_version.dev is not None or dist_version.local is not None:
+        return True
+    if dist_version == Version("0.0.0"):
+        return True
+    try:
+        origin = importlib.metadata.distribution(dist_name)
+        if hasattr(origin, "url") and isinstance(origin.url, str) and origin.url.startswith("file://"):
             return True
-        if distVersion == Version("0.0.0"):
-            return True
-        origin = importlib.metadata.distribution(distName)
-        if origin is not None and hasattr(origin, "url") and isinstance(origin.url, str) and origin.url.startswith("file://"):
-            return True
-        return False
-
-    imported = set(name.split(".")[0] for name in sys.modules)
-    for name in imported:
-        if not _is_ignorable_module(name):
-            maybe_dist_version = _maybe_module_dist(name)
-            if maybe_dist_version is None:
-                logger.debug(f"failed to provide install pin for imported: {name=}, {maybe_dist_version=}")
-            else:
-                dist, version = maybe_dist_version
-                if not _is_ignorable_dist(dist, version):
-                    yield f"{dist}=={version}"
+    except Exception:
+        pass
+    return False
 
 
 class PackagesEnv(AbstractContextManager):
+    """Context manager responsible for runtime pip installs.
+
+    Tracks what we install and caches the module->dist_name mapping for imported
+    modules. This avoids repeated expensive packages_distributions() scans and
+    eliminates the need for a `pip freeze` call on every extend().
+
+    We only protect already-imported modules from version changes: those are the
+    only modules that cannot be safely re-loaded in a running process. Non-imported
+    packages can be freely changed by pip.
+    """
+
     def __init__(self) -> None:
         self.clean = True
+        # dist_name -> version, accumulated from parsed pip output of each extend() call
+        self._installed: dict[str, Version] = {}
+        # module_name -> dist_name (or None if no dist found), permanently cached per module.
+        # None entries are cleared after each install in case a new dist now provides them.
+        self._dist_name_cache: dict[str, str | None] = {}
+
+    def _populate_dist_cache(self, mod_names: set[str]) -> None:
+        """Batch-populate the dist_name cache for a set of module names.
+
+        Calls packages_distributions() once for all uncached modules, avoiding
+        repeated expensive metadata scans.
+        """
+        new_mods = {m for m in mod_names if m not in self._dist_name_cache and not _is_ignorable_module(m)}
+        if not new_mods:
+            return
+        pkg_dist = importlib.metadata.packages_distributions()
+        for mod in new_mods:
+            maybe = pkg_dist.get(mod, [])
+            self._dist_name_cache[mod] = maybe[0] if maybe else None
+
+    def _import_pins(self) -> dict[str, Version]:
+        """Return {dist_name: version} for all currently imported top-level modules.
+
+        Version is fetched fresh from importlib.metadata (not from __version__),
+        which gives the installed dist version rather than the potentially-decorated
+        __version__ (eg torch adds +cu126, ecmwf libs add a 4th build counter).
+        """
+        imported = set(name.split(".")[0] for name in sys.modules)
+        self._populate_dist_cache(imported)
+
+        pins: dict[str, Version] = {}
+        for name in imported:
+            if _is_ignorable_module(name):
+                continue
+            dist_name = self._dist_name_cache.get(name)
+            if dist_name is None:
+                logger.debug(f"failed to provide install pin for imported: {name!r}")
+                continue
+            try:
+                version = Version(importlib.metadata.version(dist_name))
+            except importlib.metadata.PackageNotFoundError:
+                continue
+            if not _is_ignorable_dist(dist_name, version):
+                pins[dist_name] = version
+        return pins
+
+    def _prefer_installed(self, packages: list[str]) -> list[str]:
+        """Pin user-requested packages to their currently-imported version where
+        compatible, and append pins for all other imported distributions.
+
+        This replaces the old `uv pip freeze` approach. We only protect imported
+        modules because those are the only ones that cannot be safely changed in a
+        running process.
+        """
+        import_pins = self._import_pins()
+        result: list[str] = []
+
+        for package_spec in packages:
+            try:
+                parts = re.split(r"([<>=!~].*)", package_spec)
+                package = parts[0]
+                if package in import_pins:
+                    pin_version = import_pins[package]
+                    if len(parts) == 1:
+                        # bare name with no constraint -> pin to imported version
+                        result.append(f"{package}=={pin_version}")
+                    else:
+                        specifier = SpecifierSet(parts[1].strip())
+                        if pin_version in specifier:
+                            # constraint is compatible -> pin to imported version
+                            result.append(f"{package}=={pin_version}")
+                        else:
+                            # constraint conflicts with imported version -> pass through and let
+                            # _check_conflicts or post-install verify catch it
+                            logger.warning(f"will upgrade a package {package} -- may cause issues in post-verify")
+                            result.append(package_spec)
+                else:
+                    result.append(package_spec)
+            except Exception:
+                logger.warning(f"failed to discern preference for package {package_spec} -- continuing")
+                result.append(package_spec)
+
+        # Append pins for all imported distributions not already covered above.
+        # This prevents pip from silently downgrading or upgrading loaded modules
+        # when resolving transitive dependencies.
+        for dist, version in import_pins.items():
+            result.append(f"{dist}=={version}")
+
+        return result
+
+    def _check_conflicts(self, packages: list[str]) -> list[ResolutionIssue]:
+        """Pre-pip conflict detection.
+
+        Groups package specs by name and checks whether any exact == pin is
+        incompatible with another spec for the same package. Emits at most one
+        ResolutionIssue per conflicting package name.
+        """
+        specs: dict[str, list[SpecifierSet]] = {}
+        for pkg in packages:
+            try:
+                parts = re.split(r"([<>=!~].*)", pkg)
+                name = parts[0]
+                spec = SpecifierSet(parts[1].strip()) if len(parts) > 1 else SpecifierSet("")
+                specs.setdefault(name, []).append(spec)
+            except Exception:
+                continue
+
+        issues: list[ResolutionIssue] = []
+        for name, specsets in specs.items():
+            if len(specsets) <= 1:
+                continue
+            conflict: str | None = None
+            for i, si in enumerate(specsets):
+                for spec_item in si:
+                    if spec_item.operator == "==":
+                        try:
+                            pin_ver = Version(spec_item.version)
+                            for j, sj in enumerate(specsets):
+                                if j != i and str(sj) and pin_ver not in sj:
+                                    conflict = f"{name} pinned to {pin_ver} but {sj} also required"
+                                    break
+                        except Exception:
+                            pass
+                    if conflict:
+                        break
+                if conflict:
+                    break
+            if conflict:
+                issues.append(ResolutionIssue(conflict))
+
+        return issues
+
+    def _postinstall_verify(self, pip_output: str) -> list[PostverifyIssue]:
+        """Check that no already-imported module has a version mismatch with what pip just installed.
+
+        Uses the dist_name cache (populated by _prefer_installed -> _import_pins) to
+        map module names to distributions without an extra _get_dist_modules() call.
+
+        We compare base_version (stripping local/build parts like +cu126) because pip
+        reports the base wheel version while __version__ may include build discriminators.
+        """
+        installed_packages = _parse_pip_install(pip_output)
+        if not installed_packages:
+            return []
+
+        imported = set(name.split(".")[0] for name in sys.modules)
+        self._populate_dist_cache(imported)
+
+        dist_to_issues: dict[str, list[tuple[str, Version]]] = {}
+        for mod_name in imported:
+            if _is_ignorable_module(mod_name):
+                continue
+            dist_name = self._dist_name_cache.get(mod_name)
+            if dist_name is None or dist_name not in installed_packages:
+                continue
+            desired_version = installed_packages[dist_name]
+            mod_ver = _maybe_imported_version(mod_name)
+            if mod_ver is None:
+                continue
+            if mod_ver.base_version != desired_version.base_version:
+                dist_to_issues.setdefault(dist_name, []).append((mod_name, mod_ver))
+
+        return [
+            PostverifyIssue(dist_name=dist_name, desired_version=installed_packages[dist_name], mod_issues=mod_issues)
+            for dist_name, mod_issues in dist_to_issues.items()
+        ]
 
     def extend(self, packages: list[str]) -> None:
         if not packages:
             return
-        packages = list(_prefer_installed(packages))
+
+        packages = list(self._prefer_installed(packages))
+
+        conflicts = self._check_conflicts(packages)
+        if conflicts:
+            raise PkgInstallException(cast(list[PostverifyIssue | ResolutionIssue], conflicts), self.clean)
 
         logger.debug(f"installing {len(packages)} packages")
         logger.debug(f"installing packages: {','.join(packages)}")
@@ -325,10 +400,17 @@ class PackagesEnv(AbstractContextManager):
         install_output = run_command(install_command, lambda r: check_install_result(r, self.clean)).stderr
         logger.debug(f"install result: {install_output}")
 
-        install_issues = _postinstall_verify(install_output)
+        newly_installed = _parse_pip_install(install_output)
+        self._installed.update(newly_installed)
+
+        # Clear None cache entries for modules that might now be provided by newly
+        # installed packages. Non-None entries are permanent (dist names don't change).
+        if newly_installed:
+            self._dist_name_cache = {k: v for k, v in self._dist_name_cache.items() if v is not None}
+
+        install_issues = self._postinstall_verify(install_output)
         if install_issues:
-            install_issues = cast(list[PostverifyIssue | ResolutionIssue], install_issues)
-            raise PkgInstallException(install_issues, self.clean)
+            raise PkgInstallException(cast(list[PostverifyIssue | ResolutionIssue], install_issues), self.clean)
 
         # NOTE do *not* invalidate caches before postinstall verify, that could
         # hide some issues. But afterwards this is important to actually allow

--- a/src/cascade/executor/runner/setup.py
+++ b/src/cascade/executor/runner/setup.py
@@ -14,15 +14,13 @@ Each worker owns its own temporary venv. This module handles:
  - cleanup/termination of both the process and the venv directory
 """
 
-import importlib.metadata
-import json
 import logging
 import os
 import subprocess
 import sys
 import tempfile
 
-from cascade.executor.runner.packages import check_run_result, run_command
+from cascade.executor.runner.packages import check_run_result, initial_venv_packages, run_command
 
 logger = logging.getLogger(__name__)
 
@@ -35,40 +33,18 @@ venv_root = os.environ.get("CASCADE_VENV_ROOT", None)
 _python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 
 
-def _earthkit_install_spec() -> str:
-    """Returns the install spec for earthkit-workflows suitable for uv pip install.
-
-    For editable/source installs (dev mode), uses the local source path directly.
-    Otherwise, pins to the currently installed version.
-    """
-    ek_version = importlib.metadata.version("earthkit-workflows")
-    try:
-        dist = importlib.metadata.distribution("earthkit-workflows")
-        direct_url_text = dist.read_text("direct_url.json")
-        if direct_url_text:
-            info = json.loads(direct_url_text)
-            url = info.get("url", "")
-            if url.startswith("file://") and info.get("dir_info", {}).get("editable", False):
-                path = url[len("file://") :]
-                logger.debug(f"earthkit-workflows is an editable install at {path}")
-                return path
-    except Exception as e:
-        logger.debug(f"could not read direct_url.json for earthkit-workflows: {repr(e)}")
-    return f"earthkit-workflows=={ek_version}"
-
-
 def create_venv() -> tempfile.TemporaryDirectory:  # type: ignore[type-arg]
     """Creates a new temporary venv with earthkit-workflows installed at the same version as the parent process."""
     td = tempfile.TemporaryDirectory(prefix="cascade_worker_venv_", dir=venv_root)
     logger.debug(f"creating a new worker venv at {td}")
     run_command(["uv", "venv", "--python", _python_version, td.name], check_run_result)
     python = _venv_python(td.name)
-    install_spec = _earthkit_install_spec()
-    logger.debug(f"installing {install_spec} into worker venv")
-    run_command(
-        ["uv", "pip", "install", "--python", python, install_spec],
-        check_run_result,
-    )
+    for install_spec in initial_venv_packages():
+        logger.debug(f"installing {install_spec} into worker venv")
+        run_command(
+            ["uv", "pip", "install", "--python", python, install_spec],
+            check_run_result,
+        )
     return td
 
 

--- a/tests/cascade/controller/test_run.py
+++ b/tests/cascade/controller/test_run.py
@@ -47,13 +47,14 @@ def launch_executor(
     controller_address: BackboneAddress,
     portBase: int,
     i: int,
+    test_name: str,  # used to derive executor address, must be unique
 ):
     dictConfig(logging_config)
     executor = Executor(
         job_instance,
         controller_address,
         2,
-        HostId(f"test_executor{i}"),
+        HostId(f"{test_name}executor{i}"),
         portBase,
         None,
         DefaultLoggingConfig,
@@ -67,6 +68,7 @@ def run_cluster(
     job: JobInstanceRich,
     portBase: int,
     executors: int,
+    test_name: str,  # used to derive executor address, must be unique
     preschedule: Preschedule | None = None,
 ):
     # TODO rework the port assignemnt in this whole file -- we waste a lot. Note if there
@@ -78,7 +80,7 @@ def run_cluster(
     m = f"tcp://localhost:{portBase + 1}"
     ps = []
     for i, executor in enumerate(range(executors)):
-        p = Process(target=launch_executor, args=(job.jobInstance, c, portBase + 1 + i * 10, i))
+        p = Process(target=launch_executor, args=(job.jobInstance, c, portBase + 1 + i * 10, i, test_name))
         p.start()
         ps.append(p)
     try:
@@ -102,7 +104,7 @@ def test_simple():
     task1 = TaskBuilder.from_callable(_payload).with_values(a=1, b=2)
     task2 = TaskBuilder.from_callable(_payload).with_values(a=1)
     job = JobBuilder().with_node("task1", task1).with_node("task2", task2).with_edge("task1", "task2", "b").build().get_or_raise()
-    run_cluster(JobInstanceRich(jobInstance=job, checkpointSpec=None), 12000, 1)
+    run_cluster(JobInstanceRich(jobInstance=job, checkpointSpec=None), 12000, 1, "controllerSimple")
     sleep(1)  # improves stability
 
 
@@ -148,7 +150,7 @@ def test_para2():
     if not run_all_tests:
         return
     job = get_job()
-    run_cluster(job, 12200, 2)
+    run_cluster(job, 12200, 2, "controllerPara2")
     sleep(1)  # improves stability
 
 
@@ -156,7 +158,7 @@ def test_para4():
     if not run_all_tests:
         return
     job = get_job()
-    run_cluster(job, 12400, 4)
+    run_cluster(job, 12400, 4, "controllerPara4")
     sleep(1)  # improves stability
 
 
@@ -173,7 +175,7 @@ def test_para1_persist():
             to_persist=[DatasetId(task=TaskId("c2i1"), output="0")],
         )
         job.checkpointSpec = spec
-        run_cluster(job, 12600, 1)
+        run_cluster(job, 12600, 1, "controllerPara1Persist")
 
         root = pathlib.Path(td)
         run1 = root / "run1"
@@ -220,7 +222,7 @@ def test_fusing():
     ]
     # TODO we currently dont check that those actually *got fused* -- fix
     jobInstanceRich = JobInstanceRich(jobInstance=job, checkpointSpec=None)
-    run_cluster(jobInstanceRich, 12800, 2, preschedule)
+    run_cluster(jobInstanceRich, 12800, 2, "controllerFusing", preschedule)
     sleep(1)  # improves stability
 
 
@@ -259,7 +261,7 @@ def test_checkpoints():
             checkpointSpec=checkpointSpec,
         )
 
-        run_cluster(jobInstanceRich, 13200, 2, preschedule)
+        run_cluster(jobInstanceRich, 13200, 2, "ctrlCkpt1", preschedule)
         sleep(1)  # improves stability
-        run_cluster(jobInstanceRich, 13300, 2, preschedule)
+        run_cluster(jobInstanceRich, 13300, 2, "ctrlCkpt2", preschedule)
         sleep(1)  # improves stability

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -15,6 +15,7 @@ from logging.config import dictConfig
 from multiprocessing import Process
 
 import numpy as np
+import pytest
 
 import cascade.executor.platform as platform
 import cascade.executor.serde as serde
@@ -67,6 +68,7 @@ def launch_executor(job_instance: JobInstance, controller_address: BackboneAddre
     executor.recv_loop()
 
 
+@pytest.mark.concurrency_filelock("conflictInExecutorHostname")
 def test_executor():
     # job
     def test_func(x: np.ndarray) -> np.ndarray:

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -51,13 +51,13 @@ from cascade.low.core import (
 logger = logging.getLogger(__name__)
 
 
-def launch_executor(job_instance: JobInstance, controller_address: BackboneAddress, portBase: int):
+def launch_executor(job_instance: JobInstance, controller_address: BackboneAddress, portBase: int, test_name: str):
     dictConfig(logging_config)
     executor = Executor(
         job_instance,
         controller_address,
         4,
-        HostId("test_executor"),
+        HostId(f"{test_name}executor"),
         portBase,
         None,
         DefaultLoggingConfig,
@@ -100,7 +100,7 @@ def test_executor():
     m1 = f"tcp://{platform.get_bindabble_self()}:12546"
     d1 = f"tcp://{platform.get_bindabble_self()}:12547"
     l = Listener(c1)  # controller
-    p = Process(target=launch_executor, args=(job, c1, 12546))
+    p = Process(target=launch_executor, args=(job, c1, 12546, "executor1"))
 
     # run
     p.start()
@@ -108,12 +108,12 @@ def test_executor():
         # register
         ms = l.recv_messages(None)
         expected_registration = ExecutorRegistration(
-            host=HostId("test_executor"),
+            host=HostId("executor1executor"),
             maddress=m1,
             daddress=d1,
             workers=[
                 Worker(
-                    worker_id=WorkerId(HostId("test_executor"), f"w{i}"),
+                    worker_id=WorkerId(HostId("executor1executor"), f"w{i}"),
                     cpu=1,
                     gpu=0,
                     memory_mb=1024,
@@ -128,7 +128,7 @@ def test_executor():
             assert m == expected_registration
 
         # submit graph
-        w0 = WorkerId(HostId("test_executor"), "w0")
+        w0 = WorkerId(HostId("executor1executor"), "w0")
         callback(
             m1,
             TaskSequence(worker=w0, tasks=[TaskId("source"), TaskId("sink")], publish={sink_o}, extra_env=[]),
@@ -150,7 +150,7 @@ def test_executor():
             DatasetTransmitCommand(
                 ds=sink_o,
                 idx=0,
-                source=HostId("test_executor"),
+                source=HostId("executor1executor"),
                 target=HostId("controller"),
                 daddress=c1,
             ),
@@ -170,7 +170,7 @@ def test_executor():
         send_data(d1, payload, syn)
         expected = {
             Ack(idx=1),
-            DatasetPublished(origin=HostId("test_executor"), ds=source_o, transmit_idx=1),
+            DatasetPublished(origin=HostId("executor1executor"), ds=source_o, transmit_idx=1),
         }
         while expected:
             ms = l.recv_messages()
@@ -192,7 +192,7 @@ def test_executor():
             DatasetTransmitCommand(
                 ds=sink_o,
                 idx=2,
-                source=HostId("test_executor"),
+                source=HostId("executor1executor"),
                 target=HostId("controller"),
                 daddress=c1,
             ),
@@ -205,7 +205,7 @@ def test_executor():
         # shutdown
         callback(m1, ExecutorShutdown())
         ms = l.recv_messages()
-        assert ExecutorExit(host=HostId("test_executor")) in ms
+        assert ExecutorExit(host=HostId("executor1executor")) in ms
         p.join()
     except:
         if p.is_alive():

--- a/tests/cascade/executor/test_packages.py
+++ b/tests/cascade/executor/test_packages.py
@@ -4,12 +4,14 @@ import pytest
 from packaging.version import Version
 
 from cascade.executor.runner.packages import (
+    PackagesEnv,
     PostverifyIssue,
+    ResolutionIssue,
     _get_dist_modules,
+    _is_ignorable_dist,
+    _is_ignorable_module,
     _maybe_imported_version,
     _parse_pip_install,
-    _postinstall_verify,
-    _prefer_installed,
     check_install_result,
     check_run_result,
     run_command,
@@ -72,11 +74,12 @@ def test_maybe_imported_version() -> None:
 def test_postinstall_verify() -> None:
     import numpy
 
+    env = PackagesEnv()
     goodie = "Using Python 3.11.8 environment at: <venv>\nResolved 1 package in 5ms\nUninstalled 1 package in 12ms\nInstalled 1 package in 18ms\n - numpy==2.4.2\n + numpy=={numpy.__version__}\n"
-    issues = _postinstall_verify(goodie)
+    issues = env._postinstall_verify(goodie)
     assert not issues
     baddie = "Using Python 3.11.8 environment at: <venv>\nResolved 1 package in 5ms\nUninstalled 1 package in 12ms\nInstalled 1 package in 18ms\n - numpy==2.4.2\n + numpy==1.0.0\n"
-    issues = _postinstall_verify(baddie)
+    issues = env._postinstall_verify(baddie)
     assert issues == [
         PostverifyIssue(dist_name="numpy", desired_version=Version("1.0.0"), mod_issues=[("numpy", Version(numpy.__version__))])
     ]
@@ -87,15 +90,92 @@ def test_prefer_installed() -> None:
     import packaging
     import pytest
 
-    assert set(_prefer_installed(["numpy"])) >= {
+    env = PackagesEnv()
+    assert set(env._prefer_installed(["numpy"])) >= {
         f"numpy=={numpy.__version__}",
         f"packaging=={packaging.__version__}",
         f"pytest=={pytest.__version__}",
     }, "unrestricted spec of installed pkg didnt resolve to installed pkg"
-    assert set(_prefer_installed(["numpy==1.0.0"])) >= {"numpy==1.0.0"}, (
+    assert set(env._prefer_installed(["numpy==1.0.0"])) >= {"numpy==1.0.0"}, (
         "exact pin spec of installed pkg which is compatible didnt match installed version"
     )
-    assert set(_prefer_installed([f"numpy>={numpy.__version__}"])) >= {f"numpy=={numpy.__version__}"}, (
+    assert set(env._prefer_installed([f"numpy>={numpy.__version__}"])) >= {f"numpy=={numpy.__version__}"}, (
         "range spec of installed pkg which is compatible didnt match installed version"
     )
-    assert set(_prefer_installed(["grumpy==42.0.0"])) >= {"grumpy==42.0.0"}, "spec of uninstalled package got dropped"
+    assert set(env._prefer_installed(["grumpy==42.0.0"])) >= {"grumpy==42.0.0"}, "spec of uninstalled package got dropped"
+
+
+def test_check_conflicts() -> None:
+    import numpy
+
+    env = PackagesEnv()
+
+    # No conflict: single package
+    assert env._check_conflicts([f"numpy=={numpy.__version__}"]) == []
+
+    # No conflict: two compatible specs for the same package
+    assert env._check_conflicts([f"numpy=={numpy.__version__}", f"numpy>={numpy.__version__}"]) == []
+
+    # Conflict: two different exact pins
+    issues = env._check_conflicts(["numpy==1.0.0", "numpy==2.0.0"])
+    assert len(issues) == 1
+    assert isinstance(issues[0], ResolutionIssue)
+    assert "numpy" in issues[0].because
+
+    # Conflict: import pin vs incompatible user request
+    issues = env._check_conflicts([f"numpy=={numpy.__version__}", "numpy==1.0.0"])
+    assert len(issues) == 1
+    assert "numpy" in issues[0].because
+
+    # No conflict: different packages
+    assert env._check_conflicts(["numpy==1.0.0", "packaging==21.0"]) == []
+
+    # No conflict: unconstrained spec does not trigger
+    assert env._check_conflicts(["numpy", f"numpy=={numpy.__version__}"]) == []
+
+
+def test_is_ignorable_module() -> None:
+    assert _is_ignorable_module("os")
+    assert _is_ignorable_module("sys")
+    assert _is_ignorable_module("_pytest")
+    assert _is_ignorable_module("__main__")
+    assert not _is_ignorable_module("numpy")
+    assert not _is_ignorable_module("packaging")
+
+
+def test_is_ignorable_dist() -> None:
+    # A normal published package should not be ignorable
+    assert not _is_ignorable_dist("numpy", Version("2.4.1"))
+    # dev/local versions (like our own editable installs) should be ignorable
+    assert _is_ignorable_dist("earthkit-workflows", Version("0.0.0.dev0"))
+    assert _is_ignorable_dist("something", Version("1.0.0+local"))
+    assert _is_ignorable_dist("something", Version("0.0.0"))
+
+
+def test_import_pins_includes_imported_modules() -> None:
+    import numpy
+    import packaging
+
+    env = PackagesEnv()
+    pins = env._import_pins()
+
+    assert "numpy" in pins
+    assert pins["numpy"] == Version(str(pins["numpy"]))  # is a valid Version
+    assert "packaging" in pins
+
+    # Our own editable install should be excluded (dev/local version)
+    assert "earthkit-workflows" not in pins
+
+
+def test_dist_name_cache_is_populated() -> None:
+    import numpy
+
+    env = PackagesEnv()
+    # Before any call, cache is empty
+    assert "numpy" not in env._dist_name_cache
+
+    env._import_pins()
+
+    # After _import_pins, numpy should be cached
+    assert "numpy" in env._dist_name_cache
+    assert env._dist_name_cache["numpy"] == "numpy"

--- a/tests/cascade/executor/test_packages.py
+++ b/tests/cascade/executor/test_packages.py
@@ -7,7 +7,6 @@ from cascade.executor.runner.packages import (
     PackagesEnv,
     PostverifyIssue,
     ResolutionIssue,
-    _get_dist_modules,
     _is_ignorable_dist,
     _is_ignorable_module,
     _maybe_imported_version,
@@ -50,11 +49,6 @@ def test_parse_pip_install() -> None:
     expected = {}
     assert _parse_pip_install(actual) == expected, "failed to parse actual uv output"
     # TODO it would be nice to actually do some pip install here, but im reluctant to do that in a unit test. Some for test_postinstall_verify
-
-
-def test_get_dist_modules() -> None:
-    assert _get_dist_modules("numpy") == ["numpy"]
-    assert sorted(_get_dist_modules("earthkit-workflows")) == sorted(["cascade", "earthkit"])
 
 
 def test_maybe_imported_version() -> None:

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -1,6 +1,8 @@
 import time
 from multiprocessing import Process
 
+import pytest
+
 import cascade.gateway.api as api
 import cascade.gateway.client as client
 from cascade.gateway.__main__ import main_cli
@@ -16,14 +18,14 @@ tries_limit = 32
 def get_job_succ() -> JobInstanceRich:
     sod = TaskDefinition(
         func=TaskDefinition.func_enc(lambda: init_value),
-        environment=[],
+        environment=["pytest"],
         input_schema={},
         output_schema=[("o", "int")],
     )
     soi = TaskInstance(definition=sod, static_input_kw={}, static_input_ps={})
     sid = TaskDefinition(
         func=TaskDefinition.func_enc(job_func),
-        environment=[],
+        environment=["pytest"],
         input_schema={},  # TODO add 0: int once supported
         output_schema=[("o", "int")],
     )
@@ -66,6 +68,7 @@ def spawn_gateway(max_jobs: int | None = None) -> tuple[str, Process]:
     return url, p
 
 
+@pytest.mark.concurrency_filelock("conflictInExecutorHostname")
 def test_job():
     url, gw = spawn_gateway(1)
     try:

--- a/tests/cascade/low/_runtime.py
+++ b/tests/cascade/low/_runtime.py
@@ -1,0 +1,2 @@
+def add(x, y):
+    return x + y

--- a/tests/cascade/low/test_dask.py
+++ b/tests/cascade/low/test_dask.py
@@ -1,14 +1,14 @@
+import pytest
 from dask._task_spec import DataNode, Task, TaskRef
 
 from cascade.low.core import DatasetId, DefaultTaskOutput, JobInstanceRich, TaskId
 from cascade.low.dask import graph2job
 from cascade.main import run_locally
 
-
-def add(x, y):
-    return x + y
+from ._runtime import add
 
 
+@pytest.mark.concurrency_filelock("conflictInExecutorHostname")
 def test_dask():
     dask_graph = {"x": (x := DataNode(None, 1)), "y": (y := DataNode(None, 2)), "z": Task("z", add, TaskRef("x"), TaskRef("y"))}
     cascade_job = graph2job(dask_graph)

--- a/tests/cascade/low/test_dask.py
+++ b/tests/cascade/low/test_dask.py
@@ -16,5 +16,6 @@ def test_dask():
         JobInstanceRich(jobInstance=cascade_job, checkpointSpec=None),
         workers=2,
         hosts=1,
+        portBase=32345,
     )
     assert outputs == {DatasetId(TaskId("'z'"), DefaultTaskOutput): 3}

--- a/tests/cascade/shm/test_shm.py
+++ b/tests/cascade/shm/test_shm.py
@@ -24,7 +24,7 @@ from cascade.executor.platform import get_mp_ctx
 # the mp manager gets launched.
 
 
-@pytest.mark.parametrize("shm_addr", [12345, "/tmp/shmport12345"])
+@pytest.mark.parametrize("shm_addr", [22345, "/tmp/shmport22345"])
 def test_shm_simple(shm_addr):
     api.publish_socket_addr(shm_addr)
     pref = f"cTi{shm_addr % 10}" if isinstance(shm_addr, int) else f"cTu{shm_addr[-1]}"
@@ -58,7 +58,7 @@ def test_shm_simple(shm_addr):
         serverP.terminate()
 
 
-@pytest.mark.parametrize("shm_addr", [12346, "/tmp/shmport12346"])
+@pytest.mark.parametrize("shm_addr", [22346, "/tmp/shmport22346"])
 def test_shm_disk(shm_addr):
     capacity = 4
     pref = f"cTi{shm_addr % 10}" if isinstance(shm_addr, int) else f"cTu{shm_addr[-1]}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+import fcntl
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def lock_resource(request, tmp_path_factory):
+    """
+    Parametrized lock fixture using Unix fcntl.
+    Usage: @pytest.mark.concurrency_filelock("my_resource_name")
+    """
+    # 1. Determine the lock name from the marker, default to 'global'
+    marker = request.node.get_closest_marker("concurrency_filelock")
+    if not marker:
+        yield
+        return
+    resource_name = marker.args[0]
+
+    # 2. Ensure all xdist workers point to the same base temp directory
+    # tmp_path_factory.getbasetemp() is unique per worker,
+    # but its parent is shared across the session.
+    shared_dir = tmp_path_factory.getbasetemp().parent
+    lock_file = shared_dir / f"{resource_name}.lock"
+
+    # 3. Perform the system-level lock
+    with open(lock_file, "a") as f:
+        # LOCK_EX: Exclusive lock
+        # This blocks until the lock is acquired
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            # LOCK_UN: Unlock
+            fcntl.flock(f, fcntl.LOCK_UN)


### PR DESCRIPTION
- Remove uv pip freeze; use _import_pins() to protect only already-imported modules (the only ones that cannot be safely re-loaded in a running process)
- Add PackagesEnv._dist_name_cache for permanent module->dist_name caching; _populate_dist_cache() does a single packages_distributions() call per batch of new modules; None entries cleared after each install
- Move _prefer_installed and _postinstall_verify to PackagesEnv methods sharing the dist_name cache
- Add PackagesEnv._check_conflicts(): pre-pip conflict detection grouping specs by package name, checking == pins against all other specs, at most one issue per conflicting package
- Track newly installed packages in PackagesEnv._installed from pip output
- Fix _is_ignorable_dist: use 'is not None' for .dev/.local (dev0 == 0, falsy)
- Promote _is_ignorable_module and _is_ignorable_dist to module-level
- Extend tests: test_check_conflicts, test_is_ignorable_module/dist, test_import_pins_includes_imported_modules, test_dist_name_cache_is_populated

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
