### PR TITLE
Switch worker launch to multiprocessing

### DIFF
--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -18,7 +18,6 @@ the tasks themselves.
 import atexit
 import logging
 import os
-import subprocess
 import tempfile
 import uuid
 from dataclasses import dataclass
@@ -58,7 +57,7 @@ from cascade.executor.msg import (
     WorkerShutdown,
 )
 from cascade.executor.runner.entrypoint import worker_address
-from cascade.executor.runner.setup import RunnerContext
+from cascade.executor.runner.setup import RunnerContext, WorkerProcessHandle
 from cascade.low.core import DatasetId, HostId, JobInstance, TaskId, WorkerId
 from cascade.low.exceptions import CascadeError, CascadeInfrastructureError, CascadeInternalError, CascadeUserError, ser
 from cascade.low.func import md5hash24
@@ -79,7 +78,7 @@ def address_of(port: int) -> BackboneAddress:
 
 @dataclass
 class WorkerHandle:
-    process: subprocess.Popen[bytes]
+    process: WorkerProcessHandle
     attempt_cnt: int
     venv_dir: tempfile.TemporaryDirectory[str]
 
@@ -104,7 +103,7 @@ class Executor:
         self.workers: dict[WorkerId, WorkerHandle | None] = {WorkerId(host, f"w{i}"): None for i in range(workers)}
         self.worker_awaits: dict[WorkerId, None | TaskSequence] = {}
         self.loggingConfig = loggingConfig
-        self.old_workers: list[tuple[subprocess.Popen[bytes], tempfile.TemporaryDirectory[str]]] = []
+        self.old_workers: list[tuple[WorkerProcessHandle, tempfile.TemporaryDirectory[str]]] = []
 
         self.datasets: set[DatasetId] = set()
         self.heartbeat_watcher = GraceWatcher(grace_ms=heartbeat_grace_ms)

--- a/src/cascade/executor/platform.py
+++ b/src/cascade/executor/platform.py
@@ -17,6 +17,13 @@ import typing
 
 from cascade.low.exceptions import CascadeInternalError
 
+NewWorkerMethod = typing.Literal["popen", "multiprocessing"]
+
+NEW_WORKER_METHOD_BY_PLATFORM: dict[str, NewWorkerMethod] = {
+    "darwin": "multiprocessing",
+    "linux": "multiprocessing",
+}
+
 
 def get_bindabble_self():
     """Returns a hostname such that zmq can bind to it"""
@@ -66,6 +73,15 @@ def get_mp_ctx(situation: MpSituation) -> mp.context.ForkContext | mp.context.Sp
         return mp.get_context("forkserver")
     else:
         return mp.get_context("fork")
+
+
+def get_new_worker_method() -> NewWorkerMethod:
+    env_value = os.environ.get("CASCADE_NEW_WORKER_METHOD")
+    if env_value is not None and env_value != "":
+        if env_value in typing.get_args(NewWorkerMethod):
+            return typing.cast(NewWorkerMethod, env_value)
+        raise ValueError(f"unrecognized CASCADE_NEW_WORKER_METHOD={env_value!r}")
+    return NEW_WORKER_METHOD_BY_PLATFORM.get(sys.platform, "popen")
 
 
 # NOTE not really perftested, more like for fun

--- a/src/cascade/executor/runner/setup.py
+++ b/src/cascade/executor/runner/setup.py
@@ -10,21 +10,28 @@
 
 Each worker owns its own temporary venv. This module handles:
  - creation of a temporary venv with the same Python version and an initial earthkit-workflows install
- - launching a Python module as a subprocess inside that venv
+ - launching a Python module inside that venv
  - cleanup/termination of both the process and the venv directory
  - RunnerContext: the shared per-executor context passed to all workers via shared memory
  - WorkerSetup: the per-worker identity passed via environment variable
  - save/load helpers for the shared RunnerContext in POSIX shared memory
 """
 
+import importlib
 import logging
-import multiprocessing.resource_tracker
+import multiprocessing as mp
+import multiprocessing.resource_tracker as resource_tracker
 import os
+import runpy
+import site
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import time
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from multiprocessing.process import BaseProcess
 from multiprocessing.shared_memory import SharedMemory
 from typing import Any
 
@@ -33,6 +40,7 @@ import orjson
 from packaging.version import Version
 from typing_extensions import Self
 
+import cascade.executor.platform as platform
 from cascade.deployment.logging import LoggingConfig
 from cascade.executor.msg import BackboneAddress
 from cascade.executor.runner.packages import _parse_pip_install, check_run_result, initial_venv_packages, run_command
@@ -59,6 +67,84 @@ if (sys.version_info.major, sys.version_info.minor) >= (3, 13):
 else:
     _is_unregister = True
     _shm_kwargs = {}
+
+
+class WorkerProcessHandle(ABC):
+    @property
+    @abstractmethod
+    def pid(self) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def poll(self) -> int | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_alive(self) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def wait(self, timeout: float | None = None) -> int | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def terminate(self) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def kill(self) -> None:
+        raise NotImplementedError
+
+
+@dataclass
+class PopenWorkerProcessHandle(WorkerProcessHandle):
+    process: subprocess.Popen[bytes]
+
+    @property
+    def pid(self) -> int:
+        assert self.process.pid is not None
+        return self.process.pid
+
+    def poll(self) -> int | None:
+        return self.process.poll()
+
+    def is_alive(self) -> bool:
+        return self.process.poll() is None
+
+    def wait(self, timeout: float | None = None) -> int | None:
+        return self.process.wait(timeout=timeout)
+
+    def terminate(self) -> None:
+        self.process.terminate()
+
+    def kill(self) -> None:
+        self.process.kill()
+
+
+@dataclass
+class MpWorkerProcessHandle(WorkerProcessHandle):
+    process: BaseProcess
+
+    @property
+    def pid(self) -> int:
+        assert self.process.pid is not None
+        return self.process.pid
+
+    def poll(self) -> int | None:
+        return self.process.exitcode if not self.process.is_alive() else None
+
+    def is_alive(self) -> bool:
+        return self.process.is_alive()
+
+    def wait(self, timeout: float | None = None) -> int | None:
+        self.process.join(timeout)
+        return self.process.exitcode if not self.process.is_alive() else None
+
+    def terminate(self) -> None:
+        self.process.terminate()
+
+    def kill(self) -> None:
+        self.process.kill()
 
 
 @dataclass(frozen=True)
@@ -138,7 +224,7 @@ def save_runner_ctx_to_shm(ctx: RunnerContext, key: str) -> SharedMemory:
             time.sleep(1)  # on mac, create right after unlink leads to not found
         shm = SharedMemory(key, create=True, size=size, **_shm_kwargs)
     if _is_unregister:
-        multiprocessing.resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
+        resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
     assert shm.buf is not None
     shm.buf[:size] = data
     return shm
@@ -151,7 +237,7 @@ def load_runner_ctx_from_shm(key: str) -> RunnerContext:
     """
     shm = SharedMemory(key, create=False, **_shm_kwargs)
     if _is_unregister:
-        multiprocessing.resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
+        resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
     assert shm.buf is not None
     data = bytes(shm.buf[: shm.size])
     shm.close()
@@ -184,45 +270,84 @@ def _venv_python(venv_dir: str) -> str:
     return os.path.join(venv_dir, "bin", "python")
 
 
-def _propagate_sysprefix(env: dict[str, str]) -> None:
-    # Upserts PYTHONPATH in the env to capture all sys.prefix extra values.
-    # If there was an editable install in the parent venv, this propagates it
-    parent_venv = sys.prefix
-    extra_paths = [p for p in sys.path if p and not p.startswith(parent_venv)]
-    pythonpath = os.pathsep.join(extra_paths)
-    if pythonpath:
-        existing = env.get("PYTHONPATH", "")
-        env["PYTHONPATH"] = f"{pythonpath}{os.pathsep}{existing}" if existing else pythonpath
+def _venv_site_paths(venv_dir: str) -> list[str]:
+    paths = sysconfig.get_paths(vars={"base": venv_dir, "platbase": venv_dir})
+    result: list[str] = []
+    for key in ("purelib", "platlib"):
+        path = paths.get(key)
+        if path and path not in result:
+            result.append(path)
+    return result
 
 
-def launch_in_venv(module: str, venv_dir: str, envvars: dict[str, str]) -> "subprocess.Popen[bytes]":
-    """Launches `python -m module` inside the given venv with the provided environment variables.
-
-    The parent process's non-venv sys.path entries are forwarded via PYTHONPATH so that
-    cloudpickle-serialized callables referencing caller-side modules (e.g. test modules,
-    editable source trees) can be unpickled in the worker.
-    """
+def _build_worker_env(venv_dir: str, envvars: dict[str, str]) -> dict[str, str]:
     python = _venv_python(venv_dir)
     env = {**os.environ, **envvars, "VIRTUAL_ENV": venv_dir}
-    # NOTE we currentnly disable this call -- it does propagate editable installs finely, but
-    # it propagates *all* of them without actually installing their prereqs, which is unhealthy
-    # _propagate_sysprefix(env)
-    logger.debug(f"launching {module} in {venv_dir}")
+    env["PATH"] = f"{os.path.dirname(python)}{os.pathsep}{env.get('PATH', '')}"
+    return env
+
+
+def _activate_worker_venv(venv_dir: str, envvars: dict[str, str]) -> None:
+    env = _build_worker_env(venv_dir, envvars)
+    os.environ.clear()
+    os.environ.update(env)
+    sys.executable = _venv_python(venv_dir)
+    sys.prefix = venv_dir
+    sys.exec_prefix = venv_dir
+    for site_path in reversed(_venv_site_paths(venv_dir)):
+        site.addsitedir(site_path)
+        while site_path in sys.path:
+            sys.path.remove(site_path)
+        sys.path.insert(0, site_path)
+    importlib.invalidate_caches()
+
+
+def _launch_worker_module(module: str, venv_dir: str, envvars: dict[str, str]) -> None:
+    _activate_worker_venv(venv_dir, envvars)
+    runpy.run_module(module, run_name="__main__", alter_sys=True)
+
+
+def _launch_via_popen(module: str, venv_dir: str, envvars: dict[str, str]) -> WorkerProcessHandle:
+    python = _venv_python(venv_dir)
+    env = _build_worker_env(venv_dir, envvars)
+    logger.debug(f"launching {module} in {venv_dir} via popen")
     try:
-        return subprocess.Popen([python, "-m", module], env=env)
+        process = subprocess.Popen([python, "-m", module], env=env)
     except OSError as e:
         raise CascadeInternalError(f"failed to launch worker process (env may be too large): {repr(e)}", parent=e) from e
+    return PopenWorkerProcessHandle(process)
 
 
-def terminate_worker(process: subprocess.Popen[bytes], venv_dir: tempfile.TemporaryDirectory[str]) -> None:
+def _launch_via_multiprocessing(module: str, venv_dir: str, envvars: dict[str, str]) -> WorkerProcessHandle:
+    ctx = platform.get_mp_ctx("worker")
+    process = ctx.Process(target=_launch_worker_module, args=(module, venv_dir, envvars))
+    logger.debug(f"launching {module} in {venv_dir} via multiprocessing")
+    process.start()
+    return MpWorkerProcessHandle(process)
+
+
+def launch_in_venv(module: str, venv_dir: str, envvars: dict[str, str]) -> WorkerProcessHandle:
+    """Launches `python -m module` inside the given venv with the provided environment variables."""
+    method = platform.get_new_worker_method()
+    if method == "popen":
+        return _launch_via_popen(module, venv_dir, envvars)
+    return _launch_via_multiprocessing(module, venv_dir, envvars)
+
+
+def terminate_worker(process: WorkerProcessHandle, venv_dir: tempfile.TemporaryDirectory[str]) -> None:
     """Terminates the worker process and cleans up its venv directory."""
-    if process.poll() is None:
+    if process.is_alive():
         process.terminate()
         try:
             process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
+        except Exception:
+            logger.debug("worker did not exit cleanly during graceful shutdown wait", exc_info=True)
+        if process.is_alive():
             process.kill()
+        try:
             process.wait()
+        except Exception:
+            logger.debug("worker wait after shutdown raised", exc_info=True)
     try:
         venv_dir.cleanup()
     except Exception as e:

--- a/tests/cascade/executor/test_runner_setup.py
+++ b/tests/cascade/executor/test_runner_setup.py
@@ -1,0 +1,189 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from dataclasses import dataclass
+
+import pytest
+
+import cascade.executor.platform as platform
+import cascade.executor.runner.setup as setup
+
+
+def test_get_new_worker_method_defaults_by_platform(monkeypatch) -> None:
+    monkeypatch.setattr(platform.sys, "platform", "darwin")
+    monkeypatch.delenv("CASCADE_NEW_WORKER_METHOD", raising=False)
+    assert platform.get_new_worker_method() == "multiprocessing"
+    monkeypatch.setattr(platform.sys, "platform", "linux")
+    assert platform.get_new_worker_method() == "multiprocessing"
+    monkeypatch.setattr(platform.sys, "platform", "plan9")
+    assert platform.get_new_worker_method() == "popen"
+    monkeypatch.setenv("CASCADE_NEW_WORKER_METHOD", "popen")
+    assert platform.get_new_worker_method() == "popen"
+    monkeypatch.setenv("CASCADE_NEW_WORKER_METHOD", "multiprocessing")
+    assert platform.get_new_worker_method() == "multiprocessing"
+    monkeypatch.setenv("CASCADE_NEW_WORKER_METHOD", "invalid")
+    with pytest.raises(ValueError):
+        platform.get_new_worker_method()
+
+
+@dataclass
+class _FakePopen:
+    args: list[str]
+    env: dict[str, str]
+    alive: bool = True
+    killed: bool = False
+    terminated: bool = False
+
+    @property
+    def pid(self) -> int:
+        return 1234
+
+    def poll(self) -> int | None:
+        return None if self.alive else 0
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.alive = False
+        return 0
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.alive = False
+
+    def kill(self) -> None:
+        self.killed = True
+        self.alive = False
+
+
+def test_launch_in_venv_popen(monkeypatch) -> None:
+    captured_args: list[str] | None = None
+    captured_env: dict[str, str] | None = None
+
+    def fake_popen(args, env):  # type: ignore[no-untyped-def]
+        nonlocal captured_args, captured_env
+        captured_args = list(args)
+        captured_env = dict(env)
+        return _FakePopen(args=list(args), env=dict(env))
+
+    monkeypatch.setattr(setup.subprocess, "Popen", fake_popen)
+
+    monkeypatch.setenv("CASCADE_NEW_WORKER_METHOD", "popen")
+    handle = setup.launch_in_venv("demo.module", "/tmp/demo-venv", {"X_TEST": "1"})
+
+    assert isinstance(handle, setup.PopenWorkerProcessHandle)
+    assert captured_args == ["/tmp/demo-venv/bin/python", "-m", "demo.module"]
+    assert captured_env is not None
+    assert captured_env["VIRTUAL_ENV"] == "/tmp/demo-venv"
+    assert captured_env["X_TEST"] == "1"
+    assert captured_env["PATH"].startswith("/tmp/demo-venv/bin")
+    assert handle.pid == 1234
+
+
+class _FakeProcess:
+    def __init__(self) -> None:
+        self.started = False
+        self.alive = True
+        self.exitcode = None
+        self.pid = 4321
+        self.terminated = False
+        self.killed = False
+        self.target: object | None = None
+        self.args: tuple[object, ...] | None = None
+
+    def start(self) -> None:
+        self.started = True
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+    def join(self, timeout: float | None = None) -> None:
+        self.alive = False
+        if self.exitcode is None:
+            self.exitcode = 0
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.alive = False
+        self.exitcode = -15
+
+    def kill(self) -> None:
+        self.killed = True
+        self.alive = False
+        self.exitcode = -9
+
+
+def test_launch_in_venv_multiprocessing(monkeypatch) -> None:
+    fake_process = _FakeProcess()
+
+    class _FakeContext:
+        def Process(self, target, args):  # type: ignore[no-untyped-def]
+            fake_process.target = target
+            fake_process.args = tuple(args)
+            return fake_process
+
+    monkeypatch.setattr(setup.mp, "get_context", lambda method: _FakeContext())
+
+    monkeypatch.setenv("CASCADE_NEW_WORKER_METHOD", "multiprocessing")
+    handle = setup.launch_in_venv("demo.module", "/tmp/demo-venv", {"X_TEST": "1"})
+
+    assert isinstance(handle, setup.MpWorkerProcessHandle)
+    assert fake_process.started
+    assert fake_process.args == ("demo.module", "/tmp/demo-venv", {"X_TEST": "1"})
+    assert fake_process.target is setup._launch_worker_module
+    assert handle.pid == 4321
+    assert handle.poll() is None
+    assert handle.is_alive()
+    handle.terminate()
+    assert fake_process.terminated
+    assert handle.poll() == -15
+    assert handle.wait() == -15
+
+
+def test_terminate_worker_grace_period(tmp_path) -> None:
+    calls: list[tuple[str, float | None]] = []
+
+    @dataclass
+    class _TermProc(setup.WorkerProcessHandle):
+        alive: bool = True
+        terminated: bool = False
+        killed: bool = False
+
+        @property
+        def pid(self) -> int:
+            return 9999
+
+        def poll(self) -> int | None:
+            return None if self.alive else 0
+
+        def is_alive(self) -> bool:
+            return self.alive
+
+        def terminate(self) -> None:
+            calls.append(("terminate", None))
+            self.terminated = True
+
+        def wait(self, timeout: float | None = None) -> int | None:
+            calls.append(("wait", timeout))
+            if timeout is not None:
+                raise TimeoutError
+            self.alive = False
+            return 0
+
+        def kill(self) -> None:
+            calls.append(("kill", None))
+            self.killed = True
+            self.alive = False
+
+    proc = _TermProc()
+    venv_dir = setup.tempfile.TemporaryDirectory(dir=tmp_path)
+
+    setup.terminate_worker(proc, venv_dir)
+
+    assert calls == [("terminate", None), ("wait", 5), ("kill", None), ("wait", None)]


### PR DESCRIPTION
Use a platform/env-controlled worker launcher abstraction, keep pip targeting the worker venv, and restore graceful shutdown waiting before kill.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
