### PR TITLE
[backend.comms] track message delivery

### DIFF
--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -92,10 +92,11 @@ def callback(address: BackboneAddress, msg: Message):
     socket.send(byt)
 
 
-def send_data(address: BackboneAddress, data: DatasetTransmitPayload, syn: Syn) -> None:
+def send_data(address: BackboneAddress, data: DatasetTransmitPayload, syn: Syn) -> zmq.MessageTracker:
     socket = get_socket(address)
     byt = (ser_message(syn), pickle.dumps(data.header), data.value)
-    socket.send_multipart(byt, copy=False)
+    tracker = socket.send_multipart(byt, copy=False, track=True)
+    return tracker
 
 
 def receive_and_ack(socket: zmq.Socket, seen_syns: set[tuple[int, BackboneAddress]]) -> bytes | None:

--- a/src/cascade/executor/data_server.py
+++ b/src/cascade/executor/data_server.py
@@ -20,6 +20,8 @@ from concurrent.futures import Executor as PythonExecutor
 from time import time_ns
 from typing import cast
 
+from zmq import MessageTracker
+
 import cascade.shm.client as shm_client
 from cascade.executor.checkpoints import persist_dataset, retrieve_dataset
 from cascade.executor.comms import Listener, callback, send_data
@@ -198,6 +200,7 @@ class DataServer:
     def _send_payload(self, command: DatasetTransmitCommand) -> int:
         buf: None | shm_client.AllocatedBuffer = None
         payload: None | DatasetTransmitPayload = None
+        tracker: None | MessageTracker = None
         try:
             if command.target == self.host or command.source != self.host:
                 raise CascadeInternalError(f"invalid {command=}")
@@ -219,7 +222,7 @@ class DataServer:
             )
             payload = DatasetTransmitPayload(header, value=cast(bytes, buf.view()))
             syn = Syn(command.idx, self.dlistener.address)
-            send_data(command.daddress, payload, syn)
+            tracker = send_data(command.daddress, payload, syn)
             logger.debug(f"payload for {command} sent")
         except Exception as e:
             logger.exception(f"failed to send payload for {command}, reporting up")
@@ -233,7 +236,11 @@ class DataServer:
         finally:
             if payload is not None:
                 del payload  # to enforce deletion of exported pointer, so that buffer can be closed
+            if tracker is not None:
+                # this may raise zmq.NotDone -- but thats something we want to propagate, it signifies transmit problem
+                tracker.wait(timeout=10.0)
             if buf is not None:
+                # this *could* raise BufferError due to pointers not closed, but since we have awaited the tracker, it should not
                 buf.close()
         return time_ns()
 


### PR DESCRIPTION
since we send messages with copy=False, they retain pointer to the buffer of the message. We cannot therefore close the buffer, until we know the message has been processed by zmq

originally, the code didnt do that, leading to BufferError raised occassionally during the future cleanup

now we provide track=True to the send_multipart call, and prior to closing the buffer, we await the tracker. In case it takes too long (10s hardcoded atm), we propagate a raised exception, as that is a genuinely errorneous situation
