### PR TITLE
Feat/worker std redirect

### DIFF
--- a/integration_tests/job_numpyTrivial.py
+++ b/integration_tests/job_numpyTrivial.py
@@ -9,21 +9,11 @@ from cascade.low.core import JobInstance, JobInstanceRich
 
 
 def job() -> JobInstanceRich:
-    fac = lambda version: TaskBuilder.from_entrypoint(
-        "runtime.check_numpy_version",
-        {"expected": "str"},
-        "bool",
-        [f"numpy=={version}"],
-    ).with_values(expected=version)
-
     b = JobBuilder()
     b = b.with_node("source", TaskBuilder.from_entrypoint("runtime.source_numpy", {}, "numpy.ndarray", ["numpy"]))
     b = b.with_node(
         "t1", TaskBuilder.from_entrypoint("runtime.transform_numpy", {"a": "numpy.ndarray"}, "numpy.ndarray", ["numpy"])
     ).with_edge("source", "t1", "a")
-    b = b.with_node(
-        "t2", TaskBuilder.from_entrypoint("runtime.transform_numpy", {"a": "numpy.ndarray"}, "numpy.ndarray", ["numpy==2.0.0"])
-    ).with_edge("t1", "t2", "a")
     return JobInstanceRich(jobInstance=b.build().get_or_raise(), checkpointSpec=None)
 
 

--- a/src/cascade/deployment/logging/__init__.py
+++ b/src/cascade/deployment/logging/__init__.py
@@ -33,7 +33,7 @@ can be implemented fully within this module
 import base64
 import logging
 import logging.config
-import os
+from dataclasses import dataclass
 from typing import Literal
 
 import orjson
@@ -66,12 +66,30 @@ class LoggingConfig(CascadeBaseModel):
 DefaultLoggingConfig = LoggingConfig()
 
 
+@dataclass(frozen=True, slots=True)
+class ProcessLogPaths:
+    logs: str
+    stdout: str
+    stderr: str
+
+
+def process_log_paths(loggingConfig: LoggingConfig, hostAndRole: str) -> ProcessLogPaths | None:
+    if loggingConfig.path_base is None:
+        return None
+    path_prefix = f"{loggingConfig.path_base}{hostAndRole}"
+    return ProcessLogPaths(
+        logs=f"{path_prefix}.logs.txt",
+        stdout=f"{path_prefix}.stdout.txt",
+        stderr=f"{path_prefix}.stderr.txt",
+    )
+
+
 def as_dict_config(loggingConfig: LoggingConfig, hostAndRole: str) -> dict:
     if loggingConfig.disable:
         return {"version": 1, "disable_existing_loggers": True}
-    if loggingConfig.path_base:
-        filename = f"{loggingConfig.path_base}{hostAndRole}.txt"
-        handler = defaults.handlers["filename"](filename)  # ty:ignore[call-non-callable] # sloppy typing on my side
+    process_paths = process_log_paths(loggingConfig, hostAndRole)
+    if process_paths is not None:
+        handler = defaults.handlers["filename"](process_paths.logs)  # ty:ignore[call-non-callable] # sloppy typing on my side
     else:
         handler = defaults.handlers["stdout"]
     return {

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -28,7 +28,7 @@ import cascade.executor.platform as platform
 import cascade.executor.runner.setup as runner_setup
 import cascade.shm.api as shm_api
 import cascade.shm.client as shm_client
-from cascade.deployment.logging import LoggingConfig, as_dict_config
+from cascade.deployment.logging import LoggingConfig, as_dict_config, process_log_paths
 from cascade.executor.comms import GraceWatcher, Listener, ReliableSender, callback
 from cascade.executor.comms import default_message_resend_ms as resend_grace_ms
 from cascade.executor.comms import default_timeout_ms as comms_default_timeout_ms
@@ -228,10 +228,13 @@ class Executor:
             shm_key=self.runner_ctx_shm_key,
             initial_installed=initial_installed,
         )
+        worker_log_paths = process_log_paths(self.loggingConfig, f"worker_{worker.worker}")
         p = runner_setup.launch_in_venv(
             "cascade.executor.runner.entrypoint",
             venv_td.name,
             {runner_setup.WORKER_SETUP_ENVVAR: worker_setup.to_str()},
+            stdout_path=worker_log_paths.stdout if worker_log_paths is not None else None,
+            stderr_path=worker_log_paths.stderr if worker_log_paths is not None else None,
         )
         if worker in self.worker_awaits:
             raise CascadeInternalError(f"{worker=} was already awaiting")

--- a/src/cascade/executor/runner/setup.py
+++ b/src/cascade/executor/runner/setup.py
@@ -30,6 +30,7 @@ import sysconfig
 import tempfile
 import time
 from abc import ABC, abstractmethod
+from contextlib import ExitStack
 from dataclasses import dataclass
 from multiprocessing.process import BaseProcess
 from multiprocessing.shared_memory import SharedMemory
@@ -302,36 +303,77 @@ def _activate_worker_venv(venv_dir: str, envvars: dict[str, str]) -> None:
     importlib.invalidate_caches()
 
 
-def _launch_worker_module(module: str, venv_dir: str, envvars: dict[str, str]) -> None:
+def _redirect_standard_streams(stdout_path: str | None, stderr_path: str | None) -> None:
+    if stdout_path:
+        sys.stdout.flush()
+        stdout_fd = os.open(stdout_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        os.dup2(stdout_fd, 1)
+        os.close(stdout_fd)
+    if stderr_path:
+        sys.stderr.flush()
+        stderr_fd = os.open(stderr_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        os.dup2(stderr_fd, 2)
+        os.close(stderr_fd)
+
+
+def _launch_worker_module(
+    module: str,
+    venv_dir: str,
+    envvars: dict[str, str],
+    stdout_path: str | None,
+    stderr_path: str | None,
+) -> None:
+    _redirect_standard_streams(stdout_path, stderr_path)
     _activate_worker_venv(venv_dir, envvars)
     runpy.run_module(module, run_name="__main__", alter_sys=True)
 
 
-def _launch_via_popen(module: str, venv_dir: str, envvars: dict[str, str]) -> WorkerProcessHandle:
+def _launch_via_popen(
+    module: str,
+    venv_dir: str,
+    envvars: dict[str, str],
+    stdout_path: str | None,
+    stderr_path: str | None,
+) -> WorkerProcessHandle:
     python = _venv_python(venv_dir)
     env = _build_worker_env(venv_dir, envvars)
     logger.debug(f"launching {module} in {venv_dir} via popen")
     try:
-        process = subprocess.Popen([python, "-m", module], env=env)
+        with ExitStack() as stack:
+            stdout = stack.enter_context(open(stdout_path, "ab")) if stdout_path is not None else None
+            stderr = stack.enter_context(open(stderr_path, "ab")) if stderr_path is not None else None
+            process = subprocess.Popen([python, "-m", module], env=env, stdout=stdout, stderr=stderr)
     except OSError as e:
         raise CascadeInternalError(f"failed to launch worker process (env may be too large): {repr(e)}", parent=e) from e
     return PopenWorkerProcessHandle(process)
 
 
-def _launch_via_multiprocessing(module: str, venv_dir: str, envvars: dict[str, str]) -> WorkerProcessHandle:
+def _launch_via_multiprocessing(
+    module: str,
+    venv_dir: str,
+    envvars: dict[str, str],
+    stdout_path: str | None,
+    stderr_path: str | None,
+) -> WorkerProcessHandle:
     ctx = platform.get_mp_ctx("worker")
-    process = ctx.Process(target=_launch_worker_module, args=(module, venv_dir, envvars))
+    process = ctx.Process(target=_launch_worker_module, args=(module, venv_dir, envvars, stdout_path, stderr_path))
     logger.debug(f"launching {module} in {venv_dir} via multiprocessing")
     process.start()
     return MpWorkerProcessHandle(process)
 
 
-def launch_in_venv(module: str, venv_dir: str, envvars: dict[str, str]) -> WorkerProcessHandle:
+def launch_in_venv(
+    module: str,
+    venv_dir: str,
+    envvars: dict[str, str],
+    stdout_path: str | None = None,
+    stderr_path: str | None = None,
+) -> WorkerProcessHandle:
     """Launches `python -m module` inside the given venv with the provided environment variables."""
     method = platform.get_new_worker_method()
     if method == "popen":
-        return _launch_via_popen(module, venv_dir, envvars)
-    return _launch_via_multiprocessing(module, venv_dir, envvars)
+        return _launch_via_popen(module, venv_dir, envvars, stdout_path, stderr_path)
+    return _launch_via_multiprocessing(module, venv_dir, envvars, stdout_path, stderr_path)
 
 
 def terminate_worker(process: WorkerProcessHandle, venv_dir: tempfile.TemporaryDirectory[str]) -> None:

--- a/tests/cascade/deployment/test_logging.py
+++ b/tests/cascade/deployment/test_logging.py
@@ -1,0 +1,26 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from cascade.deployment.logging import LoggingConfig, as_dict_config, process_log_paths
+
+
+def test_as_dict_config_uses_logs_suffix() -> None:
+    cfg = LoggingConfig(path_base="/tmp/cascade.")
+    dict_config = as_dict_config(cfg, "worker_w0")
+    handler = dict_config["handlers"]["default"]
+    assert handler["class"] == "logging.FileHandler"
+    assert handler["filename"] == "/tmp/cascade.worker_w0.logs.txt"
+
+
+def test_process_log_paths_for_worker_role() -> None:
+    cfg = LoggingConfig(path_base="/tmp/cascade.")
+    paths = process_log_paths(cfg, "worker_w0")
+    assert paths is not None
+    assert paths.logs == "/tmp/cascade.worker_w0.logs.txt"
+    assert paths.stdout == "/tmp/cascade.worker_w0.stdout.txt"
+    assert paths.stderr == "/tmp/cascade.worker_w0.stderr.txt"

--- a/tests/cascade/executor/test_runner_setup.py
+++ b/tests/cascade/executor/test_runner_setup.py
@@ -7,6 +7,7 @@
 # nor does it submit to any jurisdiction.
 
 from dataclasses import dataclass
+from typing import BinaryIO
 
 import pytest
 
@@ -35,6 +36,8 @@ def test_get_new_worker_method_defaults_by_platform(monkeypatch) -> None:
 class _FakePopen:
     args: list[str]
     env: dict[str, str]
+    stdout: BinaryIO | None = None
+    stderr: BinaryIO | None = None
     alive: bool = True
     killed: bool = False
     terminated: bool = False
@@ -65,12 +68,16 @@ class _FakePopen:
 def test_launch_in_venv_popen(monkeypatch) -> None:
     captured_args: list[str] | None = None
     captured_env: dict[str, str] | None = None
+    captured_stdout: BinaryIO | None = None
+    captured_stderr: BinaryIO | None = None
 
-    def fake_popen(args, env):  # type: ignore[no-untyped-def]
-        nonlocal captured_args, captured_env
+    def fake_popen(args, env, stdout=None, stderr=None):  # type: ignore[no-untyped-def]
+        nonlocal captured_args, captured_env, captured_stdout, captured_stderr
         captured_args = list(args)
         captured_env = dict(env)
-        return _FakePopen(args=list(args), env=dict(env))
+        captured_stdout = stdout
+        captured_stderr = stderr
+        return _FakePopen(args=list(args), env=dict(env), stdout=stdout, stderr=stderr)
 
     monkeypatch.setattr(setup.subprocess, "Popen", fake_popen)
 
@@ -83,7 +90,36 @@ def test_launch_in_venv_popen(monkeypatch) -> None:
     assert captured_env["VIRTUAL_ENV"] == "/tmp/demo-venv"
     assert captured_env["X_TEST"] == "1"
     assert captured_env["PATH"].startswith("/tmp/demo-venv/bin")
+    assert captured_stdout is None
+    assert captured_stderr is None
     assert handle.pid == 1234
+
+
+def test_launch_in_venv_popen_redirects_stdio(tmp_path, monkeypatch) -> None:
+    captured_stdout_name: str | None = None
+    captured_stderr_name: str | None = None
+
+    def fake_popen(args, env, stdout=None, stderr=None):  # type: ignore[no-untyped-def]
+        nonlocal captured_stdout_name, captured_stderr_name
+        captured_stdout_name = None if stdout is None else stdout.name
+        captured_stderr_name = None if stderr is None else stderr.name
+        return _FakePopen(args=list(args), env=dict(env), stdout=stdout, stderr=stderr)
+
+    monkeypatch.setattr(setup.subprocess, "Popen", fake_popen)
+    monkeypatch.setenv("CASCADE_NEW_WORKER_METHOD", "popen")
+
+    stdout_path = str(tmp_path / "worker.stdout.txt")
+    stderr_path = str(tmp_path / "worker.stderr.txt")
+    setup.launch_in_venv(
+        "demo.module",
+        "/tmp/demo-venv",
+        {"X_TEST": "1"},
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+    )
+
+    assert captured_stdout_name == stdout_path
+    assert captured_stderr_name == stderr_path
 
 
 class _FakeProcess:
@@ -135,7 +171,7 @@ def test_launch_in_venv_multiprocessing(monkeypatch) -> None:
 
     assert isinstance(handle, setup.MpWorkerProcessHandle)
     assert fake_process.started
-    assert fake_process.args == ("demo.module", "/tmp/demo-venv", {"X_TEST": "1"})
+    assert fake_process.args == ("demo.module", "/tmp/demo-venv", {"X_TEST": "1"}, None, None)
     assert fake_process.target is setup._launch_worker_module
     assert handle.pid == 4321
     assert handle.poll() is None
@@ -144,6 +180,34 @@ def test_launch_in_venv_multiprocessing(monkeypatch) -> None:
     assert fake_process.terminated
     assert handle.poll() == -15
     assert handle.wait() == -15
+
+
+def test_launch_in_venv_multiprocessing_redirects_stdio(monkeypatch) -> None:
+    fake_process = _FakeProcess()
+
+    class _FakeContext:
+        def Process(self, target, args):  # type: ignore[no-untyped-def]
+            fake_process.target = target
+            fake_process.args = tuple(args)
+            return fake_process
+
+    monkeypatch.setattr(setup.mp, "get_context", lambda method: _FakeContext())
+    monkeypatch.setenv("CASCADE_NEW_WORKER_METHOD", "multiprocessing")
+
+    setup.launch_in_venv(
+        "demo.module",
+        "/tmp/demo-venv",
+        {"X_TEST": "1"},
+        stdout_path="/tmp/worker.stdout.txt",
+        stderr_path="/tmp/worker.stderr.txt",
+    )
+    assert fake_process.args == (
+        "demo.module",
+        "/tmp/demo-venv",
+        {"X_TEST": "1"},
+        "/tmp/worker.stdout.txt",
+        "/tmp/worker.stderr.txt",
+    )
 
 
 def test_terminate_worker_grace_period(tmp_path) -> None:


### PR DESCRIPTION
Runners in the worker now redirect their stdout/stderr to files, similarly how logging itself is being redirected -- now instead of "..workerId.txt", they generate "..workerId.{logs, stdout, stderr}.txt"

