### PR TITLE
Add PayloadBuildingContext for bulk metadata injection

### DIFF
--- a/src/earthkit/workflows/fluent.py
+++ b/src/earthkit/workflows/fluent.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import functools
 import hashlib
 import os
+import threading
+import types
 from typing import (
     Any,
     Callable,
@@ -32,6 +34,50 @@ from .graph import Node as BaseNode
 from .nodetree import nodetree_array, nodetree_arrays, nodetree_from_dict
 
 PayloadFunc = Callable | str
+
+_payload_context = threading.local()
+
+
+def _get_context_stack() -> list[dict[str, Any]]:
+    if not hasattr(_payload_context, "earthkit_workflow_payload_metadata_stack"):
+        _payload_context.earthkit_workflow_payload_metadata_stack = []
+    return _payload_context.earthkit_workflow_payload_metadata_stack  # type: ignore[return-value]
+
+
+def _get_context_metadata() -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for frame in _get_context_stack():
+        result.update(frame)
+    return result
+
+
+class PayloadBuildingContext:
+    """Context manager that injects metadata into every Payload created within it.
+
+    Contexts can be nested; inner values override outer ones on key collision.
+    Metadata passed directly to Payload() overrides any context-provided metadata.
+
+    Example
+    -------
+    with PayloadBuildingContext(key1="value1"):
+        action1 = from_source(...)
+        action2 = action1.map(some_func)
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._metadata = kwargs
+
+    def __enter__(self) -> "PayloadBuildingContext":
+        _get_context_stack().append(self._metadata)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
+        _get_context_stack().pop()
 
 
 class Payload:
@@ -57,6 +103,7 @@ class Payload:
             self.kwargs = kwargs or {}
 
         self.metadata = getattr(self.func, "_cascade", {})
+        self.metadata.update(_get_context_metadata())
         self.metadata.update(metadata or {})
 
     def to_tuple(self) -> tuple:
@@ -1110,6 +1157,7 @@ Action.register("default", Action)
 __all__ = [
     "Action",
     "Payload",
+    "PayloadBuildingContext",
     "Node",
     "from_source",
     "merge",

--- a/tests/earthkit_workflows/test_metadata.py
+++ b/tests/earthkit_workflows/test_metadata.py
@@ -10,7 +10,7 @@
 import numpy as np
 
 from earthkit.workflows import mark as ekw_mark
-from earthkit.workflows.fluent import Payload
+from earthkit.workflows.fluent import Payload, PayloadBuildingContext
 from earthkit.workflows.nodetree import nodetree_array
 
 from .helpers import mock_action
@@ -79,3 +79,81 @@ def test_payload_metadata_from_marks_explicit():
             np.atleast_1d(nodetree_array(mapped_action.nodes).values).flatten(),
         )
     )
+
+
+# ---------------------------------------------------------------------------
+# PayloadBuildingContext tests
+# ---------------------------------------------------------------------------
+
+
+def test_payload_building_context_basic():
+    """Metadata from the context is injected into every Payload created inside."""
+    with PayloadBuildingContext(env="test"):
+        p = Payload(lambda x: x)
+
+    assert p.metadata["env"] == "test"
+
+
+def test_payload_building_context_not_applied_outside():
+    """Metadata is NOT injected into Payloads created outside the context."""
+    with PayloadBuildingContext(env="test"):
+        pass
+
+    p = Payload(lambda x: x)
+    assert "env" not in p.metadata
+
+
+def test_payload_building_context_nested_merge():
+    """Inner context values override outer ones; all keys are present."""
+    with PayloadBuildingContext(key1="outer"):
+        with PayloadBuildingContext(key2="middle"):
+            with PayloadBuildingContext(key1="inner"):
+                p = Payload(lambda x: x)
+
+    assert p.metadata["key1"] == "inner"
+    assert p.metadata["key2"] == "middle"
+
+
+def test_payload_building_context_direct_param_wins():
+    """Direct metadata= argument overrides context-provided metadata."""
+    with PayloadBuildingContext(key1="from_context", key2="from_context"):
+        p = Payload(lambda x: x, metadata={"key1": "direct", "key3": "direct"})
+
+    assert p.metadata["key1"] == "direct"
+    assert p.metadata["key2"] == "from_context"
+    assert p.metadata["key3"] == "direct"
+
+
+def test_payload_building_context_full_example():
+    """Reproduces the docstring example with all three sources combined."""
+    with PayloadBuildingContext(key1="value1"):
+        with PayloadBuildingContext(key2="value2"):
+            with PayloadBuildingContext(key1="value3"):
+                p = Payload(lambda x: x, metadata={"key3": "value4"})
+
+    assert p.metadata["key1"] == "value3"
+    assert p.metadata["key2"] == "value2"
+    assert p.metadata["key3"] == "value4"
+
+
+def test_payload_building_context_on_action_map():
+    """Context metadata propagates to nodes created via Action.map."""
+    action = mock_action((2, 2))
+
+    with PayloadBuildingContext(stage="production"):
+        mapped = action.map(lambda x: x)
+
+    nodes = np.atleast_1d(nodetree_array(mapped.nodes).values).flatten()
+    assert all(n.payload.metadata["stage"] == "production" for n in nodes)
+
+
+def test_payload_building_context_does_not_bleed_between_sibling_contexts():
+    """Sibling contexts do not interfere with each other."""
+    with PayloadBuildingContext(key="first"):
+        p1 = Payload(lambda x: x)
+
+    with PayloadBuildingContext(key="second"):
+        p2 = Payload(lambda x: x)
+
+    assert p1.metadata["key"] == "first"
+    assert p2.metadata["key"] == "second"


### PR DESCRIPTION
Introduces a context manager that automatically injects key-value metadata into every Payload constructed within its scope. Contexts can be nested; inner values override outer ones on key collision, and metadata passed directly to Payload() always takes highest priority.

Priority order (lowest to highest):
  1. Function _cascade attributes (mark decorators)
  2. Context stack (outer to inner)
  3. Direct metadata= argument

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
