### PR TITLE
perf: skip pip when all requested packages already satisfied

### DIFF
--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -222,12 +222,13 @@ class Executor:
         self.sender.send(HostId("controller"), m)
 
     def _start_worker(self, worker: WorkerId, attempt_cnt: int, seq: None | TaskSequence) -> WorkerHandle:
+        venv_td, initial_installed = runner_setup.create_venv()
         worker_setup = runner_setup.WorkerSetup(
             workerId=worker,
             workerAttemptCnt=attempt_cnt,
             shm_key=self.runner_ctx_shm_key,
+            initial_installed=initial_installed,
         )
-        venv_td = runner_setup.create_venv()
         p = runner_setup.launch_in_venv(
             "cascade.executor.runner.entrypoint",
             venv_td.name,

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -13,6 +13,7 @@ import logging.config
 import os
 
 import zmq
+from packaging.version import Version
 
 import cascade.executor.platform as platform
 import cascade.executor.serde as serde
@@ -159,7 +160,7 @@ def entrypoint(workerSetup: WorkerSetup, runnerContext: RunnerContext) -> None:
     callback(runnerContext.callback, WorkerReady(workerSetup.workerId))
     with (
         Memory(runnerContext.callback, workerSetup.workerId) as memory,
-        PackagesEnv() as pckg,
+        PackagesEnv({k: Version(v) for k, v in workerSetup.initial_installed.items()}) as pckg,
     ):
         label("worker", repr(workerSetup.workerId))
         worker_num = workerSetup.workerId.worker_num()

--- a/src/cascade/executor/runner/packages.py
+++ b/src/cascade/executor/runner/packages.py
@@ -33,6 +33,7 @@ from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import Callable, Iterable, Literal, cast
 
+from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 from typing_extensions import Self
@@ -488,8 +489,40 @@ class PackagesEnv(AbstractContextManager):
             for dist_name, mod_issues in dist_to_issues.items()
         ]
 
+    def _is_already_satisfied(self, packages: list[str]) -> bool:
+        """Return True if every specifier in packages is satisfied by an already-installed package.
+
+        Checks self._installed (fast, in-memory) then falls back to importlib.metadata for
+        packages installed in the venv but not tracked in the cache. Returns False
+        conservatively for any specifier that cannot be verified, so that pip is still invoked.
+        """
+        for pkg_spec in packages:
+            try:
+                req = Requirement(pkg_spec)
+                name = req.name
+
+                installed_version = self._installed.get(name)
+                if installed_version is None:
+                    try:
+                        installed_version = Version(importlib.metadata.version(name))
+                    except importlib.metadata.PackageNotFoundError:
+                        logger.debug(f"package {name!r} not found in installed metadata, will run pip")
+                        return False
+
+                if installed_version not in req.specifier:
+                    logger.debug(f"installed {name}=={installed_version} does not satisfy {req.specifier!r}, will run pip")
+                    return False
+            except Exception:
+                logger.debug(f"could not verify satisfaction for {pkg_spec!r}, will run pip")
+                return False
+        return True
+
     def extend(self, packages: list[str]) -> None:
         if not packages:
+            return
+
+        if self._is_already_satisfied(packages):
+            logger.debug(f"all {len(packages)} requested packages already satisfied, skipping pip")
             return
 
         packages = list(self._prefer_installed(packages))

--- a/src/cascade/executor/runner/packages.py
+++ b/src/cascade/executor/runner/packages.py
@@ -277,19 +277,25 @@ class PackagesEnv(AbstractContextManager):
     packages can be freely changed by pip.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, initial_installed: dict[str, Version] | None = None) -> None:
         self.clean = True
-        # dist_name -> version, tracks what has been installed into this venv
-        # (pre-populated with the initial earthkit-workflows install from venv creation)
-        self._installed: dict[str, Version] = {}
-        for spec in initial_venv_packages():
-            # parse "name==version" style specs; skip paths (editable installs have no "==")
-            if "==" in spec:
-                name, _, ver_str = spec.partition("==")
-                try:
-                    self._installed[name.strip()] = Version(ver_str.strip())
-                except Exception:
-                    pass
+        # dist_name -> version, tracks what has been installed into this venv.
+        # When initial_installed is provided (production path) it contains the full set of
+        # packages present in the venv at worker startup, parsed from the pip output of
+        # create_venv().  When omitted (tests / legacy callers) we fall back to parsing
+        # initial_venv_packages() which only covers earthkit-workflows itself.
+        if initial_installed is not None:
+            self._installed: dict[str, Version] = dict(initial_installed)
+        else:
+            self._installed = {}
+            for spec in initial_venv_packages():
+                # parse "name==version" style specs; skip paths (editable installs have no "==")
+                if "==" in spec:
+                    name, _, ver_str = spec.partition("==")
+                    try:
+                        self._installed[name.strip()] = Version(ver_str.strip())
+                    except Exception:
+                        pass
         # module_name -> dist_name (or None if no dist found).
         # Populated lazily via _populate_dist_cache(). None entries are kept permanently:
         # modules without a dist are typically oddities and gaining a dist post-install
@@ -492,9 +498,13 @@ class PackagesEnv(AbstractContextManager):
     def _is_already_satisfied(self, packages: list[str]) -> bool:
         """Return True if every specifier in packages is satisfied by an already-installed package.
 
-        Checks self._installed (fast, in-memory) then falls back to importlib.metadata for
-        packages installed in the venv but not tracked in the cache. Returns False
+        Performs a pure in-memory lookup against self._installed.  Returns False
         conservatively for any specifier that cannot be verified, so that pip is still invoked.
+
+        self._installed is pre-populated from the venv creation pip output (covering all
+        transitive deps) and updated after every extend() call.  Packages outside that set
+        (e.g. installed by uv venv itself rather than pip) will cause a single no-op pip
+        invocation, after which extend() back-fills their entry so subsequent calls are free.
         """
         for pkg_spec in packages:
             try:
@@ -503,11 +513,8 @@ class PackagesEnv(AbstractContextManager):
 
                 installed_version = self._installed.get(name)
                 if installed_version is None:
-                    try:
-                        installed_version = Version(importlib.metadata.version(name))
-                    except importlib.metadata.PackageNotFoundError:
-                        logger.debug(f"package {name!r} not found in installed metadata, will run pip")
-                        return False
+                    logger.debug(f"package {name!r} not in installed cache, will run pip")
+                    return False
 
                 if installed_version not in req.specifier:
                     logger.debug(f"installed {name}=={installed_version} does not satisfy {req.specifier!r}, will run pip")
@@ -524,6 +531,11 @@ class PackagesEnv(AbstractContextManager):
         if self._is_already_satisfied(packages):
             logger.debug(f"all {len(packages)} requested packages already satisfied, skipping pip")
             return
+
+        # Save the user-requested packages before _prefer_installed expands them, so we can
+        # back-fill _installed for any packages pip treated as no-ops (already installed but
+        # not yet tracked — e.g. packages installed by uv venv rather than by pip).
+        user_packages = packages
 
         packages = list(self._prefer_installed(packages))
 
@@ -546,6 +558,17 @@ class PackagesEnv(AbstractContextManager):
         newly_installed = _parse_pip_install(install_output)
         self._installed.update(newly_installed)
         self._cache_dist_modules(newly_installed)
+
+        # Back-fill _installed for packages that pip reported as already satisfied (no + line).
+        # Without this, packages that exist in the venv but were never seen by _parse_pip_install
+        # would cause a no-op pip invocation on every subsequent extend() call for the same spec.
+        for pkg_spec in user_packages:
+            try:
+                req = Requirement(pkg_spec)
+                if req.name not in self._installed:
+                    self._installed[req.name] = Version(importlib.metadata.version(req.name))
+            except Exception:
+                pass
 
         install_issues = self._postinstall_verify(install_output)
         if install_issues:

--- a/src/cascade/executor/runner/packages.py
+++ b/src/cascade/executor/runner/packages.py
@@ -277,25 +277,12 @@ class PackagesEnv(AbstractContextManager):
     packages can be freely changed by pip.
     """
 
-    def __init__(self, initial_installed: dict[str, Version] | None = None) -> None:
+    def __init__(self, initial_installed: dict[str, Version]) -> None:
         self.clean = True
         # dist_name -> version, tracks what has been installed into this venv.
-        # When initial_installed is provided (production path) it contains the full set of
-        # packages present in the venv at worker startup, parsed from the pip output of
-        # create_venv().  When omitted (tests / legacy callers) we fall back to parsing
-        # initial_venv_packages() which only covers earthkit-workflows itself.
-        if initial_installed is not None:
-            self._installed: dict[str, Version] = dict(initial_installed)
-        else:
-            self._installed = {}
-            for spec in initial_venv_packages():
-                # parse "name==version" style specs; skip paths (editable installs have no "==")
-                if "==" in spec:
-                    name, _, ver_str = spec.partition("==")
-                    try:
-                        self._installed[name.strip()] = Version(ver_str.strip())
-                    except Exception:
-                        pass
+        # Seeded from the pip output of create_venv() so that all transitive deps
+        # are known upfront and _is_already_satisfied can be a pure dict lookup.
+        self._installed: dict[str, Version] = dict(initial_installed)
         # module_name -> dist_name (or None if no dist found).
         # Populated lazily via _populate_dist_cache(). None entries are kept permanently:
         # modules without a dist are typically oddities and gaining a dist post-install

--- a/src/cascade/executor/runner/setup.py
+++ b/src/cascade/executor/runner/setup.py
@@ -17,6 +17,7 @@ Each worker owns its own temporary venv. This module handles:
  - save/load helpers for the shared RunnerContext in POSIX shared memory
 """
 
+import json
 import logging
 import multiprocessing.resource_tracker
 import os
@@ -29,11 +30,12 @@ from multiprocessing.shared_memory import SharedMemory
 from typing import Any
 
 import cloudpickle
+from packaging.version import Version
 from typing_extensions import Self
 
 from cascade.deployment.logging import LoggingConfig
 from cascade.executor.msg import BackboneAddress
-from cascade.executor.runner.packages import check_run_result, initial_venv_packages, run_command
+from cascade.executor.runner.packages import _parse_pip_install, check_run_result, initial_venv_packages, run_command
 from cascade.executor.runner.runner import ExecutionContext
 from cascade.low.core import DatasetId, JobInstance, TaskId, WorkerId
 from cascade.low.exceptions import CascadeInternalError
@@ -66,17 +68,22 @@ class WorkerSetup:
     workerId: WorkerId
     workerAttemptCnt: int
     shm_key: str
+    # Packages installed in the worker venv at creation time, as {dist_name: version_str}.
+    # Pre-populates PackagesEnv._installed so it can skip pip for already-present packages.
+    initial_installed: dict[str, str]
 
     def to_str(self) -> str:
-        return f"{repr(self.workerId)}|{self.workerAttemptCnt}|{self.shm_key}"
+        installed_json = json.dumps(self.initial_installed)
+        return f"{repr(self.workerId)}|{self.workerAttemptCnt}|{self.shm_key}|{installed_json}"
 
     @classmethod
     def from_str(cls, s: str) -> Self:
-        worker_repr, attempt_str, shm_key = s.split("|", 2)
+        worker_repr, attempt_str, shm_key, installed_json = s.split("|", 3)
         return cls(
             workerId=WorkerId.from_repr(worker_repr),
             workerAttemptCnt=int(attempt_str),
             shm_key=shm_key,
+            initial_installed=json.loads(installed_json),
         )
 
 
@@ -151,19 +158,26 @@ def load_runner_ctx_from_shm(key: str) -> RunnerContext:
     return cloudpickle.loads(data)
 
 
-def create_venv() -> tempfile.TemporaryDirectory:  # type: ignore[type-arg]
-    """Creates a new temporary venv with earthkit-workflows installed at the same version as the parent process."""
+def create_venv() -> tuple[tempfile.TemporaryDirectory[str], dict[str, str]]:
+    """Creates a new temporary venv with earthkit-workflows installed at the same version as the parent process.
+
+    Returns the TemporaryDirectory for the venv and a {dist_name: version_str} dict of every
+    package pip reported as installed, so callers can pre-populate PackagesEnv._installed.
+    """
     td = tempfile.TemporaryDirectory(prefix="cascade_worker_venv_", dir=venv_root)
     logger.debug(f"creating a new worker venv at {td}")
     run_command(["uv", "venv", "--python", _python_version, td.name], check_run_result)
     python = _venv_python(td.name)
+    installed: dict[str, str] = {}
     for install_spec in initial_venv_packages():
         logger.debug(f"installing {install_spec} into worker venv")
-        run_command(
+        result = run_command(
             ["uv", "pip", "install", "--python", python, install_spec],
             check_run_result,
         )
-    return td
+        for dist_name, version in _parse_pip_install(result.stderr).items():
+            installed[dist_name] = str(version)
+    return td, installed
 
 
 def _venv_python(venv_dir: str) -> str:

--- a/src/cascade/executor/runner/setup.py
+++ b/src/cascade/executor/runner/setup.py
@@ -17,7 +17,6 @@ Each worker owns its own temporary venv. This module handles:
  - save/load helpers for the shared RunnerContext in POSIX shared memory
 """
 
-import json
 import logging
 import multiprocessing.resource_tracker
 import os
@@ -30,6 +29,7 @@ from multiprocessing.shared_memory import SharedMemory
 from typing import Any
 
 import cloudpickle
+import orjson
 from packaging.version import Version
 from typing_extensions import Self
 
@@ -73,7 +73,7 @@ class WorkerSetup:
     initial_installed: dict[str, str]
 
     def to_str(self) -> str:
-        installed_json = json.dumps(self.initial_installed)
+        installed_json = orjson.dumps(self.initial_installed).decode()
         return f"{repr(self.workerId)}|{self.workerAttemptCnt}|{self.shm_key}|{installed_json}"
 
     @classmethod
@@ -83,7 +83,7 @@ class WorkerSetup:
             workerId=WorkerId.from_repr(worker_repr),
             workerAttemptCnt=int(attempt_str),
             shm_key=shm_key,
-            initial_installed=json.loads(installed_json),
+            initial_installed=orjson.loads(installed_json),
         )
 
 

--- a/tests/cascade/executor/test_packages.py
+++ b/tests/cascade/executor/test_packages.py
@@ -234,23 +234,23 @@ def test_is_already_satisfied_not_installed() -> None:
     assert not env._is_already_satisfied(["totally-nonexistent-xyz-package"])
 
 
-def test_is_already_satisfied_falls_back_to_importlib() -> None:
-    """Packages not in _installed but present in the venv should be found via importlib."""
+def test_is_already_satisfied_not_in_cache_returns_false() -> None:
+    """Packages not in _installed are not satisfied — no importlib fallback."""
     import numpy
 
     env = PackagesEnv()
     # numpy is NOT in env._installed (we did not add it manually)
     assert "numpy" not in env._installed
-    # but it IS installed in the venv, so _is_already_satisfied should pick it up
-    assert env._is_already_satisfied([f"numpy=={numpy.__version__}"])
-    assert env._is_already_satisfied(["numpy"])
+    # Without the importlib fallback, _is_already_satisfied returns False for anything not cached
+    assert not env._is_already_satisfied([f"numpy=={numpy.__version__}"])
+    assert not env._is_already_satisfied(["numpy"])
 
 
 def test_extend_skips_pip_when_already_satisfied() -> None:
     """When every requested spec is already installed, extend() must not invoke pip."""
     import numpy
 
-    env = PackagesEnv()
+    env = _make_env_with_cache(("numpy", numpy.__version__))
     with patch("cascade.executor.runner.packages.run_command") as mock_run:
         env.extend([f"numpy=={numpy.__version__}"])
         mock_run.assert_not_called()
@@ -264,3 +264,24 @@ def test_extend_calls_pip_when_not_satisfied() -> None:
         mock_run.return_value = type("R", (), {"stderr": "", "stdout": "", "returncode": 0})()
         env.extend(["totally-nonexistent-xyz==999.0.0"])
         mock_run.assert_called_once()
+
+
+def test_extend_backfills_installed_after_noop_pip() -> None:
+    """After a no-op pip run, the requested package should be added to _installed."""
+    import numpy
+
+    env = PackagesEnv()
+    assert "numpy" not in env._installed
+
+    with patch("cascade.executor.runner.packages.run_command") as mock_run:
+        mock_run.return_value = type("R", (), {"stderr": "", "stdout": "", "returncode": 0})()
+        env.extend([f"numpy=={numpy.__version__}"])
+
+    # Back-fill: numpy should now be in _installed even though pip reported no changes
+    assert "numpy" in env._installed
+    assert env._installed["numpy"] == Version(numpy.__version__)
+
+    # Subsequent call should skip pip entirely
+    with patch("cascade.executor.runner.packages.run_command") as mock_run2:
+        env.extend([f"numpy=={numpy.__version__}"])
+        mock_run2.assert_not_called()

--- a/tests/cascade/executor/test_packages.py
+++ b/tests/cascade/executor/test_packages.py
@@ -69,7 +69,7 @@ def test_maybe_imported_version() -> None:
 def test_postinstall_verify() -> None:
     import numpy
 
-    env = PackagesEnv()
+    env = PackagesEnv({})
     goodie = "Using Python 3.11.8 environment at: <venv>\nResolved 1 package in 5ms\nUninstalled 1 package in 12ms\nInstalled 1 package in 18ms\n - numpy==2.4.2\n + numpy=={numpy.__version__}\n"
     issues = env._postinstall_verify(goodie)
     assert not issues
@@ -85,7 +85,7 @@ def test_prefer_installed() -> None:
     import packaging
     import pytest
 
-    env = PackagesEnv()
+    env = PackagesEnv({})
     assert set(env._prefer_installed(["numpy"])) >= {
         f"numpy=={numpy.__version__}",
         f"packaging=={packaging.__version__}",
@@ -103,7 +103,7 @@ def test_prefer_installed() -> None:
 def test_check_conflicts() -> None:
     import numpy
 
-    env = PackagesEnv()
+    env = PackagesEnv({})
 
     # No conflict: single package
     assert env._check_conflicts([f"numpy=={numpy.__version__}"]) == []
@@ -151,7 +151,7 @@ def test_import_pins_includes_imported_modules() -> None:
     import numpy
     import packaging
 
-    env = PackagesEnv()
+    env = PackagesEnv({})
     pins = env._import_pins()
 
     assert "numpy" in pins
@@ -165,7 +165,7 @@ def test_import_pins_includes_imported_modules() -> None:
 def test_dist_name_cache_is_populated() -> None:
     import numpy
 
-    env = PackagesEnv()
+    env = PackagesEnv({})
     # Before any call, cache is empty
     assert "numpy" not in env._dist_name_cache
 
@@ -183,7 +183,7 @@ def test_dist_name_cache_is_populated() -> None:
 
 def _make_env_with_cache(*specs: tuple[str, str]) -> PackagesEnv:
     """Create a PackagesEnv whose _installed cache is pre-populated with (name, version) pairs."""
-    env = PackagesEnv()
+    env = PackagesEnv({})
     for name, ver in specs:
         env._installed[name] = Version(ver)
     return env
@@ -229,7 +229,7 @@ def test_is_already_satisfied_multiple_one_fails() -> None:
 
 
 def test_is_already_satisfied_not_installed() -> None:
-    env = PackagesEnv()
+    env = PackagesEnv({})
     # A package that almost certainly does not exist in this venv
     assert not env._is_already_satisfied(["totally-nonexistent-xyz-package"])
 
@@ -238,7 +238,7 @@ def test_is_already_satisfied_not_in_cache_returns_false() -> None:
     """Packages not in _installed are not satisfied — no importlib fallback."""
     import numpy
 
-    env = PackagesEnv()
+    env = PackagesEnv({})
     # numpy is NOT in env._installed (we did not add it manually)
     assert "numpy" not in env._installed
     # Without the importlib fallback, _is_already_satisfied returns False for anything not cached
@@ -258,7 +258,7 @@ def test_extend_skips_pip_when_already_satisfied() -> None:
 
 def test_extend_calls_pip_when_not_satisfied() -> None:
     """When a spec is NOT satisfied, extend() must still invoke pip (and may fail)."""
-    env = PackagesEnv()
+    env = PackagesEnv({})
     with patch("cascade.executor.runner.packages.run_command") as mock_run:
         # Simulate pip returning empty stderr (no-op install) so extend() completes cleanly
         mock_run.return_value = type("R", (), {"stderr": "", "stdout": "", "returncode": 0})()
@@ -270,7 +270,7 @@ def test_extend_backfills_installed_after_noop_pip() -> None:
     """After a no-op pip run, the requested package should be added to _installed."""
     import numpy
 
-    env = PackagesEnv()
+    env = PackagesEnv({})
     assert "numpy" not in env._installed
 
     with patch("cascade.executor.runner.packages.run_command") as mock_run:

--- a/tests/cascade/executor/test_packages.py
+++ b/tests/cascade/executor/test_packages.py
@@ -1,4 +1,5 @@
 import re
+from unittest.mock import patch
 
 import pytest
 from packaging.version import Version
@@ -173,3 +174,93 @@ def test_dist_name_cache_is_populated() -> None:
     # After _import_pins, numpy should be cached
     assert "numpy" in env._dist_name_cache
     assert env._dist_name_cache["numpy"] == "numpy"
+
+
+# ---------------------------------------------------------------------------
+# Tests for the _is_already_satisfied fast-path and the extend() skip logic
+# ---------------------------------------------------------------------------
+
+
+def _make_env_with_cache(*specs: tuple[str, str]) -> PackagesEnv:
+    """Create a PackagesEnv whose _installed cache is pre-populated with (name, version) pairs."""
+    env = PackagesEnv()
+    for name, ver in specs:
+        env._installed[name] = Version(ver)
+    return env
+
+
+def test_is_already_satisfied_bare_name_in_cache() -> None:
+    env = _make_env_with_cache(("mylib", "1.2.3"))
+    # Bare name with no constraint - should be satisfied by anything installed
+    assert env._is_already_satisfied(["mylib"])
+
+
+def test_is_already_satisfied_exact_pin_matches() -> None:
+    env = _make_env_with_cache(("mylib", "1.2.3"))
+    assert env._is_already_satisfied(["mylib==1.2.3"])
+
+
+def test_is_already_satisfied_exact_pin_mismatches() -> None:
+    env = _make_env_with_cache(("mylib", "1.2.3"))
+    assert not env._is_already_satisfied(["mylib==1.0.0"])
+
+
+def test_is_already_satisfied_range_satisfied() -> None:
+    env = _make_env_with_cache(("mylib", "1.2.3"))
+    assert env._is_already_satisfied(["mylib>=1.0.0"])
+    assert env._is_already_satisfied(["mylib>=1.0.0,<2.0.0"])
+
+
+def test_is_already_satisfied_range_not_satisfied() -> None:
+    env = _make_env_with_cache(("mylib", "1.2.3"))
+    assert not env._is_already_satisfied(["mylib>=2.0.0"])
+    assert not env._is_already_satisfied(["mylib<1.0.0"])
+
+
+def test_is_already_satisfied_multiple_all_satisfied() -> None:
+    env = _make_env_with_cache(("aaa", "1.0.0"), ("bbb", "2.5.0"))
+    assert env._is_already_satisfied(["aaa==1.0.0", "bbb>=2.0"])
+
+
+def test_is_already_satisfied_multiple_one_fails() -> None:
+    env = _make_env_with_cache(("aaa", "1.0.0"), ("bbb", "2.5.0"))
+    # bbb is satisfied but aaa is not
+    assert not env._is_already_satisfied(["aaa==9.9.9", "bbb>=2.0"])
+
+
+def test_is_already_satisfied_not_installed() -> None:
+    env = PackagesEnv()
+    # A package that almost certainly does not exist in this venv
+    assert not env._is_already_satisfied(["totally-nonexistent-xyz-package"])
+
+
+def test_is_already_satisfied_falls_back_to_importlib() -> None:
+    """Packages not in _installed but present in the venv should be found via importlib."""
+    import numpy
+
+    env = PackagesEnv()
+    # numpy is NOT in env._installed (we did not add it manually)
+    assert "numpy" not in env._installed
+    # but it IS installed in the venv, so _is_already_satisfied should pick it up
+    assert env._is_already_satisfied([f"numpy=={numpy.__version__}"])
+    assert env._is_already_satisfied(["numpy"])
+
+
+def test_extend_skips_pip_when_already_satisfied() -> None:
+    """When every requested spec is already installed, extend() must not invoke pip."""
+    import numpy
+
+    env = PackagesEnv()
+    with patch("cascade.executor.runner.packages.run_command") as mock_run:
+        env.extend([f"numpy=={numpy.__version__}"])
+        mock_run.assert_not_called()
+
+
+def test_extend_calls_pip_when_not_satisfied() -> None:
+    """When a spec is NOT satisfied, extend() must still invoke pip (and may fail)."""
+    env = PackagesEnv()
+    with patch("cascade.executor.runner.packages.run_command") as mock_run:
+        # Simulate pip returning empty stderr (no-op install) so extend() completes cleanly
+        mock_run.return_value = type("R", (), {"stderr": "", "stdout": "", "returncode": 0})()
+        env.extend(["totally-nonexistent-xyz==999.0.0"])
+        mock_run.assert_called_once()

--- a/tests/cascade/executor/test_runner.py
+++ b/tests/cascade/executor/test_runner.py
@@ -92,7 +92,7 @@ def test_runner(monkeypatch):
         schema_lookup=RunnerContext.build_schema_lookup(job),
     )
 
-    with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv() as pckg:
+    with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv({}) as pckg:
         entrypoint.execute_sequence(emptyTs, memoryInstance, pckg, emptyRc)
     assert msgs == []
 
@@ -129,7 +129,7 @@ def test_runner(monkeypatch):
         schema_lookup=RunnerContext.build_schema_lookup(oneTaskJob),
     )
 
-    with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv() as pckg:
+    with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv({}) as pckg:
         entrypoint.execute_sequence(oneTaskTs, memoryInstance, pckg, oneTaskRc)
     assert msgs == [DatasetPublished(origin=worker, ds=t2ds, transmit_idx=None)]
     msgs = []
@@ -170,7 +170,7 @@ def test_runner(monkeypatch):
         schema_lookup=RunnerContext.build_schema_lookup(twoTaskJob),
     )
 
-    with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv() as pckg:
+    with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv({}) as pckg:
         entrypoint.execute_sequence(twoTaskTs, memoryInstance, pckg, twoTaskRc)
     # NOTE we assert for both messages even though *only* t3o has been specified in `publish`
     # this is because there is no fine-graining yet to distingiush between worker-mem-only
@@ -237,7 +237,7 @@ def test_runner(monkeypatch):
         schema_lookup=RunnerContext.build_schema_lookup(t4Job),
     )
 
-    with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv() as pckg:
+    with memory.Memory(test_address, worker) as memoryInstance, PackagesEnv({}) as pckg:
         entrypoint.execute_sequence(t4TaskTs, memoryInstance, pckg, t4Rc)
 
     # NOTE as above, we want to ignore the initial worker-mem-only publishes

--- a/tests/cascade/executor/util.py
+++ b/tests/cascade/executor/util.py
@@ -82,7 +82,7 @@ def simple_runner(callback: BackboneAddress, executionContext: ExecutionContext)
         raise ValueError(f"expected 1 task, gotten {len(tasks)}")
     taskId = tasks[0]
     taskInstance = executionContext.tasks[taskId]
-    with Memory(callback, WorkerId(host=HostId("testHost"), worker="testWorker")) as memory, PackagesEnv() as pckg:
+    with Memory(callback, WorkerId(host=HostId("testHost"), worker="testWorker")) as memory, PackagesEnv({}) as pckg:
         # for key, value in taskSequence.extra_env.items():
         #    os.environ[key] = value
 


### PR DESCRIPTION
Add PackagesEnv._is_already_satisfied() which checks, without invoking pip, whether every specifier in the user's package list is already met by an installed distribution. The check consults self._installed (the in-process cache) first, then falls back to importlib.metadata for packages present in the venv but not yet tracked in the cache. If every specifier is satisfied the extend() call returns immediately, avoiding the full pip invocation (resolve, network check, subprocess overhead).

The fast path is conservative: any specifier that cannot be verified triggers the normal pip flow. When pip is invoked it receives the full, broad package list as before.

Add unit tests covering:
- bare name / exact pin / range constraints against the in-memory cache
- multiple specs where one or more fail
- fallback to importlib.metadata for packages not in the cache
- extend() skips run_command when satisfied (mock)
- extend() still calls run_command when unsatisfied (mock)

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
