### PR TITLE
fix(executor): use shared memory for RunnerContext, fix init error re…

### DIFF
--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -61,6 +61,7 @@ from cascade.executor.runner.entrypoint import worker_address
 from cascade.executor.runner.setup import RunnerContext
 from cascade.low.core import DatasetId, HostId, JobInstance, TaskId, WorkerId
 from cascade.low.exceptions import CascadeError, CascadeInfrastructureError, CascadeInternalError, CascadeUserError, ser
+from cascade.low.func import md5hash24
 from cascade.low.tracing import TaskLifecycle, mark
 from cascade.low.views import param_source
 from cascade.shm.server import entrypoint as shm_server
@@ -160,7 +161,8 @@ class Executor:
         # Build the shared RunnerContext and save it to POSIX shared memory.
         # All workers on this executor share this object; only per-worker identity (WorkerSetup)
         # is passed per-process via envvar.
-        self.runner_ctx_shm_key = f"sCascRnrCtx{host}"
+        # The key is host-unique, but quick restarts are problematic on mac, and we cant have too long key for mac
+        self.runner_ctx_shm_key = md5hash24(f"sCascRnrCtx{host}" + str(uuid.uuid4()))
         runner_ctx = RunnerContext(
             job=self.job_instance,
             callback=self.mlistener.address,

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -16,16 +16,14 @@ the tasks themselves.
 # have their own zmq server as well as run the callables themselves
 
 import atexit
-import base64
 import logging
 import os
 import subprocess
 import tempfile
 import uuid
 from dataclasses import dataclass
+from multiprocessing.shared_memory import SharedMemory
 from typing import Iterable
-
-import cloudpickle
 
 import cascade.executor.platform as platform
 import cascade.executor.runner.setup as runner_setup
@@ -59,7 +57,8 @@ from cascade.executor.msg import (
     WorkerReady,
     WorkerShutdown,
 )
-from cascade.executor.runner.entrypoint import RunnerContext, worker_address
+from cascade.executor.runner.entrypoint import worker_address
+from cascade.executor.runner.setup import RunnerContext
 from cascade.low.core import DatasetId, HostId, JobInstance, TaskId, WorkerId
 from cascade.low.exceptions import CascadeError, CascadeInfrastructureError, CascadeInternalError, CascadeUserError, ser
 from cascade.low.tracing import TaskLifecycle, mark
@@ -158,6 +157,18 @@ class Executor:
             ],
             url_base=url_base,
         )
+        # Build the shared RunnerContext and save it to POSIX shared memory.
+        # All workers on this executor share this object; only per-worker identity (WorkerSetup)
+        # is passed per-process via envvar.
+        self.runner_ctx_shm_key = f"sCascRnrCtx{host}"
+        runner_ctx = RunnerContext(
+            job=self.job_instance,
+            callback=self.mlistener.address,
+            param_source=self.param_source,
+            loggingConfig=self.loggingConfig,
+            schema_lookup=self.schema_lookup,
+        )
+        self.runner_ctx_shm: SharedMemory = runner_setup.save_runner_ctx_to_shm(runner_ctx, self.runner_ctx_shm_key)
         logger.debug("constructed executor")
 
     def terminate(self) -> None:
@@ -189,6 +200,12 @@ class Executor:
                 venv.cleanup()
             except Exception as e:
                 logger.warning(f"gotten {repr(e)} when shutting down old worker {proc.pid}")
+        if hasattr(self, "runner_ctx_shm") and self.runner_ctx_shm is not None:
+            try:
+                self.runner_ctx_shm.close()
+                self.runner_ctx_shm.unlink()
+            except Exception as e:
+                logger.warning(f"failed to free runner ctx shm: {repr(e)}")
         if hasattr(self, "shm_process") and self.shm_process is not None and self.shm_process.is_alive():
             try:
                 shm_client.shutdown()
@@ -203,23 +220,16 @@ class Executor:
         self.sender.send(HostId("controller"), m)
 
     def _start_worker(self, worker: WorkerId, attempt_cnt: int, seq: None | TaskSequence) -> WorkerHandle:
-        runnerContext = RunnerContext(
+        worker_setup = runner_setup.WorkerSetup(
             workerId=worker,
             workerAttemptCnt=attempt_cnt,
-            job=self.job_instance,
-            param_source=self.param_source,
-            callback=self.mlistener.address,
-            loggingConfig=self.loggingConfig,
-            schema_lookup=self.schema_lookup,
+            shm_key=self.runner_ctx_shm_key,
         )
-        # NOTE we need to cloudpickle because runnerContext contains some lambdas
-        runnerContextClpkl = cloudpickle.dumps(runnerContext)
-        encoded = base64.b64encode(runnerContextClpkl).decode()
         venv_td = runner_setup.create_venv()
         p = runner_setup.launch_in_venv(
             "cascade.executor.runner.entrypoint",
             venv_td.name,
-            {runner_setup.CONTEXT_ENVVAR: encoded},
+            {runner_setup.WORKER_SETUP_ENVVAR: worker_setup.to_str()},
         )
         if worker in self.worker_awaits:
             raise CascadeInternalError(f"{worker=} was already awaiting")
@@ -248,8 +258,12 @@ class Executor:
             self.start_workers(self.workers.keys())
             logger.debug(f"about to send register message from {self.host}")
             self.to_controller(self.registration)
-        except:
+        except Exception as e:
             logger.exception("failed during register")
+            try:
+                self.to_controller(ExecutorFailure(self.host, ser(e)))
+            except Exception:
+                logger.exception("failed to send ExecutorFailure to controller after register failure")
             self.terminate()
         # NOTE we don't mind this registration message being lost -- if that happens, we send it
         # during next heartbeat. But we may want to introduce a check that if no message,

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -11,16 +11,12 @@
 import logging
 import logging.config
 import os
-from dataclasses import dataclass
-from typing import Any
 
-import cloudpickle
 import zmq
-from typing_extensions import Self
 
 import cascade.executor.platform as platform
 import cascade.executor.serde as serde
-from cascade.deployment.logging import LoggingConfig, init_from_obj
+from cascade.deployment.logging import init_from_obj
 from cascade.executor.comms import callback
 from cascade.executor.msg import (
     BackboneAddress,
@@ -34,45 +30,13 @@ from cascade.executor.msg import (
 )
 from cascade.executor.runner.memory import Memory
 from cascade.executor.runner.packages import PackagesEnv, PkgInstallException
-from cascade.executor.runner.runner import ExecutionContext, run
-from cascade.low.core import DatasetId, JobInstance, TaskId, WorkerId, type_dec
+from cascade.executor.runner.runner import run
+from cascade.executor.runner.setup import RunnerContext, WorkerSetup, load_runner_ctx_from_shm
+from cascade.low.core import DatasetId, TaskId, WorkerId, type_dec
 from cascade.low.exceptions import CascadeError, CascadeInfrastructureError, CascadeInternalError, CascadeUserError, ser
 from cascade.low.tracing import label
 
 logger = logging.getLogger(__name__ if __name__ != "__main__" else "cascade.executor.runner.entrypoint")
-
-
-@dataclass(frozen=True, slots=True)
-class RunnerContext:
-    """The static runner configuration"""
-
-    workerId: WorkerId
-    workerAttemptCnt: int
-    job: JobInstance
-    callback: BackboneAddress
-    param_source: dict[TaskId, dict[int | str, DatasetId]]
-    loggingConfig: LoggingConfig
-    schema_lookup: dict[DatasetId, str]
-
-    @staticmethod
-    def build_schema_lookup(job: JobInstance) -> dict[DatasetId, str]:
-        return {
-            DatasetId(task_id, output): fqn
-            for task_id, task_instance in job.tasks.items()
-            for output, fqn in task_instance.definition.output_schema
-        }
-
-    def project(self, taskSequence: TaskSequence) -> ExecutionContext:
-        param_source_ext: dict[TaskId, dict[int | str, tuple[DatasetId, str]]] = {
-            task: {k: (dataset_id, self.schema_lookup[dataset_id]) for k, dataset_id in self.param_source[task].items()}
-            for task in taskSequence.tasks
-        }
-        return ExecutionContext(
-            tasks={task: self.job.tasks[task] for task in taskSequence.tasks},
-            param_source=param_source_ext,
-            callback=self.callback,
-            publish=taskSequence.publish,
-        )
 
 
 def task_sequence_postmortem(ctx: RunnerContext, taskSequence: TaskSequence, cut: TaskId) -> list[tuple[DatasetId, str]]:
@@ -184,22 +148,21 @@ def execute_sequence(
         return False
 
 
-def entrypoint(runnerContextClpkl: bytes) -> None:
-    """runnerContext is a cloudpickled instance of RunnerContext -- needed for forkserver mp context due to defautdicts"""
-    runnerContext = cloudpickle.loads(runnerContextClpkl)
-    init_from_obj(runnerContext.loggingConfig, f"worker_{runnerContext.workerId.worker}")
+def entrypoint(workerSetup: WorkerSetup, runnerContext: RunnerContext) -> None:
+    """Main runner loop for a worker process."""
+    init_from_obj(runnerContext.loggingConfig, f"worker_{workerSetup.workerId.worker}")
     ctx = zmq.Context()
     socket = ctx.socket(zmq.PULL)
-    address = worker_address(runnerContext.workerId, runnerContext.workerAttemptCnt)
-    logger.debug(f"worker {runnerContext.workerId} binding to {address=}")
+    address = worker_address(workerSetup.workerId, workerSetup.workerAttemptCnt)
+    logger.debug(f"worker {workerSetup.workerId} binding to {address=}")
     socket.bind(address)
-    callback(runnerContext.callback, WorkerReady(runnerContext.workerId))
+    callback(runnerContext.callback, WorkerReady(workerSetup.workerId))
     with (
-        Memory(runnerContext.callback, runnerContext.workerId) as memory,
+        Memory(runnerContext.callback, workerSetup.workerId) as memory,
         PackagesEnv() as pckg,
     ):
-        label("worker", repr(runnerContext.workerId))
-        worker_num = runnerContext.workerId.worker_num()
+        label("worker", repr(workerSetup.workerId))
+        worker_num = workerSetup.workerId.worker_num()
         platform.gpu_init(worker_num)
         # TODO configure OMP_NUM_THREADS, blas, mkl, etc -- not clear how tho
 
@@ -215,7 +178,7 @@ def entrypoint(runnerContextClpkl: bytes) -> None:
             mRaw = socket.recv()
             mDes = serde.des_message(mRaw)
             if isinstance(mDes, WorkerShutdown):
-                logger.debug(f"worker {runnerContext.workerId} shutting down")
+                logger.debug(f"worker {workerSetup.workerId} shutting down")
                 break
             elif isTerminating:
                 logger.warning(f"ignoring message {mDes} because terminating")
@@ -253,10 +216,9 @@ def entrypoint(runnerContextClpkl: bytes) -> None:
 
 
 if __name__ == "__main__":
-    import base64
+    from cascade.executor.runner.setup import WORKER_SETUP_ENVVAR, WorkerSetup, load_runner_ctx_from_shm
 
-    from cascade.executor.runner.setup import CONTEXT_ENVVAR
-
-    _encoded = os.environ[CONTEXT_ENVVAR]
-    _runnerContextClpkl = base64.b64decode(_encoded)
-    entrypoint(_runnerContextClpkl)
+    _setup_str = os.environ[WORKER_SETUP_ENVVAR]
+    _worker_setup = WorkerSetup.from_str(_setup_str)
+    _runner_ctx = load_runner_ctx_from_shm(_worker_setup.shm_key)
+    entrypoint(_worker_setup, _runner_ctx)

--- a/src/cascade/executor/runner/memory.py
+++ b/src/cascade/executor/runner/memory.py
@@ -10,7 +10,6 @@
 Interaction with shm
 """
 
-import hashlib
 import logging
 import sys
 from contextlib import AbstractContextManager
@@ -22,6 +21,7 @@ from cascade.executor.comms import callback
 from cascade.executor.msg import BackboneAddress, DatasetPublished
 from cascade.low.core import NO_OUTPUT_PLACEHOLDER, DatasetId, WorkerId
 from cascade.low.exceptions import CascadeInternalError
+from cascade.low.func import md5hash24
 from cascade.low.tracing import Microtrace, timer
 
 logger = logging.getLogger(__name__)
@@ -29,9 +29,7 @@ logger = logging.getLogger(__name__)
 
 def ds2shmid(ds: DatasetId) -> str:
     # we cant use too long file names for shm, https://trac.macports.org/ticket/64806
-    h = hashlib.new("md5", usedforsecurity=False)
-    h.update((ds.task + ds.output).encode())
-    return h.hexdigest()[:24]
+    return md5hash24(ds.task + ds.output)
 
 
 class Memory(AbstractContextManager):

--- a/src/cascade/executor/runner/setup.py
+++ b/src/cascade/executor/runner/setup.py
@@ -23,6 +23,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 from dataclasses import dataclass
 from multiprocessing.shared_memory import SharedMemory
 from typing import Any
@@ -60,7 +61,7 @@ else:
 
 @dataclass(frozen=True)
 class WorkerSetup:
-    """Per-worker identity: what is factored out of RunnerContext and passed via envvar."""
+    """Per-worker identity: together with RunnerContext below, forms complete worker startup config"""
 
     workerId: WorkerId
     workerAttemptCnt: int
@@ -121,10 +122,13 @@ def save_runner_ctx_to_shm(ctx: RunnerContext, key: str) -> SharedMemory:
     try:
         shm = SharedMemory(key, create=True, size=size, **_shm_kwargs)
     except FileExistsError:
+        # this should not happen thanks to uuid, but if it does we handle gracefully
         logger.error(f"runner ctx shm {key!r} already existed; deleting and recreating")
         _old = SharedMemory(key, create=False, **_shm_kwargs)
         _old.close()
         _old.unlink()
+        if sys.platform == "darwin":
+            time.sleep(1)  # on mac, create right after unlink leads to not found
         shm = SharedMemory(key, create=True, size=size, **_shm_kwargs)
     if _is_unregister:
         multiprocessing.resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]

--- a/src/cascade/executor/runner/setup.py
+++ b/src/cascade/executor/runner/setup.py
@@ -6,31 +6,145 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Worker venv creation and process launching.
+"""Worker venv creation and process launching, plus RunnerContext/WorkerSetup definitions.
 
 Each worker owns its own temporary venv. This module handles:
  - creation of a temporary venv with the same Python version and an initial earthkit-workflows install
  - launching a Python module as a subprocess inside that venv
  - cleanup/termination of both the process and the venv directory
+ - RunnerContext: the shared per-executor context passed to all workers via shared memory
+ - WorkerSetup: the per-worker identity passed via environment variable
+ - save/load helpers for the shared RunnerContext in POSIX shared memory
 """
 
 import logging
+import multiprocessing.resource_tracker
 import os
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
+from multiprocessing.shared_memory import SharedMemory
+from typing import Any
 
+import cloudpickle
+from typing_extensions import Self
+
+from cascade.deployment.logging import LoggingConfig
+from cascade.executor.msg import BackboneAddress
 from cascade.executor.runner.packages import check_run_result, initial_venv_packages, run_command
+from cascade.executor.runner.runner import ExecutionContext
+from cascade.low.core import DatasetId, JobInstance, TaskId, WorkerId
+from cascade.low.exceptions import CascadeInternalError
 
 logger = logging.getLogger(__name__)
 
-CONTEXT_ENVVAR = "CASCADE_RUNNER_CONTEXT"
+WORKER_SETUP_ENVVAR = "CASCADE_WORKER_SETUP"
 # NOTE on some systems, default /tmp can be mounted with noexec, leading to issues at runtime
 # like 'failed to map segment from shared object' for binary dependencies like zmq
 # Thus override this envvar to some exec-mounted filesystem
 venv_root = os.environ.get("CASCADE_VENV_ROOT", None)
 
 _python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+
+# Shared memory unregistering pattern: Python's resource tracker automatically unlinks
+# shared memory it created, which is wrong for memory we share across processes.
+# On 3.13+ we can disable tracking at creation time; on older versions we unregister manually.
+if (sys.version_info.major, sys.version_info.minor) >= (3, 13):
+    _is_unregister = False
+    _shm_kwargs: dict[str, Any] = {"track": False}
+else:
+    _is_unregister = True
+    _shm_kwargs = {}
+
+
+@dataclass(frozen=True)
+class WorkerSetup:
+    """Per-worker identity: what is factored out of RunnerContext and passed via envvar."""
+
+    workerId: WorkerId
+    workerAttemptCnt: int
+    shm_key: str
+
+    def to_str(self) -> str:
+        return f"{repr(self.workerId)}|{self.workerAttemptCnt}|{self.shm_key}"
+
+    @classmethod
+    def from_str(cls, s: str) -> Self:
+        worker_repr, attempt_str, shm_key = s.split("|", 2)
+        return cls(
+            workerId=WorkerId.from_repr(worker_repr),
+            workerAttemptCnt=int(attempt_str),
+            shm_key=shm_key,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RunnerContext:
+    """The static runner configuration shared across all workers on an executor."""
+
+    job: JobInstance
+    callback: BackboneAddress
+    param_source: dict[TaskId, dict[int | str, DatasetId]]
+    loggingConfig: LoggingConfig
+    schema_lookup: dict[DatasetId, str]
+
+    @staticmethod
+    def build_schema_lookup(job: JobInstance) -> dict[DatasetId, str]:
+        return {
+            DatasetId(task_id, output): fqn
+            for task_id, task_instance in job.tasks.items()
+            for output, fqn in task_instance.definition.output_schema
+        }
+
+    def project(self, taskSequence: Any) -> ExecutionContext:
+        param_source_ext: dict[TaskId, dict[int | str, tuple[DatasetId, str]]] = {
+            task: {k: (dataset_id, self.schema_lookup[dataset_id]) for k, dataset_id in self.param_source[task].items()}
+            for task in taskSequence.tasks
+        }
+        return ExecutionContext(
+            tasks={task: self.job.tasks[task] for task in taskSequence.tasks},
+            param_source=param_source_ext,
+            callback=self.callback,
+            publish=taskSequence.publish,
+        )
+
+
+def save_runner_ctx_to_shm(ctx: RunnerContext, key: str) -> SharedMemory:
+    """Cloudpickle ctx and store it in a new POSIX shared memory block named key.
+
+    Returns the SharedMemory object; the caller owns it and must call .close()/.unlink() on exit.
+    If a stale block with the same name exists, it is deleted and recreated.
+    """
+    data = cloudpickle.dumps(ctx)
+    size = len(data)
+    try:
+        shm = SharedMemory(key, create=True, size=size, **_shm_kwargs)
+    except FileExistsError:
+        logger.error(f"runner ctx shm {key!r} already existed; deleting and recreating")
+        _old = SharedMemory(key, create=False, **_shm_kwargs)
+        _old.close()
+        _old.unlink()
+        shm = SharedMemory(key, create=True, size=size, **_shm_kwargs)
+    if _is_unregister:
+        multiprocessing.resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
+    assert shm.buf is not None
+    shm.buf[:size] = data
+    return shm
+
+
+def load_runner_ctx_from_shm(key: str) -> RunnerContext:
+    """Open the shared memory block named key, deserialize the RunnerContext, and close the block.
+
+    The worker calls this once during init; the memory stays alive until the executor frees it.
+    """
+    shm = SharedMemory(key, create=False, **_shm_kwargs)
+    if _is_unregister:
+        multiprocessing.resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
+    assert shm.buf is not None
+    data = bytes(shm.buf[: shm.size])
+    shm.close()
+    return cloudpickle.loads(data)
 
 
 def create_venv() -> tempfile.TemporaryDirectory:  # type: ignore[type-arg]
@@ -69,7 +183,10 @@ def launch_in_venv(module: str, venv_dir: str, envvars: dict[str, str]) -> "subp
         existing = env.get("PYTHONPATH", "")
         env["PYTHONPATH"] = f"{pythonpath}{os.pathsep}{existing}" if existing else pythonpath
     logger.debug(f"launching {module} in {venv_dir}")
-    return subprocess.Popen([python, "-m", module], env=env)
+    try:
+        return subprocess.Popen([python, "-m", module], env=env)
+    except OSError as e:
+        raise CascadeInternalError(f"failed to launch worker process (env may be too large): {repr(e)}", parent=e) from e
 
 
 def terminate_worker(process: subprocess.Popen[bytes], venv_dir: tempfile.TemporaryDirectory[str]) -> None:

--- a/src/cascade/low/func.py
+++ b/src/cascade/low/func.py
@@ -8,6 +8,7 @@
 
 """Things."""
 
+import hashlib
 import importlib
 from abc import abstractmethod
 from typing import (
@@ -199,3 +200,9 @@ def pydantic_recursive_collect(base: BaseModel | Iterable, attr: str, prefix: st
         if isinstance(v, BaseModel) or isinstance(v, Iterable):
             results.extend(pydantic_recursive_collect(v, attr, prefix + formatter(k)))
     return results
+
+
+def md5hash24(i: str) -> str:
+    h = hashlib.new("md5", usedforsecurity=False)
+    h.update(i.encode())
+    return h.hexdigest()[:24]

--- a/tests/cascade/executor/test_runner.py
+++ b/tests/cascade/executor/test_runner.py
@@ -19,6 +19,7 @@ import cascade.shm.client as shm_cli
 from cascade.deployment.logging import DefaultLoggingConfig
 from cascade.executor.msg import DatasetPublished, TaskSequence
 from cascade.executor.runner.packages import PackagesEnv
+from cascade.executor.runner.setup import RunnerContext
 from cascade.low.core import (
     DatasetId,
     HostId,
@@ -83,14 +84,12 @@ def test_runner(monkeypatch):
         extra_env=[],
     )
     job = JobInstance(tasks={}, edges=[])
-    emptyRc = entrypoint.RunnerContext(
-        workerId=worker,
-        workerAttemptCnt=0,
+    emptyRc = RunnerContext(
         callback=test_address,
         job=job,
         param_source={},
         loggingConfig=DefaultLoggingConfig,
-        schema_lookup=entrypoint.RunnerContext.build_schema_lookup(job),
+        schema_lookup=RunnerContext.build_schema_lookup(job),
     )
 
     with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv() as pckg:
@@ -122,14 +121,12 @@ def test_runner(monkeypatch):
         extra_env=[],
     )
     oneTaskJob = JobInstance(tasks={TaskId("t2"): t2}, edges=[])
-    oneTaskRc = entrypoint.RunnerContext(
-        workerId=worker,
-        workerAttemptCnt=0,
+    oneTaskRc = RunnerContext(
         callback=test_address,
         job=oneTaskJob,
         param_source=param_source(oneTaskJob.edges),
         loggingConfig=DefaultLoggingConfig,
-        schema_lookup=entrypoint.RunnerContext.build_schema_lookup(oneTaskJob),
+        schema_lookup=RunnerContext.build_schema_lookup(oneTaskJob),
     )
 
     with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv() as pckg:
@@ -165,14 +162,12 @@ def test_runner(monkeypatch):
         tasks={TaskId("t3a"): t3a, TaskId("t3b"): t3b},
         edges=[Task2TaskEdge(source=t3i, sink_task=TaskId("t3b"), sink_input_kw="x", sink_input_ps=None)],
     )
-    twoTaskRc = entrypoint.RunnerContext(
-        workerId=worker,
-        workerAttemptCnt=0,
+    twoTaskRc = RunnerContext(
         callback=test_address,
         job=twoTaskJob,
         param_source=param_source(twoTaskJob.edges),
         loggingConfig=DefaultLoggingConfig,
-        schema_lookup=entrypoint.RunnerContext.build_schema_lookup(twoTaskJob),
+        schema_lookup=RunnerContext.build_schema_lookup(twoTaskJob),
     )
 
     with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv() as pckg:
@@ -234,14 +229,12 @@ def test_runner(monkeypatch):
             for i in range(N)
         ],
     )
-    t4Rc = entrypoint.RunnerContext(
-        workerId=worker,
-        workerAttemptCnt=0,
+    t4Rc = RunnerContext(
         callback=test_address,
         job=t4Job,
         param_source=param_source(t4Job.edges),
         loggingConfig=DefaultLoggingConfig,
-        schema_lookup=entrypoint.RunnerContext.build_schema_lookup(t4Job),
+        schema_lookup=RunnerContext.build_schema_lookup(t4Job),
     )
 
     with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv() as pckg:

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -97,6 +97,8 @@ def test_job():
             assert job_progress_res.error is None
             is_computed = job_progress_res.progresses[job_id].pct == "100.00"  # ty: ignore[possibly-missing-attribute]
             is_datasets = ji.jobInstance.ext_outputs[0] in job_progress_res.datasets[job_id]
+            has_failure = job_progress_res.progresses[job_id].failure is not None
+            assert not has_failure, f"the job {job_id} has failed with {job_progress_res.progresses[job_id].failure}"
             if is_computed and is_datasets:
                 break
             else:


### PR DESCRIPTION
…porting

Task 1: Catch OSError from subprocess.Popen in launch_in_venv and re-raise as CascadeInternalError, preventing silent failures when the environment is too large.

Task 2: In executor.register(), send ExecutorFailure to the controller before calling terminate() on any init failure, so the controller is notified instead of left hanging indefinitely.

Task 3: Replace the envvar-based RunnerContext transfer (which fails with ENOMSG when the context is too large) with POSIX shared memory:

- Factor out (workerId, workerAttemptCnt) from RunnerContext into a new WorkerSetup dataclass with string-based serde, passed via CASCADE_WORKER_SETUP envvar.
- RunnerContext (job, callback, param_source, loggingConfig, schema_lookup) is now shared across all workers on an executor.
- Executor.__init__ cloudpickles RunnerContext into a POSIX shared memory block keyed sCascRnrCtx{hostId}; the key is communicated to each worker via WorkerSetup.shm_key.
- Shared memory is created/owned by the executor and freed in terminate(); workers open, read, and immediately close it during their own init.
- Follow the same resource-tracker unregistering pattern as cascade/shm/client.py to avoid Python auto-unlinking memory it did not exclusively own.
- WorkerSetup, RunnerContext, save_runner_ctx_to_shm, and load_runner_ctx_from_shm live in executor/runner/setup.py.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
