### PR TITLE
Add method to combine datatree branches

### DIFF
--- a/src/earthkit/workflows/fluent.py
+++ b/src/earthkit/workflows/fluent.py
@@ -737,6 +737,8 @@ class Action:
         ----------
         dim: str, dimension to concatenate arrays along. Either existing or new dimension
         path: str, path along which leaf nodes will be concatenated into single array
+        force: bool, if True, then incompatible dimensions in node arrays are concatenated to ensure
+        each node array has the same dimensions.
 
         Return
         ------
@@ -744,12 +746,12 @@ class Action:
 
         Raises
         ------
-        ValueError if arrays along leaves are not compatible
+        ValueError if arrays along leaves are not compatible and force=False
         """
         temp_dim = self._temp_dim()
         action = self.select(path=path)
-        narrays: dict[str, xr.DataArray] = {apath: array for apath, array in nodetree_arrays(action.nodes)}
         if force:
+            narrays: dict[str, xr.DataArray] = {apath: array for apath, array in nodetree_arrays(action.nodes)}
             common_dims = list(set.intersection(*[set(x.dims) for x in narrays.values()]))
             for apath in narrays.keys():
                 action = action.flatten(new_dim=temp_dim, keep_dims=common_dims, path=apath).concatenate(dim=temp_dim, path=apath)

--- a/src/earthkit/workflows/fluent.py
+++ b/src/earthkit/workflows/fluent.py
@@ -263,6 +263,15 @@ class Action:
         else:
             new_nodes = nodetree.to_dict()
         self.nodes = nodetree_from_dict(new_nodes)
+        self._node_dims = set.union(set(), *[arr.dims for arr in new_nodes.values()])
+
+    def _temp_dim(self) -> str:
+        temp_dim = "**tempindex**"
+        index = 0
+        while temp_dim in self._node_dims:
+            temp_dim = f"**tempindex{index}**"
+            index += 1
+        return temp_dim
 
     def graph(self) -> Graph:
         """Creates graph from the nodes of the action.
@@ -668,22 +677,22 @@ class Action:
         ------
         Action
         """
+        temp_dim = self._temp_dim()
         node_arrays = {npath: narray for npath, narray in nodetree_arrays(self.nodes)}
         for npath, narray in nodetree_arrays(self.select(path=path).nodes):
             if narray.size == 1:
-                raise ValueError("Can not flatten array containing single node")
+                continue
             diff = set(keep_dims).difference(narray.dims)
             if len(diff) > 0:
                 raise ValueError(f"Dimensions {diff} not in array at {npath}")
             stack_dims = [x for x in narray.dims if x not in keep_dims]
             if len(stack_dims) > 0:
-                node_arrays[npath] = narray.stack(**{"**tempindex**": stack_dims}).reset_index(stack_dims, drop=True)
-            reset_coords = [name for name, coord in node_arrays[npath].coords.items() if "**tempindex**" in coord.dims]
+                node_arrays[npath] = narray.stack(dim={temp_dim: stack_dims}).reset_index(stack_dims, drop=True)
+            reset_coords = [name for name, coord in node_arrays[npath].coords.items() if temp_dim in coord.dims]
             if len(reset_coords) > 0:
                 node_arrays[npath] = node_arrays[npath].reset_coords(reset_coords, drop=True)
-
         action = type(self)(nodetree_from_dict(node_arrays))
-        return _combine_nodes(action, method, dim="**tempindex**", batch_size=0, keep_dim=False, path=path, backend_kwargs=backend_kwargs)
+        return _combine_nodes(action, method, dim=temp_dim, batch_size=0, keep_dim=False, path=path, backend_kwargs=backend_kwargs)
 
     def set_path(self, path: str) -> "Action":
         """Create path for current node array

--- a/src/earthkit/workflows/fluent.py
+++ b/src/earthkit/workflows/fluent.py
@@ -753,7 +753,7 @@ class Action:
             common_dims = set.intersection(*[set(x.dims) for x in narrays.values()])
             for apath in narrays.keys():
                 action = action.flatten(new_dim=temp_dim, keep_dims=common_dims, path=apath).concatenate(dim=temp_dim, path=apath)
-        new_array = xr.concat([x[1] for x in nodetree_arrays(action.nodes)], dim=dim, coords="different", compat="equals")
+        new_array = xr.concat([x[1] for x in nodetree_arrays(action.nodes)], dim=dim, coords="different", compat="equals", join="exact")
         if path:
             node_arrays = {apath: array for apath, array in nodetree_arrays(self.nodes) if path not in array}
             node_arrays[path] = new_array

--- a/src/earthkit/workflows/fluent.py
+++ b/src/earthkit/workflows/fluent.py
@@ -641,19 +641,20 @@ class Action:
     @capture_payload_metadata
     def flatten(
         self,
-        dim: str = "",
-        axis: int = 0,
+        keep_dims: list[str] = [],
         path: Optional[str] = None,
+        method: str = "concat",
         backend_kwargs: dict = {},
         payload_metadata: dict | None = None,
     ) -> "Action":
-        """Flattens the array of nodes along specified dimension by creating new
-        nodes from stacking internal data of nodes along that dimension.
+        """Flattens the array of nodes along all dims, except keep_sims, for node arrays
+        along path. Internal data in nodes is combined either by stacking for concatenating,
+        specified by method
 
         Parameters
         ----------
-        dim: str, name of dimension to flatten along
-        axis: int, axis of new dimension in internal data
+        keep_dims: str, name of dimensions not to flatten
+        method: str, either concat or stack
         path: str, path to select subset of nodes to operate on, if provided
         backend_kwargs: dict, kwargs for the underlying array module stack method
 
@@ -661,11 +662,18 @@ class Action:
         ------
         Action
         """
-        return self.reduce(
-            Payload(backends.stack, kwargs={"axis": axis, **backend_kwargs}),
-            dim=dim,
-            path=path,
-        )
+        node_arrays = {npath: narray for npath, narray in nodetree_arrays(self.nodes)}
+        for npath, narray in nodetree_arrays(self.select(path=path).nodes):
+            if narray.size == 1:
+                raise ValueError("Can not flatten array containing single node")
+            diff = set(keep_dims).difference(narray.dims)
+            if len(diff) > 0:
+                raise ValueError(f"Dimensions {diff} not in array at {npath}")
+            stack_dims = [x for x in narray.dims if x not in keep_dims]
+            node_arrays[npath] = narray.stack(**{"**tempindex**": stack_dims}).reset_index(stack_dims, drop=True)
+
+        action = type(self)(nodetree_from_dict(node_arrays))
+        return _combine_nodes(action, method, dim="**tempindex**", batch_size=0, keep_dim=False, path=path, backend_kwargs=backend_kwargs)
 
     def set_path(self, path: str) -> "Action":
         """Create path for current node array
@@ -682,7 +690,7 @@ class Action:
             raise NotImplementedError("Multiple node arrays present, can not set single path")
         return type(self)(nodetree_from_dict({path: nodetree_array(self.nodes)}))
 
-    def split(self, expansion: dict[str, PayloadFunc | Payload]) -> "Action":
+    def create_branches(self, expansion: dict[str, PayloadFunc | Payload]) -> "Action":
         """Create action containing new node arrays by splitting an existing node array
         by the specified functions in expansion
 
@@ -705,6 +713,31 @@ class Action:
         action = self.select(path=parent)
         for path, func in expansion.items():
             node_arrays[path] = nodetree_array(action.map(func).nodes, parent)
+        return type(self)(nodetree_from_dict(node_arrays))
+    
+    def combine_branches(self, dim: str, path: Optional[str] = None) -> "Action":
+        """Combine node arrays for leaves along path into a single node array
+
+        Parameters
+        ----------
+        dim: str, dimension to concatenate arrays along. Either existing or new dimension
+        path: str, path along which leaf nodes will be concatenated into single array
+
+        Return
+        ------
+        Action
+
+        Raises
+        ------
+        ValueError if arrays along leaves are not compatible
+        """
+        action = self.select(path=path)
+        new_array = xr.concat([x[1] for x in nodetree_arrays(action.nodes)], dim=dim)
+        if path:
+            node_arrays = {apath: array for apath, array in nodetree_arrays(self.nodes) if path not in array}
+            node_arrays[path] = new_array
+        else:
+            node_arrays = {"/": new_array}
         return type(self)(nodetree_from_dict(node_arrays))
 
     def _validate_criteria(self, array: xr.DataArray, criteria: dict) -> tuple[bool, dict]:
@@ -1121,6 +1154,8 @@ def _combine_nodes(
         if not keep_dim:
             action._squeeze_dimension(dim, path=path)
         return action
+    if backend_method not in ["stack", "concat"]:
+        raise ValueError(f"Unknown method {backend_method} for combining nodes")
     return action.reduce(
         Payload(getattr(backends, backend_method), kwargs=backend_kwargs),
         dim=dim,

--- a/src/earthkit/workflows/fluent.py
+++ b/src/earthkit/workflows/fluent.py
@@ -685,9 +685,9 @@ class Action:
             if len(stack_dims) > 0:
                 node_arrays[npath] = narray.stack(dim={new_dim: stack_dims}).reset_index(stack_dims, drop=True)
 
-            reset_coords = [name for name, coord in node_arrays[npath].coords.items() if new_dim in coord.dims]
-            if reset_coords and len(reset_coords) > 0:
-                node_arrays[npath] = node_arrays[npath].reset_coords(reset_coords, drop=True)
+            to_reset = [name for name, coord in node_arrays[npath].coords.items() if new_dim in coord.dims]
+            if reset_coords and len(to_reset) > 0:
+                node_arrays[npath] = node_arrays[npath].reset_coords(to_reset, drop=True)
         return type(self)(nodetree_from_dict(node_arrays))
 
     def set_path(self, path: str) -> "Action":
@@ -748,9 +748,9 @@ class Action:
         """
         temp_dim = self._temp_dim()
         action = self.select(path=path)
-        narrays = {apath: array for apath, array in nodetree_arrays(action.nodes)}
+        narrays: dict[str, xr.DataArray] = {apath: array for apath, array in nodetree_arrays(action.nodes)}
         if force:
-            common_dims = set.intersection(*[set(x.dims) for x in narrays.values()])
+            common_dims = list(set.intersection(*[set(x.dims) for x in narrays.values()]))
             for apath in narrays.keys():
                 action = action.flatten(new_dim=temp_dim, keep_dims=common_dims, path=apath).concatenate(dim=temp_dim, path=apath)
         new_array = xr.concat([x[1] for x in nodetree_arrays(action.nodes)], dim=dim, coords="different", compat="equals", join="exact")

--- a/src/earthkit/workflows/fluent.py
+++ b/src/earthkit/workflows/fluent.py
@@ -677,9 +677,10 @@ class Action:
                 raise ValueError(f"Dimensions {diff} not in array at {npath}")
             stack_dims = [x for x in narray.dims if x not in keep_dims]
             if len(stack_dims) > 0:
-                node_arrays[npath] = (
-                    narray.stack(**{"**tempindex**": stack_dims}).reset_index(stack_dims, drop=True).reset_coords(drop=True)
-                )
+                node_arrays[npath] = narray.stack(**{"**tempindex**": stack_dims}).reset_index(stack_dims, drop=True)
+            reset_coords = [name for name, coord in node_arrays[npath].coords.items() if "**tempindex**" in coord.dims]
+            if len(reset_coords) > 0:
+                node_arrays[npath] = node_arrays[npath].reset_coords(reset_coords, drop=True)
 
         action = type(self)(nodetree_from_dict(node_arrays))
         return _combine_nodes(action, method, dim="**tempindex**", batch_size=0, keep_dim=False, path=path, backend_kwargs=backend_kwargs)
@@ -746,7 +747,7 @@ class Action:
             common_dims = set.intersection(*[set(x.dims) for x in narrays.values()])
             for apath in narrays.keys():
                 action = action.flatten(keep_dims=common_dims, path=apath)
-        new_array = xr.concat([x[1] for x in nodetree_arrays(action.nodes)], dim=dim)
+        new_array = xr.concat([x[1] for x in nodetree_arrays(action.nodes)], dim=dim, coords="different", compat="equals")
         if path:
             node_arrays = {apath: array for apath, array in nodetree_arrays(self.nodes) if path not in array}
             node_arrays[path] = new_array

--- a/src/earthkit/workflows/fluent.py
+++ b/src/earthkit/workflows/fluent.py
@@ -582,6 +582,12 @@ class Action:
         for npath, narray in nodetree_arrays(self.select(path=path).nodes):
             if len(dim) == 0:
                 dim = str(narray.dims[0])
+            if dim not in narray.sizes:
+                continue
+            if narray.sizes[dim] == 1:
+                if not keep_dim:
+                    node_arrays[npath] = narray.squeeze(dim)
+                continue
 
             batched = self.select(path=npath)
             level = 0
@@ -636,7 +642,7 @@ class Action:
 
         new_nodes = {npath: narray for npath, narray in nodetree_arrays(self.nodes)}
         new_nodes.update(node_arrays)
-        return type(batched)(nodetree_from_dict(new_nodes), yields)
+        return type(self)(nodetree_from_dict(new_nodes), yields)
 
     @capture_payload_metadata
     def flatten(
@@ -670,7 +676,8 @@ class Action:
             if len(diff) > 0:
                 raise ValueError(f"Dimensions {diff} not in array at {npath}")
             stack_dims = [x for x in narray.dims if x not in keep_dims]
-            node_arrays[npath] = narray.stack(**{"**tempindex**": stack_dims}).reset_index(stack_dims, drop=True)
+            if len(stack_dims) > 0:
+                node_arrays[npath] = narray.stack(**{"**tempindex**": stack_dims}).reset_index(stack_dims, drop=True)
 
         action = type(self)(nodetree_from_dict(node_arrays))
         return _combine_nodes(action, method, dim="**tempindex**", batch_size=0, keep_dim=False, path=path, backend_kwargs=backend_kwargs)
@@ -714,8 +721,8 @@ class Action:
         for path, func in expansion.items():
             node_arrays[path] = nodetree_array(action.map(func).nodes, parent)
         return type(self)(nodetree_from_dict(node_arrays))
-    
-    def combine_branches(self, dim: str, path: Optional[str] = None) -> "Action":
+
+    def combine_branches(self, dim: str, path: Optional[str] = None, force: bool = False) -> "Action":
         """Combine node arrays for leaves along path into a single node array
 
         Parameters
@@ -732,6 +739,11 @@ class Action:
         ValueError if arrays along leaves are not compatible
         """
         action = self.select(path=path)
+        narrays = {apath: array for apath, array in nodetree_arrays(action.nodes)}
+        if force:
+            common_coords = set.intersection(*[set(x.coords) for x in narrays.values()])
+            for apath in narrays.keys():
+                action = action.flatten(keep_dims=common_coords, path=apath)
         new_array = xr.concat([x[1] for x in nodetree_arrays(action.nodes)], dim=dim)
         if path:
             node_arrays = {apath: array for apath, array in nodetree_arrays(self.nodes) if path not in array}
@@ -1149,11 +1161,6 @@ def _combine_nodes(
     path: Optional[str] = None,
     backend_kwargs: dict = {},
 ) -> Action:
-    if action.nodes.sizes[dim] == 1:
-        # no-op
-        if not keep_dim:
-            action._squeeze_dimension(dim, path=path)
-        return action
     if backend_method not in ["stack", "concat"]:
         raise ValueError(f"Unknown method {backend_method} for combining nodes")
     return action.reduce(

--- a/src/earthkit/workflows/fluent.py
+++ b/src/earthkit/workflows/fluent.py
@@ -677,7 +677,9 @@ class Action:
                 raise ValueError(f"Dimensions {diff} not in array at {npath}")
             stack_dims = [x for x in narray.dims if x not in keep_dims]
             if len(stack_dims) > 0:
-                node_arrays[npath] = narray.stack(**{"**tempindex**": stack_dims}).reset_index(stack_dims, drop=True)
+                node_arrays[npath] = (
+                    narray.stack(**{"**tempindex**": stack_dims}).reset_index(stack_dims, drop=True).reset_coords(drop=True)
+                )
 
         action = type(self)(nodetree_from_dict(node_arrays))
         return _combine_nodes(action, method, dim="**tempindex**", batch_size=0, keep_dim=False, path=path, backend_kwargs=backend_kwargs)
@@ -741,9 +743,9 @@ class Action:
         action = self.select(path=path)
         narrays = {apath: array for apath, array in nodetree_arrays(action.nodes)}
         if force:
-            common_coords = set.intersection(*[set(x.coords) for x in narrays.values()])
+            common_dims = set.intersection(*[set(x.dims) for x in narrays.values()])
             for apath in narrays.keys():
-                action = action.flatten(keep_dims=common_coords, path=apath)
+                action = action.flatten(keep_dims=common_dims, path=apath)
         new_array = xr.concat([x[1] for x in nodetree_arrays(action.nodes)], dim=dim)
         if path:
             node_arrays = {apath: array for apath, array in nodetree_arrays(self.nodes) if path not in array}

--- a/src/earthkit/workflows/fluent.py
+++ b/src/earthkit/workflows/fluent.py
@@ -656,28 +656,24 @@ class Action:
     @capture_payload_metadata
     def flatten(
         self,
+        new_dim: str,
         keep_dims: list[str] = [],
         path: Optional[str] = None,
-        method: str = "concat",
-        backend_kwargs: dict = {},
-        payload_metadata: dict | None = None,
+        reset_coords: bool = False,
     ) -> "Action":
-        """Flattens the array of nodes along all dims, except keep_sims, for node arrays
-        along path. Internal data in nodes is combined either by stacking for concatenating,
-        specified by method
+        """Restructures node arrays by flattening arrays along all dims, except keep_dims, for node arrays
+        along path.
 
         Parameters
         ----------
         keep_dims: str, name of dimensions not to flatten
-        method: str, either concat or stack
+        new_dim: str, name of new dimension containing flattened dims
         path: str, path to select subset of nodes to operate on, if provided
-        backend_kwargs: dict, kwargs for the underlying array module stack method
 
         Return
         ------
         Action
         """
-        temp_dim = self._temp_dim()
         node_arrays = {npath: narray for npath, narray in nodetree_arrays(self.nodes)}
         for npath, narray in nodetree_arrays(self.select(path=path).nodes):
             if narray.size == 1:
@@ -687,12 +683,12 @@ class Action:
                 raise ValueError(f"Dimensions {diff} not in array at {npath}")
             stack_dims = [x for x in narray.dims if x not in keep_dims]
             if len(stack_dims) > 0:
-                node_arrays[npath] = narray.stack(dim={temp_dim: stack_dims}).reset_index(stack_dims, drop=True)
-            reset_coords = [name for name, coord in node_arrays[npath].coords.items() if temp_dim in coord.dims]
-            if len(reset_coords) > 0:
+                node_arrays[npath] = narray.stack(dim={new_dim: stack_dims}).reset_index(stack_dims, drop=True)
+
+            reset_coords = [name for name, coord in node_arrays[npath].coords.items() if new_dim in coord.dims]
+            if reset_coords and len(reset_coords) > 0:
                 node_arrays[npath] = node_arrays[npath].reset_coords(reset_coords, drop=True)
-        action = type(self)(nodetree_from_dict(node_arrays))
-        return _combine_nodes(action, method, dim=temp_dim, batch_size=0, keep_dim=False, path=path, backend_kwargs=backend_kwargs)
+        return type(self)(nodetree_from_dict(node_arrays))
 
     def set_path(self, path: str) -> "Action":
         """Create path for current node array
@@ -750,12 +746,13 @@ class Action:
         ------
         ValueError if arrays along leaves are not compatible
         """
+        temp_dim = self._temp_dim()
         action = self.select(path=path)
         narrays = {apath: array for apath, array in nodetree_arrays(action.nodes)}
         if force:
             common_dims = set.intersection(*[set(x.dims) for x in narrays.values()])
             for apath in narrays.keys():
-                action = action.flatten(keep_dims=common_dims, path=apath)
+                action = action.flatten(new_dim=temp_dim, keep_dims=common_dims, path=apath).concatenate(dim=temp_dim, path=apath)
         new_array = xr.concat([x[1] for x in nodetree_arrays(action.nodes)], dim=dim, coords="different", compat="equals")
         if path:
             node_arrays = {apath: array for apath, array in nodetree_arrays(self.nodes) if path not in array}

--- a/tests/earthkit_workflows/test_fluent.py
+++ b/tests/earthkit_workflows/test_fluent.py
@@ -346,6 +346,9 @@ def test_branches():
     reduced = subbranches.sum(path="/branch1/subbranch1")
     with pytest.raises(ValueError):
         reduced.combine_branches("dim_1")
+    force = reduced.combine_branches(dim="dim_new", force=True)
+    for path, array in nodetree_arrays(force.nodes):
+        assert array.shape == (3, 4)
 
 
 @pytest.mark.parametrize(

--- a/tests/earthkit_workflows/test_fluent.py
+++ b/tests/earthkit_workflows/test_fluent.py
@@ -300,7 +300,46 @@ def test_generators():
     serialise(graph)
 
 
-def test_branches():
+@pytest.mark.parametrize(
+    "branch_config",
+    [
+        {
+            "/branch1": lambda data: np.where(data <= 0, data, np.nan),
+            "/branch2": lambda data: np.where(data > 0, data, np.nan),
+        },
+        {
+            "/branch1/subbranch1": lambda data: np.where(data < 0, data, np.nan),
+            "/branch1/subbranch2": lambda data: np.where(data == 0, data, np.nan),
+            "/branch2": lambda data: np.where(data == 0, data, np.nan),
+        },
+    ],
+    ids=["branches", "subranches"],
+)
+@pytest.mark.parametrize(
+    "combine_dim",
+    [
+        "dim_0",
+        "dim_new",
+    ],
+    ids=["existing-dim", "new-dim"],
+)
+def test_branches(branch_config, combine_dim):
+    input_action = mock_action((3, 4))
+    branches = input_action.create_branches(branch_config)
+    assert set(x[0] for x in nodetree_arrays(branches.nodes)) == set(branch_config.keys())
+    for npath, narray in nodetree_arrays(branches.nodes):
+        assert narray.shape == (3, 4)
+        assert "branch" in npath
+    recombined = branches.combine_branches(dim=combine_dim)
+    for path, array in nodetree_arrays(recombined.nodes):
+        assert path == "/"
+        if combine_dim == "dim_new":
+            assert array.shape == ((len(branch_config)), 3, 4)
+        else:
+            assert array.shape == ((len(branch_config)) * 3, 4)
+
+
+def test_invalid_branches():
     input_action = mock_action((3, 4))
     branches = input_action.create_branches(
         {
@@ -308,29 +347,6 @@ def test_branches():
             "/branch2": lambda data: np.where(data > 0, data, np.nan),
         }
     )
-    for npath, narray in nodetree_arrays(branches.nodes):
-        assert narray.shape == (3, 4)
-        assert "branch" in npath
-    recombined = branches.combine_branches(dim="dim_0")
-    for path, array in nodetree_arrays(recombined.nodes):
-        assert path == "/"
-        assert array.shape == (6, 4)
-
-    subbranches = branches.create_branches(
-        {
-            "/branch1/subbranch1": lambda data: np.where(data < 0, data, np.nan),
-            "/branch1/subbranch2": lambda data: np.where(data == 0, data, np.nan),
-        }
-    )
-    assert [x[0] for x in nodetree_arrays(subbranches.nodes)] == [
-        "/branch2",
-        "/branch1/subbranch1",
-        "/branch1/subbranch2",
-    ]
-    for path, array in nodetree_arrays(subbranches.combine_branches(dim="dim_new").nodes):
-        assert path == "/"
-        assert array.shape == (3, 3, 4)
-
     with pytest.raises(NotImplementedError):
         branches.set_path("/new_root")
 
@@ -343,12 +359,26 @@ def test_branches():
             }
         )
 
-    reduced = subbranches.sum(path="/branch1/subbranch1")
+
+def test_combine_branches():
+    input_action = mock_action((3, 4))
+    branches = input_action.create_branches(
+        {
+            "/branch1/subbranch1": lambda data: np.where(data < 0, data, np.nan),
+            "/branch1/subbranch2": lambda data: np.where(data == 0, data, np.nan),
+            "/branch2": lambda data: np.where(data == 0, data, np.nan),
+        }
+    )
+    reduced = branches.sum(path="/branch1/subbranch1")
+    reduced.nodes["/branch2"].coords["dim_2"] = 1
+    reduced.nodes["/branch1/subbranch1"].coords["dim_2"] = 2
+    reduced.nodes["/branch1/subbranch2"].coords["dim_2"] = 2
     with pytest.raises(ValueError):
         reduced.combine_branches("dim_1")
-    force = reduced.combine_branches(dim="dim_new", force=True)
-    for path, array in nodetree_arrays(force.nodes):
-        assert array.shape == (3, 4)
+    force = reduced.combine_branches(dim="dim_1", force=True)
+    for _, array in nodetree_arrays(force.nodes):
+        assert array.shape == (12,)
+    force.flatten()
 
 
 @pytest.mark.parametrize(

--- a/tests/earthkit_workflows/test_fluent.py
+++ b/tests/earthkit_workflows/test_fluent.py
@@ -378,7 +378,6 @@ def test_combine_branches():
     force = reduced.combine_branches(dim="dim_1", force=True)
     for _, array in nodetree_arrays(force.nodes):
         assert array.shape == (12,)
-    force.flatten()
 
 
 @pytest.mark.parametrize(

--- a/tests/earthkit_workflows/test_fluent.py
+++ b/tests/earthkit_workflows/test_fluent.py
@@ -129,18 +129,20 @@ def test_broadcast():
 def test_flatten_expand():
     input_action = mock_action((2, 3))
 
-    with pytest.raises(Exception):
-        input_action.flatten(dim="dim_2")
-
-    action1 = input_action.flatten(dim="dim_1")
+    with pytest.raises(ValueError):
+        input_action.flatten(keep_dims=["dim_2"])
+    action1 = input_action.flatten(keep_dims=["dim_0"])
     action1_array = nodetree_array(action1.nodes)
     assert action1_array.shape == (2,)
     assert len(action1_array.data.item(0).inputs) == 3
 
-    action2 = action1.flatten(dim="dim_0")
+    action2 = action1.flatten(method="stack")
     assert len(nodetree_array(action2.nodes).data.item(0).inputs) == 2
 
-    with pytest.raises(Exception):
+    flatten_all = input_action.flatten()
+    assert flatten_all.nodes == action2.nodes
+
+    with pytest.raises(ValueError):
         action2.flatten()
 
     action3 = action2.expand("dim_0", internal_dim=0, dim_size=2)
@@ -298,9 +300,9 @@ def test_generators():
     serialise(graph)
 
 
-def test_split():
+def test_branches():
     input_action = mock_action((3, 4))
-    branches = input_action.split(
+    branches = input_action.create_branches(
         {
             "/branch1": lambda data: np.where(data <= 0, data, np.nan),
             "/branch2": lambda data: np.where(data > 0, data, np.nan),
@@ -309,8 +311,12 @@ def test_split():
     for npath, narray in nodetree_arrays(branches.nodes):
         assert narray.shape == (3, 4)
         assert "branch" in npath
+    recombined = branches.combine_branches(dim="dim_0")
+    for path, array in nodetree_arrays(recombined.nodes):
+        assert path == "/"
+        assert array.shape == (6, 4)
 
-    subbranches = branches.split(
+    subbranches = branches.create_branches(
         {
             "/branch1/subbranch1": lambda data: np.where(data < 0, data, np.nan),
             "/branch1/subbranch2": lambda data: np.where(data == 0, data, np.nan),
@@ -321,18 +327,25 @@ def test_split():
         "/branch1/subbranch1",
         "/branch1/subbranch2",
     ]
+    for path, array in nodetree_arrays(subbranches.combine_branches(dim="dim_new").nodes):
+        assert path == "/"
+        assert array.shape == (3, 3, 4)
 
     with pytest.raises(NotImplementedError):
         branches.set_path("/new_root")
 
     with_root = input_action.set_path("/root")
     with pytest.raises(ValueError):
-        with_root.split(
+        with_root.create_branches(
             {
                 "/branch1": lambda data: np.where(data <= 0, data, np.nan),
                 "/branch2": lambda data: np.where(data > 0, data, np.nan),
             }
         )
+
+    reduced = subbranches.sum(path="/branch1/subbranch1")
+    with pytest.raises(ValueError):
+        reduced.combine_branches("dim_1")
 
 
 @pytest.mark.parametrize(
@@ -352,7 +365,7 @@ def test_select(selection, num_arrays, shapes_or_error):
         branch1=mock_action((3, 4)),
         branch2=mock_action((3, 5)),
     )
-    subbranches = branches.split(
+    subbranches = branches.create_branches(
         {
             "/branch1/subbranch1": lambda data: np.where(data < 0, data, np.nan),
             "/branch1/subbranch2": lambda data: np.where(data == 0, data, np.nan),
@@ -385,7 +398,7 @@ def test_iselect(selection, num_arrays, shapes_or_error):
         branch1=mock_action((3, 4)),
         branch2=mock_action((3, 5)),
     )
-    subbranches = branches.split(
+    subbranches = branches.create_branches(
         {
             "/branch1/subbranch1": lambda data: np.where(data < 0, data, np.nan),
             "/branch1/subbranch2": lambda data: np.where(data == 0, data, np.nan),

--- a/tests/earthkit_workflows/test_fluent.py
+++ b/tests/earthkit_workflows/test_fluent.py
@@ -142,9 +142,6 @@ def test_flatten_expand():
     flatten_all = input_action.flatten()
     assert flatten_all.nodes == action2.nodes
 
-    with pytest.raises(ValueError):
-        action2.flatten()
-
     action3 = action2.expand("dim_0", internal_dim=0, dim_size=2)
     action3_array = nodetree_array(action3.nodes)
     assert action3_array.shape == (2,)
@@ -378,6 +375,20 @@ def test_combine_branches():
     force = reduced.combine_branches(dim="dim_1", force=True)
     for _, array in nodetree_arrays(force.nodes):
         assert array.shape == (12,)
+
+
+def test_flatten_branches():
+    input_action = mock_action((3, 4))
+    branches = input_action.create_branches(
+        {
+            "/branch1/subbranch1": lambda data: np.where(data < 0, data, np.nan),
+            "/branch1/subbranch2": lambda data: np.where(data == 0, data, np.nan),
+            "/branch2": lambda data: np.where(data == 0, data, np.nan),
+        }
+    )
+    reduced = branches.flatten(path="/branch1/subbranch1")
+    flattened = reduced.flatten()
+    assert reduced.sel(path="/branch1/subbranch1").nodes == flattened.sel(path="/branch1/subbranch1").nodes
 
 
 @pytest.mark.parametrize(

--- a/tests/earthkit_workflows/test_fluent.py
+++ b/tests/earthkit_workflows/test_fluent.py
@@ -130,16 +130,16 @@ def test_flatten_expand():
     input_action = mock_action((2, 3))
 
     with pytest.raises(ValueError):
-        input_action.flatten(keep_dims=["dim_2"])
-    action1 = input_action.flatten(keep_dims=["dim_0"])
+        input_action.flatten(new_dim="temp", keep_dims=["dim_2"])
+    action1 = input_action.flatten(new_dim="temp", keep_dims=["dim_0"]).concatenate(dim="temp")
     action1_array = nodetree_array(action1.nodes)
     assert action1_array.shape == (2,)
     assert len(action1_array.data.item(0).inputs) == 3
 
-    action2 = action1.flatten(method="stack")
+    action2 = action1.flatten(new_dim="temp").stack(dim="temp")
     assert len(nodetree_array(action2.nodes).data.item(0).inputs) == 2
 
-    flatten_all = input_action.flatten()
+    flatten_all = input_action.flatten(new_dim="temp").concatenate(dim="temp")
     assert flatten_all.nodes == action2.nodes
 
     action3 = action2.expand("dim_0", internal_dim=0, dim_size=2)
@@ -386,8 +386,8 @@ def test_flatten_branches():
             "/branch2": lambda data: np.where(data == 0, data, np.nan),
         }
     )
-    reduced = branches.flatten(path="/branch1/subbranch1")
-    flattened = reduced.flatten()
+    reduced = branches.flatten(new_dim="temp", path="/branch1/subbranch1").concatenate(dim="temp")
+    flattened = reduced.flatten(new_dim="temp").concatenate(dim="temp")
     assert reduced.sel(path="/branch1/subbranch1").nodes == flattened.sel(path="/branch1/subbranch1").nodes
 
 

--- a/tests/earthkit_workflows/test_fluent.py
+++ b/tests/earthkit_workflows/test_fluent.py
@@ -358,19 +358,22 @@ def test_invalid_branches():
 
 
 def test_combine_branches():
-    input_action = mock_action((3, 4))
-    branches = input_action.create_branches(
-        {
-            "/branch1/subbranch1": lambda data: np.where(data < 0, data, np.nan),
-            "/branch1/subbranch2": lambda data: np.where(data == 0, data, np.nan),
-            "/branch2": lambda data: np.where(data == 0, data, np.nan),
-        }
+    branches = merge(
+        mock_action((3, 4))
+        .set_path("/branch1")
+        .create_branches(
+            {
+                "/branch1/subbranch1": lambda data: np.where(data < 0, data, np.nan),
+                "/branch1/subbranch2": lambda data: np.where(data == 0, data, np.nan),
+            },
+        ),
+        mock_action((5, 4, 6)).set_path("/branch2"),
     )
     reduced = branches.sum(path="/branch1/subbranch1")
-    reduced.nodes["/branch2"].coords["dim_2"] = 1
-    reduced.nodes["/branch1/subbranch1"].coords["dim_2"] = 2
-    reduced.nodes["/branch1/subbranch2"].coords["dim_2"] = 2
-    with pytest.raises(ValueError):
+    reduced.nodes["/branch2"].coords["scalar_dim"] = 1
+    reduced.nodes["/branch1/subbranch1"].coords["scalar_dim"] = 2
+    reduced.nodes["/branch1/subbranch2"].coords["scalar_dim"] = 2
+    with pytest.raises(Exception, match="cannot align objects with join='exact"):
         reduced.combine_branches("dim_1")
     force = reduced.combine_branches(dim="dim_1", force=True)
     for _, array in nodetree_arrays(force.nodes):


### PR DESCRIPTION
### Description
- Modify `flatten` method to act across multiple dimensions and reduce method to just restructuring node arrays
- Add method `combine_branches` to merge datatree branches back together with `force` option, to handle reduction along dimensions that may differ between node arrays

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
