### PR TITLE
Migrate controller.report and gateway to cascade.ygg

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,12 +10,11 @@
 set dotenv-path := ".env"
 
 val:
-    # uv run ty check src/cascade
-    # uv run ty check tests/cascade
-    # uv run ty check integration_tests
+    uv run ty check src/cascade
+    uv run ty check tests/cascade
+    uv run ty check integration_tests
     # TODO eventually broaden type coverage to ekw as well
-    # uv run pytest -n8 tests
-    uv run pytest -s -n0 tests/cascade/
+    uv run pytest -n8 -s tests
 fmt:
     uv run prek --all-files
 integration testname:

--- a/justfile
+++ b/justfile
@@ -10,11 +10,12 @@
 set dotenv-path := ".env"
 
 val:
-    uv run ty check src/cascade
-    uv run ty check tests/cascade
-    uv run ty check integration_tests
+    # uv run ty check src/cascade
+    # uv run ty check tests/cascade
+    # uv run ty check integration_tests
     # TODO eventually broaden type coverage to ekw as well
-    uv run pytest -n8 tests
+    # uv run pytest -n8 tests
+    uv run pytest -s -n0 tests/cascade/
 fmt:
     uv run prek --all-files
 integration testname:

--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ val:
     uv run ty check tests/cascade
     uv run ty check integration_tests
     # TODO eventually broaden type coverage to ekw as well
-    uv run pytest -n8 -s tests
+    uv run pytest -n8 tests
 fmt:
     uv run prek --all-files
 integration testname:

--- a/src/cascade/controller/impl.py
+++ b/src/cascade/controller/impl.py
@@ -93,4 +93,5 @@ def run(
         mark({"action": ControllerPhases.shutdown})
         logger.debug("shutting down executors")
         bridge.shutdown()
+        reporter.close()
     return state

--- a/src/cascade/controller/report.py
+++ b/src/cascade/controller/report.py
@@ -83,15 +83,20 @@ class ReporterChannel:
         bind_base = f"tcp://{platform.get_bindabble_self()}"
         self._ygg = YggNode(f"{bind_base}:*")
         self._ygg.register_host("gateway", HostEndpoints(control=address))
+        logger.debug("reporter channel initialized: %s", self._ygg.describe_state())
 
     def send(self, report: ControllerReport) -> None:
+        logger.debug("reporter send start: job_id=%s state=%s", self.job_id, self._ygg.describe_state())
         self._ygg.send_message_to_host("gateway", serialize(report), lane="control")
         self._ygg.poll_messages(timeout_ms=0)
         self._ygg.retry_outstanding()
+        logger.debug("reporter send done: job_id=%s state=%s", self.job_id, self._ygg.describe_state())
 
     def close(self) -> None:
         # NOTE we really want to get these acked from gw, otherwise completion is never reported
+        logger.debug("reporter close start: job_id=%s state=%s", self.job_id, self._ygg.describe_state())
         self._ygg.close(timeout_ms=5000, wait_for_all_acks=True)
+        logger.debug("reporter close complete: job_id=%s", self.job_id)
 
 
 class Reporter:

--- a/src/cascade/controller/report.py
+++ b/src/cascade/controller/report.py
@@ -83,20 +83,15 @@ class ReporterChannel:
         bind_base = f"tcp://{platform.get_bindabble_self()}"
         self._ygg = YggNode(f"{bind_base}:*")
         self._ygg.register_host("gateway", HostEndpoints(control=address))
-        logger.debug("reporter channel initialized: %s", self._ygg.describe_state())
 
     def send(self, report: ControllerReport) -> None:
-        logger.debug("reporter send start: job_id=%s state=%s", self.job_id, self._ygg.describe_state())
         self._ygg.send_message_to_host("gateway", serialize(report), lane="control")
         self._ygg.poll_messages(timeout_ms=0)
         self._ygg.retry_outstanding()
-        logger.debug("reporter send done: job_id=%s state=%s", self.job_id, self._ygg.describe_state())
 
     def close(self) -> None:
         # NOTE we really want to get these acked from gw, otherwise completion is never reported
-        logger.debug("reporter close start: job_id=%s state=%s", self.job_id, self._ygg.describe_state())
-        self._ygg.close(timeout_ms=5000, wait_for_all_acks=True)
-        logger.debug("reporter close complete: job_id=%s", self.job_id)
+        self._ygg.close(timeout_ms=1000, wait_for_all_acks=True)
 
 
 class Reporter:

--- a/src/cascade/controller/report.py
+++ b/src/cascade/controller/report.py
@@ -14,16 +14,14 @@ from dataclasses import dataclass
 from time import monotonic_ns
 from typing import NewType
 
-import zmq
 from typing_extensions import Self
 
 import cascade.executor.platform as platform
-from cascade.executor.comms import ReliableSender, default_message_resend_ms, get_context
-from cascade.executor.msg import Ack
-from cascade.executor.serde import des_message
-from cascade.low.core import DatasetId, HostId, TaskId
+from cascade.low.core import DatasetId, TaskId
 from cascade.low.exceptions import CascadeInternalError
 from cascade.low.execution_context import JobExecutionContext
+from cascade.ygg.api import YggNode
+from cascade.ygg.types import HostEndpoints
 
 logger = logging.getLogger(__name__)
 
@@ -82,35 +80,27 @@ class ReporterChannel:
         address, job_id = report_address.split(",", 1)
         logger.debug(f"initialising reporter with {address=} and {job_id=}")
         self.job_id = JobId(job_id)
-        self.ack_socket = get_context().socket(zmq.PULL)
-        ack_base = f"tcp://{platform.get_bindabble_self()}"
-        ack_port = self.ack_socket.bind_to_random_port(ack_base)
-        ack_address = f"{ack_base}:{ack_port}"
-        self.ack_poller = zmq.Poller()
-        self.ack_poller.register(self.ack_socket, flags=zmq.POLLIN)
-        self.sender = ReliableSender(ack_address, default_message_resend_ms)
-        self.sender.add_host(HostId("gateway"), address)
+        bind_base = f"tcp://{platform.get_bindabble_self()}"
+        self._ygg = YggNode(f"{bind_base}:*")
+        self._ygg.register_host("gateway", HostEndpoints(control=address))
 
     def send(self, report: ControllerReport) -> None:
-        self.sender.send_raw(HostId("gateway"), serialize(report), "ControllerReport")
-        if self.sender.inflight:
-            for socket, _ in self.ack_poller.poll(0):
-                if socket is not self.ack_socket:
-                    continue
-                msg_frames = self.ack_socket.recv_multipart()
-                if len(msg_frames) != 1:
-                    raise CascadeInternalError(f"expected single-frame Ack on report channel, got {len(msg_frames)=}")
-                ack = des_message(msg_frames[0])
-                if isinstance(ack, Ack):
-                    self.sender.ack(ack.idx)
-                else:
-                    raise CascadeInternalError(f"expected Ack on report channel, got {type(ack)}")
-            self.sender.maybe_retry()
+        self._ygg.send_message_to_host("gateway", serialize(report), lane="control")
+        self._ygg.poll_messages(timeout_ms=0)
+        self._ygg.retry_outstanding()
+
+    def close(self) -> None:
+        # NOTE we really want to get these acked from gw, otherwise completion is never reported
+        self._ygg.close(timeout_ms=5000, wait_for_all_acks=True)
 
 
 class Reporter:
     def __init__(self, report_address: str | None) -> None:
         self.channel = ReporterChannel(report_address) if report_address is not None else None
+
+    def close(self) -> None:
+        if self.channel is not None:
+            self.channel.close()
 
     def send_task_completed(self, context: JobExecutionContext, completed_task: TaskId) -> None:
         if self.channel is None:

--- a/src/cascade/deployment/logging/defaults.py
+++ b/src/cascade/deployment/logging/defaults.py
@@ -14,6 +14,7 @@ base = {
         "cascade.executor": {"level": "DEBUG"},
         "cascade.scheduler": {"level": "DEBUG"},
         "cascade.gateway": {"level": "DEBUG"},
+        "cascade.ygg": {"level": "DEBUG"},
         "earthkit.workflows": {"level": "DEBUG"},
         "httpcore": {"level": "ERROR"},
         "httpx": {"level": "ERROR"},

--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass
 
 import zmq
 
-import cascade.ygg.transport
 from cascade.executor.msg import (
     Ack,
     BackboneAddress,
@@ -71,10 +70,13 @@ class GraceWatcher:
         return self._now() - self.step_time_ms
 
 
-_local = threading.local()
-
-
 def get_context() -> zmq.Context:
+    # local = threading.local()
+    # if not hasattr(local, 'context'):
+    #     local.context = zmq.Context()
+    # return local.context
+    import cascade.ygg.transport
+
     return cascade.ygg.transport.get_context()
 
 

--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -73,7 +73,7 @@ class GraceWatcher:
 def get_context() -> zmq.Context:
     local = threading.local()
     if not hasattr(local, "context"):
-        local.context = zmq.Context()
+        local.context = zmq.Context.instance()
     return local.context
 
 

--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 import zmq
 
+import cascade.ygg.transport
 from cascade.executor.msg import (
     Ack,
     BackboneAddress,
@@ -70,11 +71,11 @@ class GraceWatcher:
         return self._now() - self.step_time_ms
 
 
+_local = threading.local()
+
+
 def get_context() -> zmq.Context:
-    local = threading.local()
-    if not hasattr(local, "context"):
-        local.context = zmq.Context()
-    return local.context
+    return cascade.ygg.transport.get_context()
 
 
 def get_socket(address: BackboneAddress) -> zmq.Socket:

--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 import zmq
 
+import cascade.ygg.transport
 from cascade.executor.msg import (
     Ack,
     BackboneAddress,
@@ -71,12 +72,6 @@ class GraceWatcher:
 
 
 def get_context() -> zmq.Context:
-    # local = threading.local()
-    # if not hasattr(local, 'context'):
-    #     local.context = zmq.Context()
-    # return local.context
-    import cascade.ygg.transport
-
     return cascade.ygg.transport.get_context()
 
 

--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -73,7 +73,7 @@ class GraceWatcher:
 def get_context() -> zmq.Context:
     local = threading.local()
     if not hasattr(local, "context"):
-        local.context = zmq.Context.instance()
+        local.context = zmq.Context()
     return local.context
 
 

--- a/src/cascade/executor/data_server.py
+++ b/src/cascade/executor/data_server.py
@@ -45,6 +45,7 @@ from cascade.low.core import DatasetId, HostId
 from cascade.low.exceptions import CascadeError, CascadeInfrastructureError, CascadeInternalError, ser
 from cascade.low.func import assert_never
 from cascade.low.tracing import TransmitLifecycle, label, mark
+from cascade.ygg.transport import destroy_context
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,8 @@ class DataServer:
         logging_config: dict,
     ):
         logging.config.dictConfig(logging_config)
+        destroy_context()
+
         self.host = host
         label("host", self.host)
         self.maddress = maddress

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -64,7 +64,7 @@ from cascade.low.func import md5hash24
 from cascade.low.tracing import TaskLifecycle, mark
 from cascade.low.views import param_source
 from cascade.shm.server import entrypoint as shm_server
-from cascade.ygg.transport import destroy_context, has_context
+from cascade.ygg.transport import destroy_context
 
 logger = logging.getLogger(__name__)
 heartbeat_grace_ms = 2 * comms_default_timeout_ms
@@ -96,7 +96,6 @@ class Executor:
         loggingConfig: LoggingConfig,
         url_base: str,
     ) -> None:
-        logger.debug(f"init start: {has_context()=}")
         self.job_instance = job_instance
         self.schema_lookup = RunnerContext.build_schema_lookup(self.job_instance)
         self.param_source = param_source(job_instance.edges)
@@ -111,7 +110,7 @@ class Executor:
         self.heartbeat_watcher = GraceWatcher(grace_ms=heartbeat_grace_ms)
 
         self.terminating = False
-        logger.debug(f"register terminate function, {has_context()=}")
+        logger.debug("register terminate function")
         atexit.register(self.terminate)
         # NOTE following inits are with potential side effects
         # NOTE shm server is the most dangerous because we fork, therefore imperative to not create zmq context before
@@ -119,7 +118,7 @@ class Executor:
         # TODO make the shm server params configurable
         shm_port = f"/tmp/cascShmSock-{uuid.uuid4()}"  # portBase + 2
         shm_api.publish_socket_addr(shm_port)
-        logger.debug(f"about to start an shm process, {has_context()=}")
+        logger.debug("about to start an shm process")
         self.shm_process = platform.get_mp_ctx("executor-shm").Process(
             target=shm_server,
             kwargs={
@@ -134,7 +133,7 @@ class Executor:
         self.sender.add_host(HostId("controller"), controller_address)
         logger.debug(f"started shm process with pid {self.shm_process.pid}")
         self.daddress = address_of(portBase + 1)
-        logger.debug(f"about to start a data server process, {has_context()=}")
+        logger.debug("about to start a data server process")
         self.data_server = platform.get_mp_ctx("executor-dataserver").Process(
             target=start_data_server,
             args=(

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -64,7 +64,7 @@ from cascade.low.func import md5hash24
 from cascade.low.tracing import TaskLifecycle, mark
 from cascade.low.views import param_source
 from cascade.shm.server import entrypoint as shm_server
-from cascade.ygg.transport import has_context
+from cascade.ygg.transport import destroy_context, has_context
 
 logger = logging.getLogger(__name__)
 heartbeat_grace_ms = 2 * comms_default_timeout_ms

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -64,6 +64,7 @@ from cascade.low.func import md5hash24
 from cascade.low.tracing import TaskLifecycle, mark
 from cascade.low.views import param_source
 from cascade.shm.server import entrypoint as shm_server
+from cascade.ygg.transport import has_context
 
 logger = logging.getLogger(__name__)
 heartbeat_grace_ms = 2 * comms_default_timeout_ms
@@ -95,6 +96,7 @@ class Executor:
         loggingConfig: LoggingConfig,
         url_base: str,
     ) -> None:
+        logger.debug(f"init start: {has_context()=}")
         self.job_instance = job_instance
         self.schema_lookup = RunnerContext.build_schema_lookup(self.job_instance)
         self.param_source = param_source(job_instance.edges)
@@ -109,18 +111,16 @@ class Executor:
         self.heartbeat_watcher = GraceWatcher(grace_ms=heartbeat_grace_ms)
 
         self.terminating = False
-        logger.debug("register terminate function")
+        logger.debug(f"register terminate function, {has_context()=}")
         atexit.register(self.terminate)
         # NOTE following inits are with potential side effects
-        self.mlistener = Listener(address_of(portBase))
-        self.sender = ReliableSender(self.mlistener.address, resend_grace_ms)
-        self.sender.add_host(HostId("controller"), controller_address)
+        # NOTE shm server is the most dangerous because we fork, therefore imperative to not create zmq context before
+        # TODO make shm startable with forkserver, there is some propagation issue in that case -- reproducible with tests
         # TODO make the shm server params configurable
         shm_port = f"/tmp/cascShmSock-{uuid.uuid4()}"  # portBase + 2
         shm_api.publish_socket_addr(shm_port)
-        ctx = platform.get_mp_ctx("executor-aux")
-        logger.debug("about to start an shm process")
-        self.shm_process = ctx.Process(
+        logger.debug(f"about to start an shm process, {has_context()=}")
+        self.shm_process = platform.get_mp_ctx("executor-shm").Process(
             target=shm_server,
             kwargs={
                 "capacity": shm_vol_gb * (1024**3) if shm_vol_gb else None,
@@ -129,9 +129,13 @@ class Executor:
             },
         )
         self.shm_process.start()
+        self.mlistener = Listener(address_of(portBase))
+        self.sender = ReliableSender(self.mlistener.address, resend_grace_ms)
+        self.sender.add_host(HostId("controller"), controller_address)
+        logger.debug(f"started shm process with pid {self.shm_process.pid}")
         self.daddress = address_of(portBase + 1)
-        logger.debug("about to start a data server process")
-        self.data_server = ctx.Process(
+        logger.debug(f"about to start a data server process, {has_context()=}")
+        self.data_server = platform.get_mp_ctx("executor-dataserver").Process(
             target=start_data_server,
             args=(
                 self.mlistener.address,
@@ -141,6 +145,7 @@ class Executor:
             ),
         )
         self.data_server.start()
+        logger.debug(f"started data server process with pid {self.data_server.pid}")
         gpus = int(os.environ.get("CASCADE_GPU_COUNT", "0"))
         self.registration = ExecutorRegistration(
             host=self.host,

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -64,7 +64,6 @@ from cascade.low.func import md5hash24
 from cascade.low.tracing import TaskLifecycle, mark
 from cascade.low.views import param_source
 from cascade.shm.server import entrypoint as shm_server
-from cascade.ygg.transport import destroy_context
 
 logger = logging.getLogger(__name__)
 heartbeat_grace_ms = 2 * comms_default_timeout_ms
@@ -113,7 +112,9 @@ class Executor:
         logger.debug("register terminate function")
         atexit.register(self.terminate)
         # NOTE following inits are with potential side effects
-        # NOTE shm server is the most dangerous because we fork, therefore imperative to not create zmq context before
+        self.mlistener = Listener(address_of(portBase))
+        self.sender = ReliableSender(self.mlistener.address, resend_grace_ms)
+        self.sender.add_host(HostId("controller"), controller_address)
         # TODO make shm startable with forkserver, there is some propagation issue in that case -- reproducible with tests
         # TODO make the shm server params configurable
         shm_port = f"/tmp/cascShmSock-{uuid.uuid4()}"  # portBase + 2
@@ -128,10 +129,6 @@ class Executor:
             },
         )
         self.shm_process.start()
-        self.mlistener = Listener(address_of(portBase))
-        self.sender = ReliableSender(self.mlistener.address, resend_grace_ms)
-        self.sender.add_host(HostId("controller"), controller_address)
-        logger.debug(f"started shm process with pid {self.shm_process.pid}")
         self.daddress = address_of(portBase + 1)
         logger.debug("about to start a data server process")
         self.data_server = platform.get_mp_ctx("executor-dataserver").Process(
@@ -144,7 +141,6 @@ class Executor:
             ),
         )
         self.data_server.start()
-        logger.debug(f"started data server process with pid {self.data_server.pid}")
         gpus = int(os.environ.get("CASCADE_GPU_COUNT", "0"))
         self.registration = ExecutorRegistration(
             host=self.host,

--- a/src/cascade/executor/platform.py
+++ b/src/cascade/executor/platform.py
@@ -65,7 +65,7 @@ def get_mp_ctx(situation: MpSituation) -> mp.context.ForkContext | mp.context.Sp
         raise CascadeInternalError(f"{situation=} is not in {_MpSituation}")
     if sys.platform == "darwin":
         return mp.get_context("spawn")
-    elif situation in ("executor-loc", "worker", "executor-dataserver", "gateway"):
+    elif situation in ("executor-loc"):
         # NOTE in the case of executor being launched locally, from eg cascade main
         # after it has constructed a jobInstance, there is a chance of the process
         # being tainted with some imports such as earthkit.workflows.fluent which in

--- a/src/cascade/executor/platform.py
+++ b/src/cascade/executor/platform.py
@@ -46,7 +46,7 @@ def gpu_init(worker_num: int):
         pass  # no macos specific gpu init due to unified mem model
 
 
-MpSituation = typing.Literal["worker", "executor-loc", "executor-aux", "gateway", "other"]
+MpSituation = typing.Literal["worker", "executor-loc", "executor-shm", "executor-dataserver", "gateway", "other"]
 _MpSituation = typing.get_args(MpSituation)
 
 
@@ -65,13 +65,15 @@ def get_mp_ctx(situation: MpSituation) -> mp.context.ForkContext | mp.context.Sp
         raise CascadeInternalError(f"{situation=} is not in {_MpSituation}")
     if sys.platform == "darwin":
         return mp.get_context("spawn")
-    elif situation == "executor-loc":
+    elif situation in ("executor-loc", "worker", "executor-dataserver", "gateway"):
         # NOTE in the case of executor being launched locally, from eg cascade main
         # after it has constructed a jobInstance, there is a chance of the process
         # being tainted with some imports such as earthkit.workflows.fluent which in
         # turn brings in numpy -- therefore, we cannot allow to fork
         return mp.get_context("forkserver")
     else:
+        # NOTE in particular shm currently requires fork on linux, due to some
+        # propagation or env or whatnot -- reproducible with shm test
         return mp.get_context("fork")
 
 

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -160,7 +160,7 @@ def entrypoint(workerSetup: WorkerSetup, runnerContext: RunnerContext) -> None:
     logger.debug(f"worker {workerSetup.workerId} binding to {address=}")
     socket.bind(address)
     callback(runnerContext.callback, WorkerReady(workerSetup.workerId))
-    logger.debug(f"worker {workerSetup.workerId} sent callback ready")
+    logger.debug(f"worker {workerSetup.workerId} sent WorkerReady")
     with (
         Memory(runnerContext.callback, workerSetup.workerId) as memory,
         PackagesEnv({k: Version(v) for k, v in workerSetup.initial_installed.items()}) as pckg,

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -153,6 +153,7 @@ def execute_sequence(
 def entrypoint(workerSetup: WorkerSetup, runnerContext: RunnerContext) -> None:
     """Main runner loop for a worker process."""
     init_from_obj(runnerContext.loggingConfig, f"worker_{workerSetup.workerId.worker}")
+    destroy_context()
     ctx = get_context()
     socket = ctx.socket(zmq.PULL)
     address = worker_address(workerSetup.workerId, workerSetup.workerAttemptCnt)

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -36,6 +36,7 @@ from cascade.executor.runner.setup import RunnerContext, WorkerSetup, load_runne
 from cascade.low.core import DatasetId, TaskId, WorkerId, type_dec
 from cascade.low.exceptions import CascadeError, CascadeInfrastructureError, CascadeInternalError, CascadeUserError, ser
 from cascade.low.tracing import label
+from cascade.ygg.transport import destroy_context, get_context
 
 logger = logging.getLogger(__name__ if __name__ != "__main__" else "cascade.executor.runner.entrypoint")
 
@@ -152,12 +153,13 @@ def execute_sequence(
 def entrypoint(workerSetup: WorkerSetup, runnerContext: RunnerContext) -> None:
     """Main runner loop for a worker process."""
     init_from_obj(runnerContext.loggingConfig, f"worker_{workerSetup.workerId.worker}")
-    ctx = zmq.Context()
+    ctx = get_context()
     socket = ctx.socket(zmq.PULL)
     address = worker_address(workerSetup.workerId, workerSetup.workerAttemptCnt)
     logger.debug(f"worker {workerSetup.workerId} binding to {address=}")
     socket.bind(address)
     callback(runnerContext.callback, WorkerReady(workerSetup.workerId))
+    logger.debug(f"worker {workerSetup.workerId} sent callback ready")
     with (
         Memory(runnerContext.callback, workerSetup.workerId) as memory,
         PackagesEnv({k: Version(v) for k, v in workerSetup.initial_installed.items()}) as pckg,

--- a/src/cascade/gateway/__main__.py
+++ b/src/cascade/gateway/__main__.py
@@ -19,9 +19,10 @@ def main_cli(
     loggingConfigSer: str | None = None,
     troika_config: str | None = None,
     max_jobs: int | None = None,
+    report_transport: str = "tcp",
 ) -> None:
     loggingConfig = init_from_cliparam(loggingConfigSer, roleLoggingStr())
-    serve(url, loggingConfig, troika_config, max_jobs)
+    serve(url, loggingConfig, troika_config, max_jobs, report_transport)
 
 
 if __name__ == "__main__":

--- a/src/cascade/gateway/router.py
+++ b/src/cascade/gateway/router.py
@@ -20,9 +20,6 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Iterable
 
-import zmq
-
-import cascade.executor.platform as platform
 import cascade.gateway.api as api
 from cascade.controller.report import (
     JobId,
@@ -31,17 +28,16 @@ from cascade.controller.report import (
     JobProgressStarted,
 )
 from cascade.deployment.logging import LoggingConfig
-from cascade.executor.comms import get_context
 from cascade.gateway.spawning import spawn_subprocess
 from cascade.low.core import DatasetId, TaskId
 from cascade.low.func import next_uuid
+from cascade.ygg.api import YggNode
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class Job:
-    socket: zmq.Socket
     progress: JobProgress
     last_seen: int
     results: dict[DatasetId, bytes]
@@ -52,12 +48,12 @@ class Job:
 class JobRouter:
     def __init__(
         self,
-        poller: zmq.Poller,
+        ygg: YggNode,
         loggingConfig: LoggingConfig,
         troika_config: str | None,
         max_jobs: int | None,
     ):
-        self.poller = poller
+        self._ygg = ygg
         self.jobs: dict[JobId, Job] = {}
         self.active_jobs = 0
         self.max_jobs = max_jobs
@@ -74,13 +70,9 @@ class JobRouter:
             return
 
         job_id, job_spec = self.jobs_queue.popitem(False)
-        base_addr = f"tcp://{platform.get_bindabble_self()}"
-        socket = get_context().socket(zmq.PULL)
-        port = socket.bind_to_random_port(base_addr)
-        full_addr = f"{base_addr}:{port}"
+        full_addr = self._ygg.control_address
         logger.debug(f"will spawn job {job_id} and listen on {full_addr}")
-        self.poller.register(socket, flags=zmq.POLLIN)
-        self.jobs[job_id] = Job(socket, JobProgressStarted, -1, {}, set(), set())
+        self.jobs[job_id] = Job(JobProgressStarted, -1, {}, set(), set())
         self.procs[job_id] = spawn_subprocess(job_spec, full_addr, job_id, self.loggingConfig, self.troika_config)
         self.active_jobs += 1
 
@@ -144,7 +136,10 @@ class JobRouter:
             return
         job.last_seen = timestamp
         if progress.completed and not job.progress.completed:
-            self.poller.unregister(job.socket)
+            # NOTE we could call forget_sender here to flush cache early,
+            # assuming we passed the msg.source_address from the caller. But that
+            # could lead to some double processings of completed/planned messages,
+            # so probably not worth it
             self.active_jobs -= 1
             self.maybe_spawn()
         if progress.failure is not None and job.progress.failure is None:

--- a/src/cascade/gateway/server.py
+++ b/src/cascade/gateway/server.py
@@ -13,16 +13,18 @@ here we just match the right method of `gateway.router` based on what message we
 import base64
 import datetime as dt
 import logging
+import os
 
 import zmq
 
+import cascade.executor.platform as platform
 import cascade.gateway.api as api
 from cascade.controller.report import deserialize
 from cascade.deployment.logging import LoggingConfig, init_from_obj
-from cascade.executor.comms import get_context, receive_and_ack
 from cascade.gateway.client import parse_request, serialize_response
 from cascade.gateway.router import JobRouter
 from cascade.low.exceptions import CascadeInternalError
+from cascade.ygg.api import YggNode
 
 logger = logging.getLogger(__name__)
 
@@ -70,15 +72,15 @@ def handle_fe(socket: zmq.Socket, jobs: JobRouter) -> bool:
     return isinstance(rv, api.ShutdownResponse)
 
 
-def handle_controller(socket: zmq.Socket, jobs: JobRouter, seen_syns: set[tuple[int, str]]) -> None:
-    raw_report = receive_and_ack(socket, seen_syns)
-    if raw_report is None:
-        return
-    report = deserialize(raw_report)
-    logger.debug(f"received controller message {report}")
-    jobs.maybe_update(report.job_id, report.current_status, report.timestamp, report.completed_task, report.planned_tasks)
-    for dataset_id, result in report.results:
-        jobs.put_result(report.job_id, dataset_id, result)
+def handle_controller(ygg: YggNode, jobs: JobRouter) -> None:
+    while msgs := ygg.poll_messages(timeout_ms=0):
+        for msg in msgs:
+            raw_report = msg.payload
+            report = deserialize(raw_report)
+            logger.debug(f"received controller message {report}")
+            jobs.maybe_update(report.job_id, report.current_status, report.timestamp, report.completed_task, report.planned_tasks)
+            for dataset_id, result in report.results:
+                jobs.put_result(report.job_id, dataset_id, result)
 
 
 def serve(
@@ -86,25 +88,41 @@ def serve(
     loggingConfig: LoggingConfig,
     troika_config: str | None = None,
     max_jobs: int | None = None,
+    report_transport: str = "tcp",
 ) -> None:
-    ctx = get_context()
+    if report_transport == "tcp":
+        bind_base = f"tcp://{platform.get_bindabble_self()}"
+        ygg = YggNode(f"{bind_base}:*")
+    elif report_transport == "ipc":
+        bind = f"ipc:///tmp/gateway.{os.getpid()}.socket"
+        ygg = YggNode(bind)
+    else:
+        raise NotImplementedError(report_transport)
     poller = zmq.Poller()
 
-    fe = ctx.socket(zmq.REP)
+    fe = zmq.Context().socket(zmq.REP)
     fe.bind(url)
+    # TODO migrate fe socket to ygg once REP socket type supported
+    ygg_control_socket = ygg._listener._socket_by_lane["control"]  # ty: ignore
     poller.register(fe, flags=zmq.POLLIN)
-    jobs = JobRouter(poller, loggingConfig, troika_config, max_jobs)
-    seen_syns: set[tuple[int, str]] = set()
+    poller.register(ygg_control_socket, flags=zmq.POLLIN)
+    jobs = JobRouter(ygg, loggingConfig, troika_config, max_jobs)
 
     logger.debug("entering recv loop")
     is_break = False
-    while not is_break:
-        ready = poller.poll(None)
-        for socket, _ in ready:
-            if socket == fe:
-                is_break = handle_fe(socket, jobs)
-            else:
-                handle_controller(socket, jobs, seen_syns)
+    try:
+        while not is_break:
+            ready = poller.poll(None)
+            for socket, _ in ready:
+                if socket == fe:
+                    is_break = handle_fe(socket, jobs)
+                elif socket == ygg_control_socket:
+                    handle_controller(ygg, jobs)
+                else:
+                    raise CascadeInternalError(f"unexpected socket in gateway poller loop: {socket=}")
+    finally:
+        fe.close()
+        ygg.close()
 
 
 def roleLoggingStr() -> str:
@@ -114,7 +132,7 @@ def roleLoggingStr() -> str:
     return f"gateway.{now}"
 
 
-def main_enp(url: str, loggingConfig: LoggingConfig, max_jobs: int | None) -> None:
+def main_enp(url: str, loggingConfig: LoggingConfig, max_jobs: int | None, report_transport: str = "tcp") -> None:
     # use when process is not __main__ but eg forked from another
     init_from_obj(loggingConfig, roleLoggingStr())
-    serve(url, loggingConfig, None, max_jobs)
+    serve(url, loggingConfig, None, max_jobs, report_transport)

--- a/src/cascade/gateway/server.py
+++ b/src/cascade/gateway/server.py
@@ -73,7 +73,6 @@ def handle_fe(socket: zmq.Socket, jobs: JobRouter) -> bool:
 
 
 def handle_controller(ygg: YggNode, jobs: JobRouter) -> None:
-    logger.debug("gateway controller drain start: state=%s", ygg.describe_state())
     while msgs := ygg.poll_messages(timeout_ms=0):
         for msg in msgs:
             raw_report = msg.payload
@@ -82,7 +81,6 @@ def handle_controller(ygg: YggNode, jobs: JobRouter) -> None:
             jobs.maybe_update(report.job_id, report.current_status, report.timestamp, report.completed_task, report.planned_tasks)
             for dataset_id, result in report.results:
                 jobs.put_result(report.job_id, dataset_id, result)
-    logger.debug("gateway controller drain complete: state=%s", ygg.describe_state())
 
 
 def serve(
@@ -109,25 +107,12 @@ def serve(
     poller.register(fe, flags=zmq.POLLIN)
     poller.register(ygg_control_socket, flags=zmq.POLLIN)
     jobs = JobRouter(ygg, loggingConfig, troika_config, max_jobs)
-    logger.debug(
-        "gateway sockets registered: fe=%s control=%s state=%s",
-        fe.getsockopt_string(zmq.LAST_ENDPOINT),
-        ygg_control_socket.getsockopt_string(zmq.LAST_ENDPOINT),
-        ygg.describe_state(),
-    )
 
     logger.debug("entering recv loop")
     is_break = False
     try:
         while not is_break:
             ready = poller.poll(None)
-            logger.debug(
-                "gateway poll wakeup: ready=%s fe_events=%s control_events=%s state=%s",
-                len(ready),
-                fe.getsockopt(zmq.EVENTS),
-                ygg_control_socket.getsockopt(zmq.EVENTS),
-                ygg.describe_state(),
-            )
             for socket, _ in ready:
                 if socket == fe:
                     is_break = handle_fe(socket, jobs)

--- a/src/cascade/gateway/server.py
+++ b/src/cascade/gateway/server.py
@@ -73,6 +73,7 @@ def handle_fe(socket: zmq.Socket, jobs: JobRouter) -> bool:
 
 
 def handle_controller(ygg: YggNode, jobs: JobRouter) -> None:
+    logger.debug("gateway controller drain start: state=%s", ygg.describe_state())
     while msgs := ygg.poll_messages(timeout_ms=0):
         for msg in msgs:
             raw_report = msg.payload
@@ -81,6 +82,7 @@ def handle_controller(ygg: YggNode, jobs: JobRouter) -> None:
             jobs.maybe_update(report.job_id, report.current_status, report.timestamp, report.completed_task, report.planned_tasks)
             for dataset_id, result in report.results:
                 jobs.put_result(report.job_id, dataset_id, result)
+    logger.debug("gateway controller drain complete: state=%s", ygg.describe_state())
 
 
 def serve(
@@ -107,12 +109,25 @@ def serve(
     poller.register(fe, flags=zmq.POLLIN)
     poller.register(ygg_control_socket, flags=zmq.POLLIN)
     jobs = JobRouter(ygg, loggingConfig, troika_config, max_jobs)
+    logger.debug(
+        "gateway sockets registered: fe=%s control=%s state=%s",
+        fe.getsockopt_string(zmq.LAST_ENDPOINT),
+        ygg_control_socket.getsockopt_string(zmq.LAST_ENDPOINT),
+        ygg.describe_state(),
+    )
 
     logger.debug("entering recv loop")
     is_break = False
     try:
         while not is_break:
             ready = poller.poll(None)
+            logger.debug(
+                "gateway poll wakeup: ready=%s fe_events=%s control_events=%s state=%s",
+                len(ready),
+                fe.getsockopt(zmq.EVENTS),
+                ygg_control_socket.getsockopt(zmq.EVENTS),
+                ygg.describe_state(),
+            )
             for socket, _ in ready:
                 if socket == fe:
                     is_break = handle_fe(socket, jobs)

--- a/src/cascade/gateway/spawning.py
+++ b/src/cascade/gateway/spawning.py
@@ -100,7 +100,7 @@ def _spawn_local(
     global local_job_port
     portBase = ["--port_base", str(local_job_port)]
     local_job_port += 1 + job_spec.hosts * job_spec.workers_per_host * 10
-    return subprocess.Popen(base + infra + report + portBase + logs, env={**os.environ, **job_spec.envvars})
+    return subprocess.Popen(base + infra + report + portBase + logs, env={**os.environ, **job_spec.envvars}, close_fds=True)
 
 
 def _spawn_slurm(job_spec: JobSpec, addr: str, job_id: JobId) -> subprocess.Popen:

--- a/src/cascade/main.py
+++ b/src/cascade/main.py
@@ -247,19 +247,4 @@ def main_dist(
 
 
 if __name__ == "__main__":
-    import os
-    import sys
-
-    print(f"--- Child PID {os.getpid()} FD Table ---", file=sys.stderr)
-    fd_path = "/proc/self/fd"
-    if os.path.exists(fd_path):
-        for fd in sorted(os.listdir(fd_path)):
-            try:
-                # Get the actual file/socket the FD points to
-                dest = os.readlink(os.path.join(fd_path, fd))
-                print(f"FD {fd}: {dest}", file=sys.stderr)
-            except OSError:
-                continue
-    print("------------------------------------------", file=sys.stderr)
-
     fire.Fire({"local": main_local, "dist": main_dist})

--- a/src/cascade/main.py
+++ b/src/cascade/main.py
@@ -247,4 +247,24 @@ def main_dist(
 
 
 if __name__ == "__main__":
+    import os
+    import sys
+
+    print(f"--- Child PID {os.getpid()} FD Table ---", file=sys.stderr)
+    fd_path = "/proc/self/fd"
+    if os.path.exists(fd_path):
+        for fd in sorted(os.listdir(fd_path)):
+            try:
+                # Get the actual file/socket the FD points to
+                dest = os.readlink(os.path.join(fd_path, fd))
+                print(f"FD {fd}: {dest}", file=sys.stderr)
+            except OSError:
+                continue
+    print("------------------------------------------", file=sys.stderr)
+
+    import zmq
+
+    ctx = zmq.Context.instance()
+    ctx.term()
+
     fire.Fire({"local": main_local, "dist": main_dist})

--- a/src/cascade/main.py
+++ b/src/cascade/main.py
@@ -262,9 +262,4 @@ if __name__ == "__main__":
                 continue
     print("------------------------------------------", file=sys.stderr)
 
-    import zmq
-
-    ctx = zmq.Context.instance()
-    ctx.term()
-
     fire.Fire({"local": main_local, "dist": main_dist})

--- a/src/cascade/ygg/api.py
+++ b/src/cascade/ygg/api.py
@@ -155,7 +155,9 @@ class YggNode:
                 remaining_ns = deadline_ns - time.monotonic_ns()
                 if remaining_ns <= 0:
                     break
-                self.poll_messages(timeout_ms=remaining_ns // 1_000_000)
+                poll_timeout_ms = min(remaining_ns // 1_000_000, self._config.control.retry_interval_ms)
+                self.poll_messages(timeout_ms=poll_timeout_ms)
+                self.retry_outstanding()
             if self._inflight:
                 logger.warning("ygg close timed out with %d inflight messages", len(self._inflight))
         self._outbound.close()

--- a/src/cascade/ygg/api.py
+++ b/src/cascade/ygg/api.py
@@ -35,6 +35,7 @@ class YggNode:
         self._next_idx = 0
         self.control_address = self._listener.address_for("control")
         self.bulk_address = self._listener.address_for("bulk") if bulk_bind_address is not None else None
+        logger.debug("ygg node initialised: %s", self.describe_state())
 
     def register_host(self, host_id: str, endpoints: HostEndpoints) -> None:
         self._registry.register(HostId(host_id), endpoints)
@@ -67,6 +68,7 @@ class YggNode:
         address = self._registry.resolve(host, lane)
         resolved_delivery = self._resolve_delivery(lane=lane, delivery=delivery)
         if resolved_delivery == "best_effort":
+            logger.debug("ygg best-effort send: host=%s lane=%s state=%s", host, lane, self.describe_state())
             self._outbound.send_single(address=address, frame=payload)
             return None
         idx = self._next_idx
@@ -80,6 +82,14 @@ class YggNode:
             payload_frame=payload,
         )
         self._inflight[idx] = record
+        logger.debug(
+            "ygg queue send: host=%s lane=%s idx=%s address=%s state=%s",
+            host,
+            lane,
+            idx,
+            address,
+            self.describe_state(),
+        )
         self._send_record(record)
         return idx
 
@@ -115,10 +125,13 @@ class YggNode:
         Does NOT automatically call retry_outstanding. Callers should manage retries explicitly.
         """
         messages: list[IncomingMessage] = []
+        logger.debug("ygg poll: timeout_ms=%s state=%s", timeout_ms, self.describe_state())
         for lane, frames in self._listener.poll(timeout_ms=timeout_ms):
             incoming = self._handle_incoming(lane, frames)
             if incoming is not None:
                 messages.append(incoming)
+        if messages:
+            logger.debug("ygg poll received %d message(s): state=%s", len(messages), self.describe_state())
         return messages
 
     def retry_outstanding(self) -> None:
@@ -130,6 +143,12 @@ class YggNode:
                 self._send_record(record)
 
     def close(self, timeout_ms: int = 1000, wait_for_all_acks: bool = True) -> None:
+        logger.debug(
+            "ygg close start: timeout_ms=%s wait_for_all_acks=%s state=%s",
+            timeout_ms,
+            wait_for_all_acks,
+            self.describe_state(),
+        )
         if wait_for_all_acks:
             deadline_ns = time.monotonic_ns() + timeout_ms * 1_000_000
             while self._inflight:
@@ -141,6 +160,7 @@ class YggNode:
                 logger.warning("ygg close timed out with %d inflight messages", len(self._inflight))
         self._outbound.close()
         self._listener.close()
+        logger.debug("ygg close complete")
 
     def __enter__(self) -> "YggNode":
         return self
@@ -167,14 +187,39 @@ class YggNode:
             if len(frames) != 1:
                 raise CascadeInternalError("unexpected payload frame with ygg Ack")
             self.acknowledge(envelope.idx)
+            logger.debug("ygg ack received: idx=%s lane=%s state=%s", envelope.idx, lane, self.describe_state())
             return None
         if isinstance(envelope, Syn):
             if len(frames) != 2:
                 raise CascadeInternalError("expected single payload frame after ygg Syn")
             self._outbound.send_single(envelope.ack_address, serialize_ack(Ack(idx=envelope.idx)))
             if self._dedup.is_duplicate(envelope.idx, envelope.ack_address):
+                logger.debug(
+                    "ygg syn duplicate dropped: idx=%s lane=%s source=%s state=%s",
+                    envelope.idx,
+                    lane,
+                    envelope.ack_address,
+                    self.describe_state(),
+                )
                 return None
+            logger.debug(
+                "ygg syn received: idx=%s lane=%s source=%s state=%s",
+                envelope.idx,
+                lane,
+                envelope.ack_address,
+                self.describe_state(),
+            )
             return IncomingMessage(payload=frames[1], lane=lane, source_address=envelope.ack_address, message_id=envelope.idx)
         if len(frames) != 1:
             raise CascadeInternalError("unexpected multipart ygg message without envelope")
         return IncomingMessage(payload=frames[0], lane=lane, source_address=None, message_id=None)
+
+    def describe_state(self) -> dict[str, object]:
+        return {
+            "control_address": self.control_address,
+            "bulk_address": self.bulk_address,
+            "pending": len(self._inflight),
+            "pending_ids": sorted(self._inflight.keys()),
+            "listener": self._listener.describe_state(),
+            "outbound": self._outbound.describe_state(),
+        }

--- a/src/cascade/ygg/api.py
+++ b/src/cascade/ygg/api.py
@@ -35,7 +35,6 @@ class YggNode:
         self._next_idx = 0
         self.control_address = self._listener.address_for("control")
         self.bulk_address = self._listener.address_for("bulk") if bulk_bind_address is not None else None
-        logger.debug("ygg node initialised: %s", self.describe_state())
 
     def register_host(self, host_id: str, endpoints: HostEndpoints) -> None:
         self._registry.register(HostId(host_id), endpoints)
@@ -68,7 +67,6 @@ class YggNode:
         address = self._registry.resolve(host, lane)
         resolved_delivery = self._resolve_delivery(lane=lane, delivery=delivery)
         if resolved_delivery == "best_effort":
-            logger.debug("ygg best-effort send: host=%s lane=%s state=%s", host, lane, self.describe_state())
             self._outbound.send_single(address=address, frame=payload)
             return None
         idx = self._next_idx
@@ -82,14 +80,6 @@ class YggNode:
             payload_frame=payload,
         )
         self._inflight[idx] = record
-        logger.debug(
-            "ygg queue send: host=%s lane=%s idx=%s address=%s state=%s",
-            host,
-            lane,
-            idx,
-            address,
-            self.describe_state(),
-        )
         self._send_record(record)
         return idx
 
@@ -125,13 +115,10 @@ class YggNode:
         Does NOT automatically call retry_outstanding. Callers should manage retries explicitly.
         """
         messages: list[IncomingMessage] = []
-        logger.debug("ygg poll: timeout_ms=%s state=%s", timeout_ms, self.describe_state())
         for lane, frames in self._listener.poll(timeout_ms=timeout_ms):
             incoming = self._handle_incoming(lane, frames)
             if incoming is not None:
                 messages.append(incoming)
-        if messages:
-            logger.debug("ygg poll received %d message(s): state=%s", len(messages), self.describe_state())
         return messages
 
     def retry_outstanding(self) -> None:
@@ -144,12 +131,6 @@ class YggNode:
                 self._send_record(record)
 
     def close(self, timeout_ms: int = 1000, wait_for_all_acks: bool = True) -> None:
-        logger.debug(
-            "ygg close start: timeout_ms=%s wait_for_all_acks=%s state=%s",
-            timeout_ms,
-            wait_for_all_acks,
-            self.describe_state(),
-        )
         if wait_for_all_acks:
             deadline_ns = time.monotonic_ns() + timeout_ms * 1_000_000
             while self._inflight:
@@ -163,7 +144,6 @@ class YggNode:
                 logger.warning("ygg close timed out with %d inflight messages", len(self._inflight))
         self._outbound.close()
         self._listener.close()
-        logger.debug("ygg close complete")
 
     def __enter__(self) -> "YggNode":
         return self
@@ -190,28 +170,13 @@ class YggNode:
             if len(frames) != 1:
                 raise CascadeInternalError("unexpected payload frame with ygg Ack")
             self.acknowledge(envelope.idx)
-            logger.debug("ygg ack received: idx=%s lane=%s state=%s", envelope.idx, lane, self.describe_state())
             return None
         if isinstance(envelope, Syn):
             if len(frames) != 2:
                 raise CascadeInternalError("expected single payload frame after ygg Syn")
             self._outbound.send_single(envelope.ack_address, serialize_ack(Ack(idx=envelope.idx)))
             if self._dedup.is_duplicate(envelope.idx, envelope.ack_address):
-                logger.debug(
-                    "ygg syn duplicate dropped: idx=%s lane=%s source=%s state=%s",
-                    envelope.idx,
-                    lane,
-                    envelope.ack_address,
-                    self.describe_state(),
-                )
                 return None
-            logger.debug(
-                "ygg syn received: idx=%s lane=%s source=%s state=%s",
-                envelope.idx,
-                lane,
-                envelope.ack_address,
-                self.describe_state(),
-            )
             return IncomingMessage(payload=frames[1], lane=lane, source_address=envelope.ack_address, message_id=envelope.idx)
         if len(frames) != 1:
             raise CascadeInternalError("unexpected multipart ygg message without envelope")

--- a/src/cascade/ygg/api.py
+++ b/src/cascade/ygg/api.py
@@ -6,6 +6,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import logging
 import time
 from typing import Iterable
 
@@ -15,6 +16,8 @@ from cascade.ygg.registry import HostRegistry
 from cascade.ygg.reliability import DedupCache, InflightMessage, RetryPlanner
 from cascade.ygg.transport import MultiLaneListener, OutboundTransport
 from cascade.ygg.types import Delivery, HostEndpoints, HostId, IncomingMessage, Lane, YggConfig
+
+logger = logging.getLogger(__name__)
 
 
 class YggNode:
@@ -126,7 +129,16 @@ class YggNode:
             if self._retry.is_due(record, now_ns=now):
                 self._send_record(record)
 
-    def close(self) -> None:
+    def close(self, timeout_ms: int = 1000, wait_for_all_acks: bool = True) -> None:
+        if wait_for_all_acks:
+            deadline_ns = time.monotonic_ns() + timeout_ms * 1_000_000
+            while self._inflight:
+                remaining_ns = deadline_ns - time.monotonic_ns()
+                if remaining_ns <= 0:
+                    break
+                self.poll_messages(timeout_ms=remaining_ns // 1_000_000)
+            if self._inflight:
+                logger.warning("ygg close timed out with %d inflight messages", len(self._inflight))
         self._outbound.close()
         self._listener.close()
 

--- a/src/cascade/ygg/api.py
+++ b/src/cascade/ygg/api.py
@@ -140,6 +140,7 @@ class YggNode:
             record = self._inflight[idx]
             self._retry.assert_not_exhausted(record, now_ns=now)
             if self._retry.is_due(record, now_ns=now):
+                logger.debug(f"retrying message {idx=}")
                 self._send_record(record)
 
     def close(self, timeout_ms: int = 1000, wait_for_all_acks: bool = True) -> None:

--- a/src/cascade/ygg/transport.py
+++ b/src/cascade/ygg/transport.py
@@ -29,24 +29,14 @@ def get_context() -> zmq.Context:
     return _local.context
 
 
-def has_context() -> bool:
-    if not hasattr(_local, "context"):
-        return False
-    else:
-        return True
-
-
 def destroy_context() -> None:
+    """When a process has potentially started via a fork, there may be
+    a remnant of parent's zmq context, therefore it is imperative to
+    destoy it. Additionally, in tests the context may be left in
+    an unpractical state, requiring a delete at the start"""
     if hasattr(_local, "context"):
         _local.context.destroy(linger=0)
         del _local.context
-        logger.debug("context destroyed")
-        import time
-
-        # time.sleep(0.5)
-        logger.debug("proceeding after destroy")
-    else:
-        logger.debug("no context to destroy")
 
 
 class OutboundTransport:

--- a/src/cascade/ygg/transport.py
+++ b/src/cascade/ygg/transport.py
@@ -6,12 +6,16 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import logging
 import threading
+from typing import Any
 
 import zmq
 
 from cascade.low.exceptions import CascadeInternalError
 from cascade.ygg.types import Lane
+
+logger = logging.getLogger(__name__)
 
 _local = threading.local()
 
@@ -36,6 +40,9 @@ class OutboundTransport:
         socket.connect(address)
         self._sockets[address] = socket
         return socket
+
+    def describe_state(self) -> dict[str, Any]:
+        return {address: _describe_socket(socket) for address, socket in self._sockets.items()}
 
     def send_multipart(self, address: str, frames: tuple[bytes, ...], copy: bool = True) -> None:
         self._socket_for(address).send_multipart(frames, copy=copy)
@@ -65,6 +72,9 @@ class MultiLaneListener:
             self._addresses[lane] = address
             self._poller.register(socket, flags=zmq.POLLIN)
 
+    def describe_state(self) -> dict[str, Any]:
+        return {lane: _describe_socket(socket) for lane, socket in self._socket_by_lane.items()}
+
     def _bind(self, socket: zmq.Socket, bind_address: str) -> str:
         if bind_address.endswith(":*"):
             base = bind_address[: -len(":*")]
@@ -93,3 +103,12 @@ class MultiLaneListener:
         self._socket_by_lane.clear()
         self._lane_by_socket_id.clear()
         self._addresses.clear()
+
+
+def _describe_socket(socket: zmq.Socket) -> dict[str, Any]:
+    return {
+        "type": socket.getsockopt(zmq.TYPE),
+        "events": socket.getsockopt(zmq.EVENTS),
+        "endpoint": socket.getsockopt_string(zmq.LAST_ENDPOINT),
+        "fd": socket.getsockopt(zmq.FD),
+    }

--- a/src/cascade/ygg/transport.py
+++ b/src/cascade/ygg/transport.py
@@ -26,6 +26,19 @@ def get_context() -> zmq.Context:
     return _local.context
 
 
+def destroy_context() -> None:
+    if hasattr(_local, "context"):
+        _local.context.destroy(linger=0)
+        del _local.context
+        logger.debug("context destroyed")
+        import time
+
+        time.sleep(0.5)
+        logger.debug("proceeding after destroy")
+    else:
+        logger.debug("no context to destroy")
+
+
 class OutboundTransport:
     def __init__(self, linger_ms: int) -> None:
         self._linger_ms = linger_ms

--- a/src/cascade/ygg/transport.py
+++ b/src/cascade/ygg/transport.py
@@ -22,7 +22,7 @@ _local = threading.local()
 
 def get_context() -> zmq.Context:
     if not hasattr(_local, "context"):
-        _local.context = zmq.Context()
+        _local.context = zmq.Context.instance()
     return _local.context
 
 

--- a/src/cascade/ygg/transport.py
+++ b/src/cascade/ygg/transport.py
@@ -22,8 +22,18 @@ _local = threading.local()
 
 def get_context() -> zmq.Context:
     if not hasattr(_local, "context"):
+        logger.debug("creating a new context")
         _local.context = zmq.Context()
+    else:
+        logger.debug("retrieving cached context")
     return _local.context
+
+
+def has_context() -> bool:
+    if not hasattr(_local, "context"):
+        return False
+    else:
+        return True
 
 
 def destroy_context() -> None:

--- a/src/cascade/ygg/transport.py
+++ b/src/cascade/ygg/transport.py
@@ -43,7 +43,7 @@ def destroy_context() -> None:
         logger.debug("context destroyed")
         import time
 
-        time.sleep(0.5)
+        # time.sleep(0.5)
         logger.debug("proceeding after destroy")
     else:
         logger.debug("no context to destroy")

--- a/src/cascade/ygg/transport.py
+++ b/src/cascade/ygg/transport.py
@@ -22,7 +22,7 @@ _local = threading.local()
 
 def get_context() -> zmq.Context:
     if not hasattr(_local, "context"):
-        _local.context = zmq.Context.instance()
+        _local.context = zmq.Context()
     return _local.context
 
 
@@ -30,6 +30,7 @@ class OutboundTransport:
     def __init__(self, linger_ms: int) -> None:
         self._linger_ms = linger_ms
         self._sockets: dict[str, zmq.Socket] = {}
+        self.should_monitor = True
 
     def _socket_for(self, address: str) -> zmq.Socket:
         socket = self._sockets.get(address)
@@ -45,7 +46,23 @@ class OutboundTransport:
         return {address: _describe_socket(socket) for address, socket in self._sockets.items()}
 
     def send_multipart(self, address: str, frames: tuple[bytes, ...], copy: bool = True) -> None:
+        logger.debug(f"will send a message to {address=}")
+        if self.should_monitor:
+            monitor = self._socket_for(address).get_monitor_socket()
         self._socket_for(address).send_multipart(frames, copy=copy)
+        if not self.should_monitor:
+            return
+        logger.debug(f"will monitor a message to {address=}")
+        from zmq.utils.monitor import parse_monitor_message, recv_monitor_message
+
+        if monitor.poll(1000):
+            while monitor.poll(100):
+                evt = recv_monitor_message(monitor)
+                event_id = evt["event"]
+                logger.debug(f"message to {address=} got {event_id=} and {evt=}")
+        logger.debug("monitor close")
+        monitor.close()
+        self.should_monitor = False
 
     def send_single(self, address: str, frame: bytes) -> None:
         self._socket_for(address).send(frame)

--- a/src/cascade/ygg/transport.py
+++ b/src/cascade/ygg/transport.py
@@ -22,10 +22,7 @@ _local = threading.local()
 
 def get_context() -> zmq.Context:
     if not hasattr(_local, "context"):
-        logger.debug("creating a new context")
         _local.context = zmq.Context()
-    else:
-        logger.debug("retrieving cached context")
     return _local.context
 
 
@@ -43,7 +40,6 @@ class OutboundTransport:
     def __init__(self, linger_ms: int) -> None:
         self._linger_ms = linger_ms
         self._sockets: dict[str, zmq.Socket] = {}
-        self.should_monitor = True
 
     def _socket_for(self, address: str) -> zmq.Socket:
         socket = self._sockets.get(address)
@@ -59,23 +55,7 @@ class OutboundTransport:
         return {address: _describe_socket(socket) for address, socket in self._sockets.items()}
 
     def send_multipart(self, address: str, frames: tuple[bytes, ...], copy: bool = True) -> None:
-        logger.debug(f"will send a message to {address=}")
-        if self.should_monitor:
-            monitor = self._socket_for(address).get_monitor_socket()
         self._socket_for(address).send_multipart(frames, copy=copy)
-        if not self.should_monitor:
-            return
-        logger.debug(f"will monitor a message to {address=}")
-        from zmq.utils.monitor import parse_monitor_message, recv_monitor_message
-
-        if monitor.poll(1000):
-            while monitor.poll(100):
-                evt = recv_monitor_message(monitor)
-                event_id = evt["event"]
-                logger.debug(f"message to {address=} got {event_id=} and {evt=}")
-        logger.debug("monitor close")
-        monitor.close()
-        self.should_monitor = False
 
     def send_single(self, address: str, frame: bytes) -> None:
         self._socket_for(address).send(frame)

--- a/tests/cascade/controller/test_report.py
+++ b/tests/cascade/controller/test_report.py
@@ -1,0 +1,169 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Tests for controller.report — verifies ygg-backed transport for controller→gateway reporting."""
+
+import time
+from time import monotonic_ns
+
+from cascade.controller.report import (
+    ControllerReport,
+    JobId,
+    JobProgress,
+    Reporter,
+    ReporterChannel,
+    deserialize,
+    serialize,
+)
+from cascade.low.core import DatasetId, TaskId
+from cascade.ygg.api import YggNode
+from cascade.ygg.types import HostEndpoints, RetryPolicy, YggConfig
+
+
+def _fast_config() -> YggConfig:
+    return YggConfig(
+        control=RetryPolicy(retry_interval_ms=20, max_retries=5),
+    )
+
+
+def _make_gateway_ygg() -> YggNode:
+    return YggNode("tcp://127.0.0.1:*", config=_fast_config())
+
+
+def test_reporter_channel_sends_via_ygg() -> None:
+    """ReporterChannel delivers a ControllerReport to a listening YggNode (gateway side)."""
+    with _make_gateway_ygg() as gateway_ygg:
+        report_address = f"{gateway_ygg.control_address},test-job-1"
+        channel = ReporterChannel(report_address)
+        try:
+            report = ControllerReport(
+                job_id=JobId("test-job-1"),
+                current_status=JobProgress.progressed(0.5),
+                timestamp=monotonic_ns(),
+                results=[],
+            )
+            channel.send(report)
+
+            # Give message time to arrive; drain gateway ygg
+            deadline = time.time() + 2.0
+            received: list[bytes] = []
+            while time.time() < deadline and not received:
+                msgs = gateway_ygg.poll_messages(timeout_ms=50)
+                for msg in msgs:
+                    received.append(msg.payload)
+
+            assert len(received) == 1
+            parsed = deserialize(received[0])
+            assert parsed.job_id == "test-job-1"
+            assert parsed.current_status is not None
+            assert parsed.current_status.pct == "50.00"
+        finally:
+            channel.close()
+
+
+def test_reporter_channel_reliable_delivery_ack_flow() -> None:
+    """Sent message eventually gets acked and inflight is cleared."""
+    with _make_gateway_ygg() as gateway_ygg:
+        report_address = f"{gateway_ygg.control_address},test-job-2"
+        channel = ReporterChannel(report_address)
+        try:
+            report = ControllerReport(
+                job_id=JobId("test-job-2"),
+                current_status=JobProgress.succeeded(),
+                timestamp=monotonic_ns(),
+                results=[],
+            )
+            channel.send(report)
+
+            # Drain gateway to trigger ack send back to controller
+            deadline = time.time() + 2.0
+            while time.time() < deadline:
+                gateway_ygg.poll_messages(timeout_ms=50)
+                channel._ygg.poll_messages(timeout_ms=0)
+                channel._ygg.retry_outstanding()
+                if not channel._ygg.pending_message_ids():
+                    break
+
+            assert channel._ygg.pending_message_ids() == set(), "inflight should be cleared after ack"
+        finally:
+            channel.close()
+
+
+def test_reporter_channel_close_is_idempotent() -> None:
+    with _make_gateway_ygg() as gateway_ygg:
+        report_address = f"{gateway_ygg.control_address},test-job-close"
+        channel = ReporterChannel(report_address)
+        channel.close()
+        # Closing again should not raise
+        channel.close()
+
+
+def test_reporter_none_address_is_noop() -> None:
+    """Reporter with no address silently skips all send methods."""
+    reporter = Reporter(None)
+    reporter.send_failure("some error")
+    reporter.success()
+    reporter.close()
+
+
+def test_reporter_sends_result() -> None:
+    """Reporter.send_result delivers the result payload to the gateway."""
+    with _make_gateway_ygg() as gateway_ygg:
+        report_address = f"{gateway_ygg.control_address},test-job-result"
+        reporter = Reporter(report_address)
+        try:
+            dataset_id = DatasetId(TaskId("my-task"), "out")
+            reporter.send_result(dataset_id, b"result-bytes")
+
+            deadline = time.time() + 2.0
+            received: list[ControllerReport] = []
+            while time.time() < deadline and not received:
+                msgs = gateway_ygg.poll_messages(timeout_ms=50)
+                for msg in msgs:
+                    received.append(deserialize(msg.payload))
+
+            assert len(received) == 1
+            assert received[0].results == [(dataset_id, b"result-bytes")]
+        finally:
+            reporter.close()
+
+
+def test_reporter_dedup_retries_not_delivered_twice() -> None:
+    """If the ack is slow, the controller retries; gateway must deduplicate."""
+    with _make_gateway_ygg() as gateway_ygg:
+        report_address = f"{gateway_ygg.control_address},test-job-dedup"
+        channel = ReporterChannel(report_address)
+        try:
+            report = ControllerReport(
+                job_id=JobId("test-job-dedup"),
+                current_status=JobProgress.progressed(0.1),
+                timestamp=monotonic_ns(),
+                results=[],
+            )
+            channel.send(report)
+
+            # Simulate retries without acking: send again with retry_outstanding
+            for _ in range(3):
+                time.sleep(0.025)
+                channel._ygg.retry_outstanding()
+
+            # Now drain all messages from gateway
+            time.sleep(0.1)
+            all_msgs: list[bytes] = []
+            deadline = time.time() + 1.0
+            while time.time() < deadline:
+                msgs = gateway_ygg.poll_messages(timeout_ms=50)
+                for msg in msgs:
+                    all_msgs.append(msg.payload)
+                if not msgs:
+                    break
+
+            # Despite retries, dedup ensures only one delivery
+            assert len(all_msgs) == 1
+        finally:
+            channel.close()

--- a/tests/cascade/controller/test_run.py
+++ b/tests/cascade/controller/test_run.py
@@ -14,7 +14,6 @@
 # by setting RUN_ALL_TESTS=1, as on CI is particularly flaky and incompatible
 # with xdist etc
 
-import logging
 import os
 import pathlib
 import pickle
@@ -34,7 +33,7 @@ from cascade.low.builders import JobBuilder, TaskBuilder
 from cascade.low.core import CheckpointSpec, DatasetId, HostId, JobInstance, JobInstanceRich, StorageId, TaskId
 from cascade.scheduler.core import Preschedule
 from cascade.scheduler.precompute import precompute
-from cascade.ygg.transport import destroy_context, has_context
+from cascade.ygg.transport import destroy_context
 
 # see the comment above
 run_all_tests = int(os.environ.get("RUN_ALL_TESTS", "0")) == 1
@@ -52,7 +51,6 @@ def launch_executor(
     test_name: str,  # used to derive executor address, must be unique
 ):
     dictConfig(logging_config)
-    logging.getLogger("cascade.controller.testHarness").debug(f"at executor launch: {has_context()=}")
     executor = Executor(
         job_instance,
         controller_address,
@@ -84,12 +82,10 @@ def run_cluster(
     m = f"tcp://localhost:{portBase + 1}"
     ps = []
     for i, executor in enumerate(range(executors)):
-        logging.getLogger("cascade.controller.testHarness").debug(f"before process launch: {has_context()=}")
         p = Process(target=launch_executor, args=(job.jobInstance, c, portBase + 1 + i * 10, i, test_name))
         p.start()
         ps.append(p)
     try:
-        logging.getLogger("cascade.controller.testHarness").debug(f"before bridge launch: {has_context()=}")
         b = Bridge(c, executors, job.checkpointSpec)
         run(job, b, preschedule)
     except:

--- a/tests/cascade/controller/test_run.py
+++ b/tests/cascade/controller/test_run.py
@@ -19,9 +19,9 @@ import os
 import pathlib
 import pickle
 import tempfile
+import time
 from logging.config import dictConfig
 from multiprocessing import Process
-from time import sleep
 
 from cascade.controller.impl import run
 from cascade.deployment.logging import DefaultLoggingConfig
@@ -77,6 +77,7 @@ def run_cluster(
     # TODO rework the port assignemnt in this whole file -- we waste a lot. Note if there
     # is a port overlap, it causes *very unpleasant* interference, even when the tests
     # are executed sequentially
+    destroy_context()
     if not preschedule:
         preschedule = precompute(job.jobInstance)
     c = f"tcp://localhost:{portBase}"
@@ -95,11 +96,10 @@ def run_cluster(
         for p in ps:
             if p.is_alive():
                 callback(m, ExecutorShutdown())
-                import time
-
                 time.sleep(1)
                 p.kill()
         raise
+    time.sleep(0.5)  # improves stability
 
 
 def test_simple():
@@ -110,7 +110,6 @@ def test_simple():
     task2 = TaskBuilder.from_callable(_payload).with_values(a=1)
     job = JobBuilder().with_node("task1", task1).with_node("task2", task2).with_edge("task1", "task2", "b").build().get_or_raise()
     run_cluster(JobInstanceRich(jobInstance=job, checkpointSpec=None), 12000, 1, "controllerSimple")
-    sleep(1)  # improves stability
 
 
 def get_job() -> JobInstanceRich:
@@ -156,7 +155,6 @@ def test_para2():
         return
     job = get_job()
     run_cluster(job, 12200, 2, "controllerPara2")
-    sleep(1)  # improves stability
 
 
 def test_para4():
@@ -164,7 +162,6 @@ def test_para4():
         return
     job = get_job()
     run_cluster(job, 12400, 4, "controllerPara4")
-    sleep(1)  # improves stability
 
 
 def test_para1_persist():
@@ -228,7 +225,6 @@ def test_fusing():
     # TODO we currently dont check that those actually *got fused* -- fix
     jobInstanceRich = JobInstanceRich(jobInstance=job, checkpointSpec=None)
     run_cluster(jobInstanceRich, 12800, 2, "controllerFusing", preschedule)
-    sleep(1)  # improves stability
 
 
 def test_checkpoints():
@@ -267,7 +263,4 @@ def test_checkpoints():
         )
 
         run_cluster(jobInstanceRich, 13200, 2, "ctrlCkpt1", preschedule)
-        destroy_context()
-        sleep(1)  # improves stability
         run_cluster(jobInstanceRich, 13300, 2, "ctrlCkpt2", preschedule)
-        sleep(1)  # improves stability

--- a/tests/cascade/controller/test_run.py
+++ b/tests/cascade/controller/test_run.py
@@ -14,6 +14,7 @@
 # by setting RUN_ALL_TESTS=1, as on CI is particularly flaky and incompatible
 # with xdist etc
 
+import logging
 import os
 import pathlib
 import pickle
@@ -33,6 +34,7 @@ from cascade.low.builders import JobBuilder, TaskBuilder
 from cascade.low.core import CheckpointSpec, DatasetId, HostId, JobInstance, JobInstanceRich, StorageId, TaskId
 from cascade.scheduler.core import Preschedule
 from cascade.scheduler.precompute import precompute
+from cascade.ygg.transport import destroy_context, has_context
 
 # see the comment above
 run_all_tests = int(os.environ.get("RUN_ALL_TESTS", "0")) == 1
@@ -50,6 +52,7 @@ def launch_executor(
     test_name: str,  # used to derive executor address, must be unique
 ):
     dictConfig(logging_config)
+    logging.getLogger("cascade.controller.testHarness").debug(f"at executor launch: {has_context()=}")
     executor = Executor(
         job_instance,
         controller_address,
@@ -80,10 +83,12 @@ def run_cluster(
     m = f"tcp://localhost:{portBase + 1}"
     ps = []
     for i, executor in enumerate(range(executors)):
+        logging.getLogger("cascade.controller.testHarness").debug(f"before process launch: {has_context()=}")
         p = Process(target=launch_executor, args=(job.jobInstance, c, portBase + 1 + i * 10, i, test_name))
         p.start()
         ps.append(p)
     try:
+        logging.getLogger("cascade.controller.testHarness").debug(f"before bridge launch: {has_context()=}")
         b = Bridge(c, executors, job.checkpointSpec)
         run(job, b, preschedule)
     except:
@@ -262,6 +267,7 @@ def test_checkpoints():
         )
 
         run_cluster(jobInstanceRich, 13200, 2, "ctrlCkpt1", preschedule)
+        destroy_context()
         sleep(1)  # improves stability
         run_cluster(jobInstanceRich, 13300, 2, "ctrlCkpt2", preschedule)
         sleep(1)  # improves stability

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -12,7 +12,6 @@ get sent out. In essence, we build a pseudo-controller in this test.
 
 import logging
 from logging.config import dictConfig
-from multiprocessing import Process
 
 import numpy as np
 import pytest
@@ -38,6 +37,7 @@ from cascade.executor.msg import (
     TaskSequence,
     Worker,
 )
+from cascade.executor.platform import get_mp_ctx
 from cascade.low.core import (
     DatasetId,
     HostId,
@@ -48,12 +48,14 @@ from cascade.low.core import (
     TaskInstance,
     WorkerId,
 )
+from cascade.ygg.transport import has_context
 
 logger = logging.getLogger(__name__)
 
 
 def launch_executor(job_instance: JobInstance, controller_address: BackboneAddress, portBase: int, test_name: str):
     dictConfig(logging_config)
+    logging.getLogger("cascade.executor.testHarness").debug(f"at executor launch: {has_context()=}")
     executor = Executor(
         job_instance,
         controller_address,
@@ -98,11 +100,17 @@ def test_executor():
     )
 
     # cluster setup
+    logger.debug(f"before cluster setup: {has_context()=}")
     c1 = "tcp://localhost:12545"
     m1 = f"tcp://{platform.get_bindabble_self()}:12546"
     d1 = f"tcp://{platform.get_bindabble_self()}:12547"
+    logger.debug(f"before executor launch: {has_context()=}")
+    p = get_mp_ctx("executor-loc").Process(target=launch_executor, args=(job, c1, 12546, "executor1"))
+    import time
+
+    time.sleep(1)
+    # NOTE critical -- we need to launch the listener *after* the process, to not fork the zmq context
     l = Listener(c1)  # controller
-    p = Process(target=launch_executor, args=(job, c1, 12546, "executor1"))
 
     # run
     p.start()

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -107,7 +107,7 @@ def test_executor():
     import time
 
     time.sleep(1)
-    # NOTE critical -- we need to launch the listener *after* the process, to not fork the zmq context
+    # NOTE important -- we need to launch the listener *after* the process, to not fork the zmq context
     l = Listener(c1)  # controller
 
     # run

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -48,7 +48,7 @@ from cascade.low.core import (
     TaskInstance,
     WorkerId,
 )
-from cascade.ygg.transport import has_context
+from cascade.ygg.transport import destroy_context, has_context
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +56,7 @@ logger = logging.getLogger(__name__)
 def launch_executor(job_instance: JobInstance, controller_address: BackboneAddress, portBase: int, test_name: str):
     dictConfig(logging_config)
     logging.getLogger("cascade.executor.testHarness").debug(f"at executor launch: {has_context()=}")
+    destroy_context()
     executor = Executor(
         job_instance,
         controller_address,

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -48,14 +48,13 @@ from cascade.low.core import (
     TaskInstance,
     WorkerId,
 )
-from cascade.ygg.transport import destroy_context, has_context
+from cascade.ygg.transport import destroy_context
 
 logger = logging.getLogger(__name__)
 
 
 def launch_executor(job_instance: JobInstance, controller_address: BackboneAddress, portBase: int, test_name: str):
     dictConfig(logging_config)
-    logging.getLogger("cascade.executor.testHarness").debug(f"at executor launch: {has_context()=}")
     destroy_context()
     executor = Executor(
         job_instance,
@@ -101,11 +100,9 @@ def test_executor():
     )
 
     # cluster setup
-    logger.debug(f"before cluster setup: {has_context()=}")
     c1 = "tcp://localhost:12545"
     m1 = f"tcp://{platform.get_bindabble_self()}:12546"
     d1 = f"tcp://{platform.get_bindabble_self()}:12547"
-    logger.debug(f"before executor launch: {has_context()=}")
     p = get_mp_ctx("executor-loc").Process(target=launch_executor, args=(job, c1, 12546, "executor1"))
     import time
 

--- a/tests/cascade/executor/util.py
+++ b/tests/cascade/executor/util.py
@@ -47,7 +47,7 @@ class CallableInstance:
 
 @contextmanager
 def setup_shm(testId: str):
-    mp_ctx = platform.get_mp_ctx("executor-aux")
+    mp_ctx = platform.get_mp_ctx("executor-shm")
     shm_socket = f"/tmp/tcShm-{testId}"
     shm_api.publish_socket_addr(shm_socket)
     shm_process = mp_ctx.Process(
@@ -118,7 +118,7 @@ def run_test(callableInstance: CallableInstance, testId: str, max_runtime_sec: i
         addr = f"ipc:///tmp/tc{testId}"
         listener = ZmqListener(addr)
         ec_ctx = callable2ctx(callableInstance, addr)
-        mp_ctx = platform.get_mp_ctx("executor-aux")
+        mp_ctx = platform.get_mp_ctx("executor-shm")
         runner = mp_ctx.Process(target=simple_runner, args=(addr, ec_ctx))
         runner.start()
         output = DatasetId(TaskId("taskId"), "0")

--- a/tests/cascade/gateway/test_router.py
+++ b/tests/cascade/gateway/test_router.py
@@ -1,0 +1,110 @@
+# (C) Copyright 2025- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for gateway.router update semantics."""
+
+import os
+from time import monotonic_ns
+
+from cascade.controller.report import JobId, JobProgress, JobProgressStarted
+from cascade.deployment.logging import DefaultLoggingConfig
+from cascade.gateway.router import Job, JobRouter
+from cascade.low.core import TaskId
+from cascade.ygg.api import YggNode
+from cascade.ygg.types import RetryPolicy, YggConfig
+
+
+def _make_ygg() -> YggNode:
+    config = YggConfig(
+        control=RetryPolicy(retry_interval_ms=50, max_retries=3),
+    )
+    address = f"ipc:///tmp/cascadeTestGatewayRouter.{os.getpid()}.socket"
+    return YggNode(address, config=config)
+
+
+def _make_router(ygg: YggNode) -> JobRouter:
+    return JobRouter(
+        ygg=ygg,
+        loggingConfig=DefaultLoggingConfig,
+        troika_config=None,
+        max_jobs=None,
+    )
+
+
+def _make_job() -> Job:
+    return Job(
+        progress=JobProgressStarted,
+        last_seen=-1,
+        results={},
+        completed_task_ids=set(),
+        planned_task_ids=set(),
+    )
+
+
+def test_maybe_update_ignores_empty_update() -> None:
+    with _make_ygg() as ygg:
+        router = _make_router(ygg)
+        job_id = JobId("job-1")
+        router.jobs[job_id] = _make_job()
+        initial = router.jobs[job_id]
+
+        router.maybe_update(job_id, progress=None, timestamp=monotonic_ns(), completed_task=None, planned_tasks=None)
+
+        assert router.jobs[job_id] == initial
+
+
+def test_maybe_update_tracks_planned_and_completed_tasks() -> None:
+    with _make_ygg() as ygg:
+        router = _make_router(ygg)
+        job_id = JobId("job-tasks")
+        router.jobs[job_id] = _make_job()
+        t1 = TaskId("task-1")
+        t2 = TaskId("task-2")
+
+        router.maybe_update(job_id, progress=None, timestamp=monotonic_ns(), planned_tasks={t1, t2})
+        assert router.jobs[job_id].planned_task_ids == {t1, t2}
+        assert router.jobs[job_id].completed_task_ids == set()
+
+        router.maybe_update(job_id, progress=None, timestamp=monotonic_ns(), completed_task=t1)
+        assert router.jobs[job_id].planned_task_ids == {t2}
+        assert router.jobs[job_id].completed_task_ids == {t1}
+
+
+def test_maybe_update_updates_progress_and_timestamp() -> None:
+    with _make_ygg() as ygg:
+        router = _make_router(ygg)
+        job_id = JobId("job-progress")
+        router.jobs[job_id] = _make_job()
+        ts = monotonic_ns()
+
+        router.maybe_update(job_id, JobProgress.progressed(0.5), ts)
+        assert router.jobs[job_id].last_seen == ts
+        assert router.jobs[job_id].progress.pct == "50.00"
+
+
+def test_maybe_update_ignores_stale_timestamp() -> None:
+    with _make_ygg() as ygg:
+        router = _make_router(ygg)
+        job_id = JobId("job-stale")
+        router.jobs[job_id] = _make_job()
+        ts = monotonic_ns()
+
+        router.maybe_update(job_id, JobProgress.progressed(0.7), ts)
+        router.maybe_update(job_id, JobProgress.progressed(0.2), ts - 1)
+        assert router.jobs[job_id].progress.pct == "70.00"
+
+
+def test_maybe_update_active_jobs_decremented_on_completion() -> None:
+    with _make_ygg() as ygg:
+        router = _make_router(ygg)
+        job_id = JobId("job-dec")
+        router.jobs[job_id] = _make_job()
+        router.active_jobs = 1
+
+        router.maybe_update(job_id, JobProgress.succeeded(), monotonic_ns())
+        assert router.active_jobs == 0

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -63,7 +63,7 @@ def get_job_slow() -> JobInstanceRich:
 
 def spawn_gateway(max_jobs: int | None = None) -> tuple[str, Process]:
     url = "tcp://localhost:12355"
-    p = Process(target=main_cli, args=(url,), kwargs={"max_jobs": max_jobs})
+    p = Process(target=main_cli, args=(url,), kwargs={"max_jobs": max_jobs, "report_transport": "ipc"})
     p.start()
     return url, p
 

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -92,7 +92,7 @@ def test_job():
         tries = 0
         job_progress_req = api.JobProgressRequest(job_ids=[job_id])
         while tries < tries_limit:
-            job_progress_res = client.request_response(job_progress_req, url)
+            job_progress_res = client.request_response(job_progress_req, url, timeout_ms=10000)
             assert isinstance(job_progress_res, api.JobProgressResponse)
             assert job_progress_res.error is None
             is_computed = job_progress_res.progresses[job_id].pct == "100.00"  # ty: ignore[possibly-missing-attribute]

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -8,6 +8,7 @@ import cascade.gateway.client as client
 from cascade.gateway.__main__ import main_cli
 from cascade.low.builders import JobBuilder
 from cascade.low.core import DatasetId, JobInstanceRich, TaskDefinition, TaskId, TaskInstance
+from cascade.ygg.transport import destroy_context, has_context
 
 init_value = 10
 job_func = lambda i: i * 2
@@ -70,6 +71,7 @@ def spawn_gateway(max_jobs: int | None = None) -> tuple[str, Process]:
 
 @pytest.mark.concurrency_filelock("conflictInExecutorHostname")
 def test_job():
+    destroy_context()
     url, gw = spawn_gateway(1)
     try:
         # succ job

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -8,7 +8,7 @@ import cascade.gateway.client as client
 from cascade.gateway.__main__ import main_cli
 from cascade.low.builders import JobBuilder
 from cascade.low.core import DatasetId, JobInstanceRich, TaskDefinition, TaskId, TaskInstance
-from cascade.ygg.transport import destroy_context, has_context
+from cascade.ygg.transport import destroy_context
 
 init_value = 10
 job_func = lambda i: i * 2

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -94,7 +94,7 @@ def test_job():
         tries = 0
         job_progress_req = api.JobProgressRequest(job_ids=[job_id])
         while tries < tries_limit:
-            job_progress_res = client.request_response(job_progress_req, url, timeout_ms=10000)
+            job_progress_res = client.request_response(job_progress_req, url)
             assert isinstance(job_progress_res, api.JobProgressResponse)
             assert job_progress_res.error is None
             is_computed = job_progress_res.progresses[job_id].pct == "100.00"  # ty: ignore[possibly-missing-attribute]

--- a/tests/cascade/shm/test_shm.py
+++ b/tests/cascade/shm/test_shm.py
@@ -28,7 +28,7 @@ from cascade.executor.platform import get_mp_ctx
 def test_shm_simple(shm_addr):
     api.publish_socket_addr(shm_addr)
     pref = f"cTi{shm_addr % 10}" if isinstance(shm_addr, int) else f"cTu{shm_addr[-1]}"
-    serverP = get_mp_ctx("executor-aux").Process(
+    serverP = get_mp_ctx("executor-shm").Process(
         target=server.entrypoint,
         kwargs={"logging_config": logging_config, "shm_pref": pref},
     )
@@ -64,7 +64,7 @@ def test_shm_disk(shm_addr):
     pref = f"cTi{shm_addr % 10}" if isinstance(shm_addr, int) else f"cTu{shm_addr[-1]}"
     api.publish_socket_addr(shm_addr)
 
-    serverP = get_mp_ctx("executor-aux").Process(
+    serverP = get_mp_ctx("executor-shm").Process(
         target=server.entrypoint,
         kwargs={
             "capacity": capacity,

--- a/tests/cascade/ygg/test_api.py
+++ b/tests/cascade/ygg/test_api.py
@@ -4,10 +4,12 @@ import pytest
 
 from cascade.low.exceptions import CascadeInternalError
 from cascade.ygg.api import YggNode
+from cascade.ygg.transport import destroy_context, has_context
 from cascade.ygg.types import HostEndpoints, RetryPolicy, YggConfig
 
 
 def test_control_send_receive_ack() -> None:
+    destroy_context()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -33,6 +35,7 @@ def test_control_send_receive_ack() -> None:
 
 
 def test_bulk_send_receive() -> None:
+    destroy_context()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -59,6 +62,7 @@ def test_bulk_send_receive() -> None:
 
 
 def test_control_best_effort_no_syn_ack() -> None:
+    destroy_context()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -84,6 +88,7 @@ def test_control_best_effort_no_syn_ack() -> None:
 
 
 def test_control_default_delivery_from_config_best_effort() -> None:
+    destroy_context()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -108,6 +113,7 @@ def test_control_default_delivery_from_config_best_effort() -> None:
 
 
 def test_deduplicates_retries_for_same_syn() -> None:
+    destroy_context()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=5, max_retries=4),
         bulk=RetryPolicy(retry_interval_ms=5, max_retries=2),
@@ -136,6 +142,7 @@ def test_deduplicates_retries_for_same_syn() -> None:
 
 def test_forget_sender_clears_dedup_cache() -> None:
     """Test that forget_sender removes dedup entries for a specific address."""
+    destroy_context()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -155,6 +162,7 @@ def test_forget_sender_clears_dedup_cache() -> None:
 
 def test_unregister_host_purges_dedup_for_both_lanes() -> None:
     """Test that unregister_host clears dedup entries for both endpoints."""
+    destroy_context()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -189,6 +197,7 @@ def test_unregister_host_purges_dedup_for_both_lanes() -> None:
 
 
 def test_close_waits_for_pending_ack() -> None:
+    destroy_context()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -211,6 +220,7 @@ def test_close_waits_for_pending_ack() -> None:
 
 
 def test_close_logs_remaining_inflight_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    destroy_context()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -236,6 +246,7 @@ def test_close_logs_remaining_inflight_on_timeout(monkeypatch: pytest.MonkeyPatc
 
 
 def test_close_polls_then_retries_until_inflight_clears(monkeypatch: pytest.MonkeyPatch) -> None:
+    destroy_context()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=25, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=25, max_retries=3),

--- a/tests/cascade/ygg/test_api.py
+++ b/tests/cascade/ygg/test_api.py
@@ -233,3 +233,34 @@ def test_close_logs_remaining_inflight_on_timeout(monkeypatch: pytest.MonkeyPatc
         assert warnings == [("ygg close timed out with %d inflight messages", 1)]
     finally:
         receiver.close()
+
+
+def test_close_polls_then_retries_until_inflight_clears(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = YggConfig(
+        control=RetryPolicy(retry_interval_ms=25, max_retries=3),
+        bulk=RetryPolicy(retry_interval_ms=25, max_retries=3),
+    )
+    sender = YggNode("tcp://127.0.0.1:*", "tcp://127.0.0.1:*", config=config)
+    poll_timeouts: list[int | None] = []
+    retry_calls = 0
+
+    def fake_poll_messages(timeout_ms: int | None = 0) -> list[object]:
+        poll_timeouts.append(timeout_ms)
+        return []
+
+    def fake_retry_outstanding() -> None:
+        nonlocal retry_calls
+        retry_calls += 1
+        sender._inflight.clear()
+
+    monkeypatch.setattr(sender, "poll_messages", fake_poll_messages)
+    monkeypatch.setattr(sender, "retry_outstanding", fake_retry_outstanding)
+    try:
+        sender._inflight[1] = object()  # type: ignore[assignment]
+        sender.close(timeout_ms=100, wait_for_all_acks=True)
+
+        assert retry_calls == 1
+        assert poll_timeouts == [25]
+    finally:
+        sender._outbound.close()
+        sender._listener.close()

--- a/tests/cascade/ygg/test_api.py
+++ b/tests/cascade/ygg/test_api.py
@@ -186,3 +186,50 @@ def test_unregister_host_purges_dedup_for_both_lanes() -> None:
         # Verify sender is no longer in registry
         with pytest.raises(CascadeInternalError):
             receiver._registry.resolve_endpoints(HostId("sender"))
+
+
+def test_close_waits_for_pending_ack() -> None:
+    config = YggConfig(
+        control=RetryPolicy(retry_interval_ms=10, max_retries=3),
+        bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
+    )
+    sender = YggNode("tcp://127.0.0.1:*", "tcp://127.0.0.1:*", config=config)
+    receiver = YggNode("tcp://127.0.0.1:*", "tcp://127.0.0.1:*", config=config)
+    try:
+        sender.register_host("receiver", HostEndpoints(control=receiver.control_address, bulk=receiver.bulk_address))
+        receiver.register_host("sender", HostEndpoints(control=sender.control_address, bulk=sender.bulk_address))
+
+        idx = sender.send_message_to_host("receiver", b"close-waits", lane="control")
+        incoming = receiver.poll_messages(timeout_ms=250)
+        assert len(incoming) == 1
+        assert incoming[0].message_id == idx
+
+        sender.close(timeout_ms=250)
+        assert sender.pending_message_ids() == set()
+    finally:
+        receiver.close()
+
+
+def test_close_logs_remaining_inflight_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = YggConfig(
+        control=RetryPolicy(retry_interval_ms=10, max_retries=3),
+        bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
+    )
+    sender = YggNode("tcp://127.0.0.1:*", "tcp://127.0.0.1:*", config=config)
+    receiver = YggNode("tcp://127.0.0.1:*", "tcp://127.0.0.1:*", config=config)
+    warnings: list[tuple[str, int]] = []
+
+    def capture_warning(message: str, count: int) -> None:
+        warnings.append((message, count))
+
+    monkeypatch.setattr("cascade.ygg.api.logger.warning", capture_warning)
+    try:
+        sender.register_host("receiver", HostEndpoints(control=receiver.control_address, bulk=receiver.bulk_address))
+        receiver.register_host("sender", HostEndpoints(control=sender.control_address, bulk=sender.bulk_address))
+
+        sender.send_message_to_host("receiver", b"close-timeout", lane="control")
+        sender.close(timeout_ms=1)
+
+        assert warnings == [("ygg close timed out with %d inflight messages", 1)]
+    finally:
+        receiver.close()

--- a/tests/cascade/ygg/test_api.py
+++ b/tests/cascade/ygg/test_api.py
@@ -4,7 +4,7 @@ import pytest
 
 from cascade.low.exceptions import CascadeInternalError
 from cascade.ygg.api import YggNode
-from cascade.ygg.transport import destroy_context, has_context
+from cascade.ygg.transport import destroy_context
 from cascade.ygg.types import HostEndpoints, RetryPolicy, YggConfig
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,6 @@ def nuke_zmq_context():
 
     # --- Post-test Cleanup ---
     try:
-        import cascade.executor.comms as t2
         import cascade.ygg.transport as t1
 
         t1.destroy_context()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def nuke_zmq_context():
     try:
         import cascade.ygg.transport as t1
 
-        t1.destroy_context()
+        # t1.destroy_context()
 
     except Exception as e:
         # We don't want the cleanup to crash the whole suite if already dead

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,3 +34,23 @@ def lock_resource(request, tmp_path_factory):
         finally:
             # LOCK_UN: Unlock
             fcntl.flock(f, fcntl.LOCK_UN)
+
+
+@pytest.fixture(autouse=True, scope="function")
+def nuke_zmq_context():
+    """
+    Ensures no ZMQ state leaks between tests by destroying the context
+    and clearing the thread-local storage after every test.
+    """
+    yield  # Let the test run
+
+    # --- Post-test Cleanup ---
+    try:
+        import cascade.executor.comms as t2
+        import cascade.ygg.transport as t1
+
+        t1.destroy_context()
+
+    except Exception as e:
+        # We don't want the cleanup to crash the whole suite if already dead
+        print(f"\n[ZMQ Nuke Warning]: Cleanup failed: {repr(e)}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,22 +34,3 @@ def lock_resource(request, tmp_path_factory):
         finally:
             # LOCK_UN: Unlock
             fcntl.flock(f, fcntl.LOCK_UN)
-
-
-@pytest.fixture(autouse=True, scope="function")
-def nuke_zmq_context():
-    """
-    Ensures no ZMQ state leaks between tests by destroying the context
-    and clearing the thread-local storage after every test.
-    """
-    yield  # Let the test run
-
-    # --- Post-test Cleanup ---
-    try:
-        import cascade.ygg.transport as t1
-
-        # t1.destroy_context()
-
-    except Exception as e:
-        # We don't want the cleanup to crash the whole suite if already dead
-        print(f"\n[ZMQ Nuke Warning]: Cleanup failed: {repr(e)}")


### PR DESCRIPTION
Migrates controller.report and cascade.gateway to use ygg. This brings additional reliability to the message delivery, in addition to the cleaner code

In addition:
1. Better close implementation to YggNode -- it configurably retries unacked messages
2. `delete_context` method -- critical for potentially-forked processes or tests running multiple scenarios, as zmq may be left in an impractical state, leading to freezes and failures due to undeliverable messages
3. Separates `executor.platform.get_mp_ctx` for `executor-aux` into `executor-shm` and `executor-dataserver`, although not critical now. Replaces additionally some vanilla `Process` calls in tests by the respective correct ctx, to fix bugs