### PR TITLE
Feat/detailed progress report

### DIFF
--- a/src/cascade/controller/act.py
+++ b/src/cascade/controller/act.py
@@ -12,6 +12,7 @@ import logging
 from typing import Iterable, Iterator, cast
 
 from cascade.controller.core import State
+from cascade.controller.report import Reporter
 from cascade.executor.bridge import Bridge
 from cascade.executor.checkpoints import build_retrieve_command, possible_repersist, retrieve_dataset
 from cascade.executor.msg import DatasetPublished, TaskSequence
@@ -23,7 +24,7 @@ from cascade.scheduler.core import Assignment
 logger = logging.getLogger(__name__)
 
 
-def act(bridge: Bridge, assignment: Assignment) -> None:
+def act(bridge: Bridge, assignment: Assignment, reporter: Reporter) -> None:
     """Converts an assignment to one or more actions which are sent to the bridge, and returned
     for tracing/updating purposes. Does *not* mutate State, but executors behind the Bridge *are* mutated.
     """
@@ -62,6 +63,7 @@ def act(bridge: Bridge, assignment: Assignment) -> None:
                 "host": "controller",
             }
         )
+    reporter.send_tasks_planned(set(assignment.tasks))
     logger.debug(f"sending {task_sequence} to bridge")
     bridge.task_sequence(task_sequence)
 

--- a/src/cascade/controller/impl.py
+++ b/src/cascade/controller/impl.py
@@ -65,7 +65,7 @@ def run(
             assignments = []
             if schedule.has_computable():
                 for assignment in assign(schedule, context):
-                    timer(act, Microtrace.ctrl_act)(bridge, assignment)
+                    timer(act, Microtrace.ctrl_act)(bridge, assignment, reporter)
                     assignments.append(assignment)
 
             mark({"action": ControllerPhases.plan})

--- a/src/cascade/controller/notify.py
+++ b/src/cascade/controller/notify.py
@@ -127,7 +127,7 @@ def notify(
                     context.task_done_at(task, worker)
                 else:
                     context.task_done(task)
-                reporter.send_progress(context)
+                reporter.send_progress(context, task)
         elif isinstance(event, DatasetTransmitPayload):
             state.receive_payload(event.header.ds, event.value, event.header.deser_fun)
             reporter.send_result(event.header.ds, event.value)

--- a/src/cascade/controller/notify.py
+++ b/src/cascade/controller/notify.py
@@ -127,7 +127,7 @@ def notify(
                     context.task_done_at(task, worker)
                 else:
                     context.task_done(task)
-                reporter.send_progress(context, task)
+                reporter.send_task_completed(context, task)
         elif isinstance(event, DatasetTransmitPayload):
             state.receive_payload(event.header.ds, event.value, event.header.deser_fun)
             reporter.send_result(event.header.ds, event.value)

--- a/src/cascade/controller/report.py
+++ b/src/cascade/controller/report.py
@@ -59,6 +59,7 @@ class ControllerReport:
     timestamp: int
     results: list[tuple[DatasetId, bytes]]
     completed_task: TaskId | None = None
+    planned_tasks: set[TaskId] | None = None
 
 
 def deserialize(raw: bytes) -> ControllerReport:
@@ -89,12 +90,19 @@ class Reporter:
         self.socket = get_context().socket(zmq.PUSH)
         self.socket.connect(address)
 
-    def send_progress(self, context: JobExecutionContext, completed_task: TaskId | None = None) -> None:
+    def send_task_completed(self, context: JobExecutionContext, completed_task: TaskId) -> None:
         if self.socket is None:
             return
         pct = 1.0 - context.remaining / context.total
         logger.debug(f"reporting progress {pct=}")
         report = ControllerReport(self.job_id, JobProgress.progressed(pct), monotonic_ns(), [], completed_task)
+        _send(self.socket, report)
+
+    def send_tasks_planned(self, task_ids: set[TaskId]) -> None:
+        if self.socket is None:
+            return
+        logger.debug(f"reporting planned tasks {task_ids=}")
+        report = ControllerReport(self.job_id, None, monotonic_ns(), [], None, task_ids)
         _send(self.socket, report)
 
     def send_result(self, dataset: DatasetId, result: bytes) -> None:

--- a/src/cascade/controller/report.py
+++ b/src/cascade/controller/report.py
@@ -77,14 +77,8 @@ def serialize(report: ControllerReport) -> bytes:
     return pickle.dumps(report)
 
 
-class Reporter:
-    def __init__(self, report_address: str | None) -> None:
-        self.sender: ReliableSender | None = None
-        self.ack_socket: zmq.Socket | None = None
-        self.ack_poller: zmq.Poller | None = None
-        self.job_id: JobId | None = None
-        if report_address is None:
-            return
+class ReporterChannel:
+    def __init__(self, report_address: str) -> None:
         address, job_id = report_address.split(",", 1)
         logger.debug(f"initialising reporter with {address=} and {job_id=}")
         self.job_id = JobId(job_id)
@@ -97,9 +91,7 @@ class Reporter:
         self.sender = ReliableSender(ack_address, default_message_resend_ms)
         self.sender.add_host(HostId("gateway"), address)
 
-    def _send(self, report: ControllerReport) -> None:
-        if self.sender is None or self.ack_poller is None or self.ack_socket is None:
-            return
+    def send(self, report: ControllerReport) -> None:
         self.sender.send_raw(HostId("gateway"), serialize(report), "ControllerReport")
         while self.sender.inflight:
             for socket, _ in self.ack_poller.poll(default_message_resend_ms):
@@ -115,48 +107,47 @@ class Reporter:
                     raise CascadeInternalError(f"expected Ack on report channel, got {type(ack)}")
             self.sender.maybe_retry()
 
+
+class Reporter:
+    def __init__(self, report_address: str | None) -> None:
+        self.channel = ReporterChannel(report_address) if report_address is not None else None
+
+    def _send(self, report: ControllerReport) -> None:
+        if self.channel is not None:
+            self.channel.send(report)
+
     def send_task_completed(self, context: JobExecutionContext, completed_task: TaskId) -> None:
-        if self.sender is None:
+        if self.channel is None:
             return
-        if self.job_id is None:
-            raise CascadeInternalError("missing job id on report sender")
         pct = 1.0 - context.remaining / context.total
         logger.debug(f"reporting progress {pct=}")
-        report = ControllerReport(self.job_id, JobProgress.progressed(pct), monotonic_ns(), [], completed_task)
+        report = ControllerReport(self.channel.job_id, JobProgress.progressed(pct), monotonic_ns(), [], completed_task)
         self._send(report)
 
     def send_tasks_planned(self, task_ids: set[TaskId]) -> None:
-        if self.sender is None:
+        if self.channel is None:
             return
-        if self.job_id is None:
-            raise CascadeInternalError("missing job id on report sender")
         logger.debug(f"reporting planned tasks {task_ids=}")
-        report = ControllerReport(self.job_id, None, monotonic_ns(), [], None, task_ids)
+        report = ControllerReport(self.channel.job_id, None, monotonic_ns(), [], None, task_ids)
         self._send(report)
 
     def send_result(self, dataset: DatasetId, result: bytes) -> None:
-        if self.sender is None:
+        if self.channel is None:
             return
-        if self.job_id is None:
-            raise CascadeInternalError("missing job id on report sender")
         logger.debug(f"uploading result {dataset=}")
-        report = ControllerReport(self.job_id, None, monotonic_ns(), [(dataset, result)])
+        report = ControllerReport(self.channel.job_id, None, monotonic_ns(), [(dataset, result)])
         self._send(report)
 
     def send_failure(self, failure: str) -> None:
-        if self.sender is None:
+        if self.channel is None:
             return
-        if self.job_id is None:
-            raise CascadeInternalError("missing job id on report sender")
         logger.debug(f"reporting failure {failure=}")
-        report = ControllerReport(self.job_id, JobProgress.failed(failure), monotonic_ns(), [])
+        report = ControllerReport(self.channel.job_id, JobProgress.failed(failure), monotonic_ns(), [])
         self._send(report)
 
     def success(self) -> None:
-        if self.sender is None:
+        if self.channel is None:
             return
-        if self.job_id is None:
-            raise CascadeInternalError("missing job id on report sender")
         logger.debug("reporter sending shutdown")
-        report = ControllerReport(self.job_id, JobProgress.succeeded(), monotonic_ns(), [])
+        report = ControllerReport(self.channel.job_id, JobProgress.succeeded(), monotonic_ns(), [])
         self._send(report)

--- a/src/cascade/controller/report.py
+++ b/src/cascade/controller/report.py
@@ -93,8 +93,8 @@ class ReporterChannel:
 
     def send(self, report: ControllerReport) -> None:
         self.sender.send_raw(HostId("gateway"), serialize(report), "ControllerReport")
-        while self.sender.inflight:
-            for socket, _ in self.ack_poller.poll(default_message_resend_ms):
+        if self.sender.inflight:
+            for socket, _ in self.ack_poller.poll(0):
                 if socket is not self.ack_socket:
                     continue
                 msg_frames = self.ack_socket.recv_multipart()

--- a/src/cascade/controller/report.py
+++ b/src/cascade/controller/report.py
@@ -18,7 +18,7 @@ import zmq
 from typing_extensions import Self
 
 from cascade.executor.comms import get_context
-from cascade.low.core import DatasetId
+from cascade.low.core import DatasetId, TaskId
 from cascade.low.exceptions import CascadeInternalError
 from cascade.low.execution_context import JobExecutionContext
 
@@ -58,6 +58,7 @@ class ControllerReport:
     current_status: JobProgress | None
     timestamp: int
     results: list[tuple[DatasetId, bytes]]
+    completed_task: TaskId | None = None
 
 
 def deserialize(raw: bytes) -> ControllerReport:
@@ -88,12 +89,12 @@ class Reporter:
         self.socket = get_context().socket(zmq.PUSH)
         self.socket.connect(address)
 
-    def send_progress(self, context: JobExecutionContext) -> None:
+    def send_progress(self, context: JobExecutionContext, completed_task: TaskId | None = None) -> None:
         if self.socket is None:
             return
         pct = 1.0 - context.remaining / context.total
         logger.debug(f"reporting progress {pct=}")
-        report = ControllerReport(self.job_id, JobProgress.progressed(pct), monotonic_ns(), [])
+        report = ControllerReport(self.job_id, JobProgress.progressed(pct), monotonic_ns(), [], completed_task)
         _send(self.socket, report)
 
     def send_result(self, dataset: DatasetId, result: bytes) -> None:

--- a/src/cascade/controller/report.py
+++ b/src/cascade/controller/report.py
@@ -112,42 +112,38 @@ class Reporter:
     def __init__(self, report_address: str | None) -> None:
         self.channel = ReporterChannel(report_address) if report_address is not None else None
 
-    def _send(self, report: ControllerReport) -> None:
-        if self.channel is not None:
-            self.channel.send(report)
-
     def send_task_completed(self, context: JobExecutionContext, completed_task: TaskId) -> None:
         if self.channel is None:
             return
         pct = 1.0 - context.remaining / context.total
         logger.debug(f"reporting progress {pct=}")
         report = ControllerReport(self.channel.job_id, JobProgress.progressed(pct), monotonic_ns(), [], completed_task)
-        self._send(report)
+        self.channel.send(report)
 
     def send_tasks_planned(self, task_ids: set[TaskId]) -> None:
         if self.channel is None:
             return
         logger.debug(f"reporting planned tasks {task_ids=}")
         report = ControllerReport(self.channel.job_id, None, monotonic_ns(), [], None, task_ids)
-        self._send(report)
+        self.channel.send(report)
 
     def send_result(self, dataset: DatasetId, result: bytes) -> None:
         if self.channel is None:
             return
         logger.debug(f"uploading result {dataset=}")
         report = ControllerReport(self.channel.job_id, None, monotonic_ns(), [(dataset, result)])
-        self._send(report)
+        self.channel.send(report)
 
     def send_failure(self, failure: str) -> None:
         if self.channel is None:
             return
         logger.debug(f"reporting failure {failure=}")
         report = ControllerReport(self.channel.job_id, JobProgress.failed(failure), monotonic_ns(), [])
-        self._send(report)
+        self.channel.send(report)
 
     def success(self) -> None:
         if self.channel is None:
             return
         logger.debug("reporter sending shutdown")
         report = ControllerReport(self.channel.job_id, JobProgress.succeeded(), monotonic_ns(), [])
-        self._send(report)
+        self.channel.send(report)

--- a/src/cascade/controller/report.py
+++ b/src/cascade/controller/report.py
@@ -17,8 +17,11 @@ from typing import NewType
 import zmq
 from typing_extensions import Self
 
-from cascade.executor.comms import get_context
-from cascade.low.core import DatasetId, TaskId
+import cascade.executor.platform as platform
+from cascade.executor.comms import ReliableSender, default_message_resend_ms, get_context
+from cascade.executor.msg import Ack
+from cascade.executor.serde import des_message
+from cascade.low.core import DatasetId, HostId, TaskId
 from cascade.low.exceptions import CascadeInternalError
 from cascade.low.execution_context import JobExecutionContext
 
@@ -74,54 +77,86 @@ def serialize(report: ControllerReport) -> bytes:
     return pickle.dumps(report)
 
 
-def _send(socket: zmq.Socket, report: ControllerReport) -> None:
-    # TODO we need to make sure sending is reliable, ie, retries and acks from gateway
-    socket.send(serialize(report))
-
-
 class Reporter:
     def __init__(self, report_address: str | None) -> None:
+        self.sender: ReliableSender | None = None
+        self.ack_socket: zmq.Socket | None = None
+        self.ack_poller: zmq.Poller | None = None
+        self.job_id: JobId | None = None
         if report_address is None:
-            self.socket = None
             return
         address, job_id = report_address.split(",", 1)
         logger.debug(f"initialising reporter with {address=} and {job_id=}")
         self.job_id = JobId(job_id)
-        self.socket = get_context().socket(zmq.PUSH)
-        self.socket.connect(address)
+        self.ack_socket = get_context().socket(zmq.PULL)
+        ack_base = f"tcp://{platform.get_bindabble_self()}"
+        ack_port = self.ack_socket.bind_to_random_port(ack_base)
+        ack_address = f"{ack_base}:{ack_port}"
+        self.ack_poller = zmq.Poller()
+        self.ack_poller.register(self.ack_socket, flags=zmq.POLLIN)
+        self.sender = ReliableSender(ack_address, default_message_resend_ms)
+        self.sender.add_host(HostId("gateway"), address)
+
+    def _send(self, report: ControllerReport) -> None:
+        if self.sender is None or self.ack_poller is None or self.ack_socket is None:
+            return
+        self.sender.send_raw(HostId("gateway"), serialize(report), "ControllerReport")
+        while self.sender.inflight:
+            for socket, _ in self.ack_poller.poll(default_message_resend_ms):
+                if socket is not self.ack_socket:
+                    continue
+                msg_frames = self.ack_socket.recv_multipart()
+                if len(msg_frames) != 1:
+                    raise CascadeInternalError(f"expected single-frame Ack on report channel, got {len(msg_frames)=}")
+                ack = des_message(msg_frames[0])
+                if isinstance(ack, Ack):
+                    self.sender.ack(ack.idx)
+                else:
+                    raise CascadeInternalError(f"expected Ack on report channel, got {type(ack)}")
+            self.sender.maybe_retry()
 
     def send_task_completed(self, context: JobExecutionContext, completed_task: TaskId) -> None:
-        if self.socket is None:
+        if self.sender is None:
             return
+        if self.job_id is None:
+            raise CascadeInternalError("missing job id on report sender")
         pct = 1.0 - context.remaining / context.total
         logger.debug(f"reporting progress {pct=}")
         report = ControllerReport(self.job_id, JobProgress.progressed(pct), monotonic_ns(), [], completed_task)
-        _send(self.socket, report)
+        self._send(report)
 
     def send_tasks_planned(self, task_ids: set[TaskId]) -> None:
-        if self.socket is None:
+        if self.sender is None:
             return
+        if self.job_id is None:
+            raise CascadeInternalError("missing job id on report sender")
         logger.debug(f"reporting planned tasks {task_ids=}")
         report = ControllerReport(self.job_id, None, monotonic_ns(), [], None, task_ids)
-        _send(self.socket, report)
+        self._send(report)
 
     def send_result(self, dataset: DatasetId, result: bytes) -> None:
-        if self.socket is None:
+        if self.sender is None:
             return
+        if self.job_id is None:
+            raise CascadeInternalError("missing job id on report sender")
         logger.debug(f"uploading result {dataset=}")
         report = ControllerReport(self.job_id, None, monotonic_ns(), [(dataset, result)])
-        _send(self.socket, report)
+        self._send(report)
 
     def send_failure(self, failure: str) -> None:
-        if self.socket is None:
+        if self.sender is None:
             return
+        if self.job_id is None:
+            raise CascadeInternalError("missing job id on report sender")
         logger.debug(f"reporting failure {failure=}")
         report = ControllerReport(self.job_id, JobProgress.failed(failure), monotonic_ns(), [])
-        _send(self.socket, report)
+        self._send(report)
 
     def success(self) -> None:
-        if self.socket is None:
+        if self.sender is None:
             return
+        if self.job_id is None:
+            raise CascadeInternalError("missing job id on report sender")
         logger.debug("reporter sending shutdown")
         report = ControllerReport(self.job_id, JobProgress.succeeded(), monotonic_ns(), [])
-        _send(self.socket, report)
+        self._send(report)

--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -100,6 +100,25 @@ def send_data(address: BackboneAddress, data: DatasetTransmitPayload, syn: Syn) 
     socket.send_multipart(byt, copy=False)
 
 
+def receive_and_ack(socket: zmq.Socket, seen_syns: set[tuple[int, BackboneAddress]]) -> bytes | None:
+    frames = socket.recv_multipart()
+    if len(frames) == 0:
+        raise CascadeInternalError("unexpected empty message")
+    maybe_syn = des_message(frames[0])
+    if isinstance(maybe_syn, Syn):
+        callback(maybe_syn.addr, Ack(idx=maybe_syn.idx))
+        key = (maybe_syn.idx, maybe_syn.addr)
+        if key in seen_syns:
+            return None
+        seen_syns.add(key)
+        if len(frames) != 2:
+            raise CascadeInternalError(f"expected payload after Syn, got {len(frames)=}")
+        return frames[1]
+    if len(frames) != 1:
+        raise CascadeInternalError("unexpected multipart message without Syn preamble")
+    return frames[0]
+
+
 class Listener:
     def __init__(self, address: BackboneAddress):
         self.address = address

--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -213,12 +213,15 @@ class ReliableSender:
 
     def send(self, host: HostId, m: Message) -> None:
         raw = ser_message(m)
+        self.send_raw(host, raw, type(m).__name__)
+
+    def send_raw(self, host: HostId, raw: bytes, clazz: str) -> None:
         syn = ser_message(Syn(idx=self.idx, addr=self.address))
         self.inflight[self.idx] = _InFlightRecord(
             host=host,
             message=(syn, raw),
             at=time.time_ns(),
-            clazz=type(m).__name__,
+            clazz=clazz,
             remaining=max_retries_per_message,
         )
         self.hosts[host][0].send_multipart((syn, raw))

--- a/src/cascade/gateway/api.py
+++ b/src/cascade/gateway/api.py
@@ -13,7 +13,7 @@ from typing import Any
 import cloudpickle
 
 from cascade.controller.report import JobId, JobProgress
-from cascade.low.core import DatasetId, JobInstance, JobInstanceRich
+from cascade.low.core import DatasetId, JobInstance, JobInstanceRich, TaskId
 from cascade.low.exceptions import CascadeInternalError
 from cascade.low.func import CascadeBaseModel
 
@@ -55,6 +55,7 @@ class SubmitJobResponse(CascadeGatewayAPI):
 
 class JobProgressRequest(CascadeGatewayAPI):
     job_ids: list[JobId]  # on empty list, return all
+    detailed_report: bool = False
 
 
 class JobProgressResponse(CascadeGatewayAPI):
@@ -62,6 +63,7 @@ class JobProgressResponse(CascadeGatewayAPI):
     datasets: dict[JobId, list[DatasetId]]
     queue_length: int
     error: str | None  # top level error
+    completed_task_ids: dict[JobId, list[TaskId]] | None = None
 
 
 class ResultRetrievalRequest(CascadeGatewayAPI):

--- a/src/cascade/gateway/api.py
+++ b/src/cascade/gateway/api.py
@@ -64,6 +64,7 @@ class JobProgressResponse(CascadeGatewayAPI):
     queue_length: int
     error: str | None  # top level error
     completed_task_ids: dict[JobId, list[TaskId]] | None = None
+    planned_task_ids: dict[JobId, list[TaskId]] | None = None
 
 
 class ResultRetrievalRequest(CascadeGatewayAPI):

--- a/src/cascade/gateway/router.py
+++ b/src/cascade/gateway/router.py
@@ -140,19 +140,23 @@ class JobRouter:
             job.planned_task_ids.update(planned_tasks - job.completed_task_ids)
         if progress is None:
             return
-        if progress.completed:
+        if timestamp <= job.last_seen:
+            return
+        job.last_seen = timestamp
+        if progress.completed and not job.progress.completed:
             self.poller.unregister(job.socket)
             self.active_jobs -= 1
             self.maybe_spawn()
         if progress.failure is not None and job.progress.failure is None:
             job.progress = progress
-        elif job.last_seen >= timestamp or job.progress.failure is not None:
+        elif job.progress.failure is not None:
             pass
         elif progress.pct is not None:
             job.progress = progress
 
     def put_result(self, job_id: JobId, dataset_id: DatasetId, result: bytes) -> None:
-        self.jobs[job_id].results[dataset_id] = result
+        if dataset_id not in self.jobs[job_id].results:
+            self.jobs[job_id].results[dataset_id] = result
 
     def delete_results(self, delete_map: dict[JobId, list[DatasetId]]) -> list[str]:
         if not delete_map:

--- a/src/cascade/gateway/router.py
+++ b/src/cascade/gateway/router.py
@@ -33,7 +33,7 @@ from cascade.deployment.logging import LoggingConfig
 from cascade.executor.comms import get_context
 from cascade.gateway.api import JobSpec
 from cascade.gateway.spawning import spawn_subprocess
-from cascade.low.core import DatasetId
+from cascade.low.core import DatasetId, TaskId
 from cascade.low.func import next_uuid
 
 logger = logging.getLogger(__name__)
@@ -45,6 +45,7 @@ class Job:
     progress: JobProgress
     last_seen: int
     results: dict[DatasetId, bytes]
+    completed_task_ids: set[TaskId]
 
 
 class JobRouter:
@@ -78,7 +79,7 @@ class JobRouter:
         full_addr = f"{base_addr}:{port}"
         logger.debug(f"will spawn job {job_id} and listen on {full_addr}")
         self.poller.register(socket, flags=zmq.POLLIN)
-        self.jobs[job_id] = Job(socket, JobProgressStarted, -1, {})
+        self.jobs[job_id] = Job(socket, JobProgressStarted, -1, {}, set())
         self.procs[job_id] = spawn_subprocess(job_spec, full_addr, job_id, self.loggingConfig, self.troika_config)
         self.active_jobs += 1
 
@@ -91,7 +92,9 @@ class JobRouter:
         self.maybe_spawn()
         return job_id
 
-    def progress_of(self, job_ids: Iterable[JobId]) -> tuple[dict[JobId, JobProgress], dict[JobId, list[DatasetId]], int]:
+    def progress_of(
+        self, job_ids: Iterable[JobId], detailed_report: bool = False
+    ) -> tuple[dict[JobId, JobProgress], dict[JobId, list[DatasetId]], int, dict[JobId, list[TaskId]] | None]:
         if not job_ids:
             job_ids = set(self.jobs.keys()).union(self.jobs_queue.keys())
         progresses = {}
@@ -103,15 +106,22 @@ class JobRouter:
             else:
                 progresses[job_id] = None
         datasets = {job_id: list(self.jobs[job_id].results.keys()) for job_id in job_ids if job_id in self.jobs}
-        return progresses, datasets, len(self.jobs_queue)
+        completed_task_ids: dict[JobId, list[TaskId]] | None = None
+        if detailed_report:
+            completed_task_ids = {job_id: list(self.jobs[job_id].completed_task_ids) for job_id in job_ids if job_id in self.jobs}
+        return progresses, datasets, len(self.jobs_queue), completed_task_ids
 
     def get_result(self, job_id: JobId, dataset_id: DatasetId) -> bytes:
         return self.jobs[job_id].results[dataset_id]
 
-    def maybe_update(self, job_id: JobId, progress: JobProgress | None, timestamp: int) -> None:
-        if progress is None:
+    def maybe_update(self, job_id: JobId, progress: JobProgress | None, timestamp: int, completed_task: TaskId | None = None) -> None:
+        if progress is None and completed_task is None:
             return
         job = self.jobs[job_id]
+        if completed_task is not None:
+            job.completed_task_ids.add(completed_task)
+        if progress is None:
+            return
         if progress.completed:
             self.poller.unregister(job.socket)
             self.active_jobs -= 1

--- a/src/cascade/gateway/router.py
+++ b/src/cascade/gateway/router.py
@@ -23,6 +23,7 @@ from typing import Iterable
 import zmq
 
 import cascade.executor.platform as platform
+import cascade.gateway.api as api
 from cascade.controller.report import (
     JobId,
     JobProgress,
@@ -31,7 +32,6 @@ from cascade.controller.report import (
 )
 from cascade.deployment.logging import LoggingConfig
 from cascade.executor.comms import get_context
-from cascade.gateway.api import JobSpec
 from cascade.gateway.spawning import spawn_subprocess
 from cascade.low.core import DatasetId, TaskId
 from cascade.low.func import next_uuid
@@ -46,6 +46,7 @@ class Job:
     last_seen: int
     results: dict[DatasetId, bytes]
     completed_task_ids: set[TaskId]
+    planned_task_ids: set[TaskId]
 
 
 class JobRouter:
@@ -60,7 +61,7 @@ class JobRouter:
         self.jobs: dict[JobId, Job] = {}
         self.active_jobs = 0
         self.max_jobs = max_jobs
-        self.jobs_queue: OrderedDict[JobId, JobSpec] = OrderedDict()
+        self.jobs_queue: OrderedDict[JobId, api.JobSpec] = OrderedDict()
         self.procs: dict[JobId, subprocess.Popen] = {}
         self.loggingConfig = loggingConfig
         self.troika_config = troika_config
@@ -79,11 +80,11 @@ class JobRouter:
         full_addr = f"{base_addr}:{port}"
         logger.debug(f"will spawn job {job_id} and listen on {full_addr}")
         self.poller.register(socket, flags=zmq.POLLIN)
-        self.jobs[job_id] = Job(socket, JobProgressStarted, -1, {}, set())
+        self.jobs[job_id] = Job(socket, JobProgressStarted, -1, {}, set(), set())
         self.procs[job_id] = spawn_subprocess(job_spec, full_addr, job_id, self.loggingConfig, self.troika_config)
         self.active_jobs += 1
 
-    def enqueue_job(self, job_spec: JobSpec) -> JobId:
+    def enqueue_job(self, job_spec: api.JobSpec) -> JobId:
         job_id = next_uuid(
             set(self.jobs.keys()).union(self.jobs_queue.keys()),
             lambda: JobId(str(uuid.uuid4())),
@@ -92,9 +93,7 @@ class JobRouter:
         self.maybe_spawn()
         return job_id
 
-    def progress_of(
-        self, job_ids: Iterable[JobId], detailed_report: bool = False
-    ) -> tuple[dict[JobId, JobProgress], dict[JobId, list[DatasetId]], int, dict[JobId, list[TaskId]] | None]:
+    def progress_of(self, job_ids: Iterable[JobId], detailed_report: bool = False) -> api.JobProgressResponse:
         if not job_ids:
             job_ids = set(self.jobs.keys()).union(self.jobs_queue.keys())
         progresses = {}
@@ -107,19 +106,38 @@ class JobRouter:
                 progresses[job_id] = None
         datasets = {job_id: list(self.jobs[job_id].results.keys()) for job_id in job_ids if job_id in self.jobs}
         completed_task_ids: dict[JobId, list[TaskId]] | None = None
+        planned_task_ids: dict[JobId, list[TaskId]] | None = None
         if detailed_report:
             completed_task_ids = {job_id: list(self.jobs[job_id].completed_task_ids) for job_id in job_ids if job_id in self.jobs}
-        return progresses, datasets, len(self.jobs_queue), completed_task_ids
+            planned_task_ids = {job_id: list(self.jobs[job_id].planned_task_ids) for job_id in job_ids if job_id in self.jobs}
+        return api.JobProgressResponse(
+            progresses=progresses,
+            datasets=datasets,
+            queue_length=len(self.jobs_queue),
+            error=None,
+            completed_task_ids=completed_task_ids,
+            planned_task_ids=planned_task_ids,
+        )
 
     def get_result(self, job_id: JobId, dataset_id: DatasetId) -> bytes:
         return self.jobs[job_id].results[dataset_id]
 
-    def maybe_update(self, job_id: JobId, progress: JobProgress | None, timestamp: int, completed_task: TaskId | None = None) -> None:
-        if progress is None and completed_task is None:
+    def maybe_update(
+        self,
+        job_id: JobId,
+        progress: JobProgress | None,
+        timestamp: int,
+        completed_task: TaskId | None = None,
+        planned_tasks: set[TaskId] | None = None,
+    ) -> None:
+        if progress is None and completed_task is None and not planned_tasks:
             return
         job = self.jobs[job_id]
         if completed_task is not None:
+            job.planned_task_ids.discard(completed_task)
             job.completed_task_ids.add(completed_task)
+        if planned_tasks:
+            job.planned_task_ids.update(planned_tasks - job.completed_task_ids)
         if progress is None:
             return
         if progress.completed:

--- a/src/cascade/gateway/server.py
+++ b/src/cascade/gateway/server.py
@@ -19,9 +19,7 @@ import zmq
 import cascade.gateway.api as api
 from cascade.controller.report import deserialize
 from cascade.deployment.logging import LoggingConfig, init_from_obj
-from cascade.executor.comms import callback, get_context
-from cascade.executor.msg import Ack, Syn
-from cascade.executor.serde import des_message
+from cascade.executor.comms import get_context, receive_and_ack
 from cascade.gateway.client import parse_request, serialize_response
 from cascade.gateway.router import JobRouter
 from cascade.low.exceptions import CascadeInternalError
@@ -72,23 +70,10 @@ def handle_fe(socket: zmq.Socket, jobs: JobRouter) -> bool:
     return isinstance(rv, api.ShutdownResponse)
 
 
-def handle_controller(socket: zmq.Socket, jobs: JobRouter, seen_syns: set[Syn]) -> None:
-    frames = socket.recv_multipart()
-    if len(frames) == 0:
-        raise CascadeInternalError("unexpected empty report message")
-    maybe_syn = des_message(frames[0])
-    if isinstance(maybe_syn, Syn):
-        callback(maybe_syn.addr, Ack(idx=maybe_syn.idx))
-        if maybe_syn in seen_syns:
-            return
-        seen_syns.add(maybe_syn)
-        if len(frames) != 2:
-            raise CascadeInternalError(f"expected report payload after Syn, got {len(frames)=}")
-        raw_report = frames[1]
-    elif len(frames) == 1:
-        raw_report = frames[0]
-    else:
-        raise CascadeInternalError("unexpected multipart report without Syn preamble")
+def handle_controller(socket: zmq.Socket, jobs: JobRouter, seen_syns: set[tuple[int, str]]) -> None:
+    raw_report = receive_and_ack(socket, seen_syns)
+    if raw_report is None:
+        return
     report = deserialize(raw_report)
     logger.debug(f"received controller message {report}")
     jobs.maybe_update(report.job_id, report.current_status, report.timestamp, report.completed_task, report.planned_tasks)
@@ -109,7 +94,7 @@ def serve(
     fe.bind(url)
     poller.register(fe, flags=zmq.POLLIN)
     jobs = JobRouter(poller, loggingConfig, troika_config, max_jobs)
-    seen_syns: set[Syn] = set()
+    seen_syns: set[tuple[int, str]] = set()
 
     logger.debug("entering recv loop")
     is_break = False

--- a/src/cascade/gateway/server.py
+++ b/src/cascade/gateway/server.py
@@ -19,7 +19,9 @@ import zmq
 import cascade.gateway.api as api
 from cascade.controller.report import deserialize
 from cascade.deployment.logging import LoggingConfig, init_from_obj
-from cascade.executor.comms import get_context
+from cascade.executor.comms import callback, get_context
+from cascade.executor.msg import Ack, Syn
+from cascade.executor.serde import des_message
 from cascade.gateway.client import parse_request, serialize_response
 from cascade.gateway.router import JobRouter
 from cascade.low.exceptions import CascadeInternalError
@@ -70,9 +72,24 @@ def handle_fe(socket: zmq.Socket, jobs: JobRouter) -> bool:
     return isinstance(rv, api.ShutdownResponse)
 
 
-def handle_controller(socket: zmq.Socket, jobs: JobRouter) -> None:
-    raw = socket.recv()
-    report = deserialize(raw)
+def handle_controller(socket: zmq.Socket, jobs: JobRouter, seen_syns: set[Syn]) -> None:
+    frames = socket.recv_multipart()
+    if len(frames) == 0:
+        raise CascadeInternalError("unexpected empty report message")
+    maybe_syn = des_message(frames[0])
+    if isinstance(maybe_syn, Syn):
+        callback(maybe_syn.addr, Ack(idx=maybe_syn.idx))
+        if maybe_syn in seen_syns:
+            return
+        seen_syns.add(maybe_syn)
+        if len(frames) != 2:
+            raise CascadeInternalError(f"expected report payload after Syn, got {len(frames)=}")
+        raw_report = frames[1]
+    elif len(frames) == 1:
+        raw_report = frames[0]
+    else:
+        raise CascadeInternalError("unexpected multipart report without Syn preamble")
+    report = deserialize(raw_report)
     logger.debug(f"received controller message {report}")
     jobs.maybe_update(report.job_id, report.current_status, report.timestamp, report.completed_task, report.planned_tasks)
     for dataset_id, result in report.results:
@@ -92,6 +109,7 @@ def serve(
     fe.bind(url)
     poller.register(fe, flags=zmq.POLLIN)
     jobs = JobRouter(poller, loggingConfig, troika_config, max_jobs)
+    seen_syns: set[Syn] = set()
 
     logger.debug("entering recv loop")
     is_break = False
@@ -101,7 +119,7 @@ def serve(
             if socket == fe:
                 is_break = handle_fe(socket, jobs)
             else:
-                handle_controller(socket, jobs)
+                handle_controller(socket, jobs, seen_syns)
 
 
 def roleLoggingStr() -> str:

--- a/src/cascade/gateway/server.py
+++ b/src/cascade/gateway/server.py
@@ -13,12 +13,11 @@ here we just match the right method of `gateway.router` based on what message we
 import base64
 import datetime as dt
 import logging
-from typing import cast
 
 import zmq
 
 import cascade.gateway.api as api
-from cascade.controller.report import JobId, JobProgress, deserialize
+from cascade.controller.report import deserialize
 from cascade.deployment.logging import LoggingConfig, init_from_obj
 from cascade.executor.comms import get_context
 from cascade.gateway.client import parse_request, serialize_response
@@ -42,14 +41,7 @@ def handle_fe(socket: zmq.Socket, jobs: JobRouter) -> bool:
             rv = api.SubmitJobResponse(job_id=None, error=repr(e))
     elif isinstance(m, api.JobProgressRequest):
         try:
-            progresses, datasets, queue_length, completed_task_ids = jobs.progress_of(m.job_ids, m.detailed_report)
-            rv = api.JobProgressResponse(
-                progresses=cast(dict[JobId, JobProgress | None], progresses),
-                datasets=datasets,
-                error=None,
-                queue_length=queue_length,
-                completed_task_ids=completed_task_ids,
-            )
+            rv = jobs.progress_of(m.job_ids, m.detailed_report)
         except Exception as e:
             logger.exception(f"failed to get progress of: {m}")
             rv = api.JobProgressResponse(progresses={}, datasets={}, error=repr(e), queue_length=-1)
@@ -82,7 +74,7 @@ def handle_controller(socket: zmq.Socket, jobs: JobRouter) -> None:
     raw = socket.recv()
     report = deserialize(raw)
     logger.debug(f"received controller message {report}")
-    jobs.maybe_update(report.job_id, report.current_status, report.timestamp, report.completed_task)
+    jobs.maybe_update(report.job_id, report.current_status, report.timestamp, report.completed_task, report.planned_tasks)
     for dataset_id, result in report.results:
         jobs.put_result(report.job_id, dataset_id, result)
 

--- a/src/cascade/gateway/server.py
+++ b/src/cascade/gateway/server.py
@@ -42,12 +42,13 @@ def handle_fe(socket: zmq.Socket, jobs: JobRouter) -> bool:
             rv = api.SubmitJobResponse(job_id=None, error=repr(e))
     elif isinstance(m, api.JobProgressRequest):
         try:
-            progresses, datasets, queue_length = jobs.progress_of(m.job_ids)
+            progresses, datasets, queue_length, completed_task_ids = jobs.progress_of(m.job_ids, m.detailed_report)
             rv = api.JobProgressResponse(
                 progresses=cast(dict[JobId, JobProgress | None], progresses),
                 datasets=datasets,
                 error=None,
                 queue_length=queue_length,
+                completed_task_ids=completed_task_ids,
             )
         except Exception as e:
             logger.exception(f"failed to get progress of: {m}")
@@ -81,7 +82,7 @@ def handle_controller(socket: zmq.Socket, jobs: JobRouter) -> None:
     raw = socket.recv()
     report = deserialize(raw)
     logger.debug(f"received controller message {report}")
-    jobs.maybe_update(report.job_id, report.current_status, report.timestamp)
+    jobs.maybe_update(report.job_id, report.current_status, report.timestamp, report.completed_task)
     for dataset_id, result in report.results:
         jobs.put_result(report.job_id, dataset_id, result)
 

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -116,6 +116,13 @@ def test_job():
         deser = api.decoded_result(result_retrieval_res, ji.jobInstance)
         assert deser == job_func(init_value)
 
+        detailed_progress_req = api.JobProgressRequest(job_ids=[job_id], detailed_report=True)
+        detailed_progress_res = client.request_response(detailed_progress_req, url)
+        assert isinstance(detailed_progress_res, api.JobProgressResponse)
+        assert detailed_progress_res.error is None
+        assert detailed_progress_res.completed_task_ids is not None
+        assert len(detailed_progress_res.completed_task_ids[job_id]) == len(ji.jobInstance.tasks)
+
         result_deletion_req = api.ResultDeletionRequest(datasets={job_id: [ji.jobInstance.ext_outputs[0]]})
         result_deletion_res = client.request_response(result_deletion_req, url)
         assert isinstance(result_deletion_res, api.ResultDeletionResponse)

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -122,6 +122,8 @@ def test_job():
         assert detailed_progress_res.error is None
         assert detailed_progress_res.completed_task_ids is not None
         assert len(detailed_progress_res.completed_task_ids[job_id]) == len(ji.jobInstance.tasks)
+        assert detailed_progress_res.planned_task_ids is not None
+        assert len(detailed_progress_res.planned_task_ids[job_id]) == 0
 
         result_deletion_req = api.ResultDeletionRequest(datasets={job_id: [ji.jobInstance.ext_outputs[0]]})
         result_deletion_res = client.request_response(result_deletion_req, url)


### PR DESCRIPTION
Extends the controller->gateway reports with:
1/ completed task_id in the progress report message
2/ planned task_ids in a new message during controller's act phase
3/ introduces the Syn-Ack reliable sending

Extend the gateway api with:
1/ detailed_report: bool = False
2/ all completed task ids, if detailed_report
3/ all planned task ids, if detailed_report
