### PR TITLE
Unify gateway startup path

### DIFF
--- a/integration_tests/harnessCluster.py
+++ b/integration_tests/harnessCluster.py
@@ -22,8 +22,9 @@ from job_noRuntime import job  # ty:ignore[unresolved-import]
 
 import cascade.gateway.api as api
 import cascade.gateway.client as client
-from cascade.gateway.__main__ import main_cli
+from cascade.deployment.logging import DefaultLoggingConfig
 from cascade.gateway.api import SlurmCluster, SshCluster
+from cascade.gateway.server import serve
 from cascade.ygg.transport import destroy_context
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
@@ -38,10 +39,15 @@ POLL_INTERVAL = 3.0
 
 
 def spawn_gateway(shared_path: str | None) -> Process:
+    logging_config_ser = DefaultLoggingConfig.ser_cliparam()
     p = Process(
-        target=main_cli,
+        target=serve,
         args=(GATEWAY_URL,),
-        kwargs={"report_transport": "tcp", "shared_path": shared_path},
+        kwargs={
+            "loggingConfigSer": logging_config_ser,
+            "report_transport": "tcp",
+            "shared_path": shared_path,
+        },
     )
     p.start()
     return p

--- a/src/cascade/deployment/logging/__init__.py
+++ b/src/cascade/deployment/logging/__init__.py
@@ -50,6 +50,7 @@ class LoggingConfig(CascadeBaseModel):
     """If None log to stdout, otherwise log into files in path_base directory, with each process having its own files.
     Expected to have been created beforehand"""
     disable: bool = False
+    ignore: bool = False
 
     def ser_cliparam(self) -> str:
         return base64.b64encode(self.model_dump_json().encode("utf-8")).decode("utf-8")
@@ -100,6 +101,8 @@ def as_dict_config(loggingConfig: LoggingConfig, hostAndRole: str) -> dict:
 
 
 def init_from_obj(loggingConfig: LoggingConfig, hostAndRole: str) -> None:
+    if loggingConfig.ignore:
+        return
     dictConfig = as_dict_config(loggingConfig, hostAndRole)
     logging.config.dictConfig(dictConfig)
 

--- a/src/cascade/gateway/__main__.py
+++ b/src/cascade/gateway/__main__.py
@@ -8,32 +8,7 @@
 
 import fire
 
-from cascade.deployment.logging import init_from_cliparam
-from cascade.gateway.server import roleLoggingStr, serve
-
-
-def main_cli(
-    url: str,
-    loggingConfigSer: str | None = None,
-    troika_config: str | None = None,
-    shared_path: str | None = None,
-    max_concurrent_jobs: int | None = None,
-    max_jobs_history: int = 20,
-    max_queue_length: int = 50,
-    report_transport: str = "tcp",
-) -> None:
-    loggingConfig = init_from_cliparam(loggingConfigSer, roleLoggingStr())
-    serve(
-        url,
-        loggingConfig,
-        troika_config,
-        shared_path,
-        max_concurrent_jobs,
-        max_jobs_history,
-        max_queue_length,
-        report_transport,
-    )
-
+from cascade.gateway.server import serve
 
 if __name__ == "__main__":
-    fire.Fire(main_cli)
+    fire.Fire(serve)

--- a/src/cascade/gateway/server.py
+++ b/src/cascade/gateway/server.py
@@ -21,7 +21,7 @@ import zmq
 import cascade.executor.platform as platform
 import cascade.gateway.api as api
 from cascade.controller.report import deserialize
-from cascade.deployment.logging import LoggingConfig, init_from_obj
+from cascade.deployment.logging import init_from_cliparam
 from cascade.gateway.client import parse_request, serialize_response
 from cascade.gateway.router import JobRouter
 from cascade.gateway.spawning import prepare_slurm_install_spec
@@ -92,7 +92,7 @@ def handle_controller(ygg: YggNode, jobs: JobRouter) -> None:
 
 def serve(
     url: str,
-    loggingConfig: LoggingConfig,
+    loggingConfigSer: str | None = None,
     troika_config: str | None = None,
     shared_path: str | None = None,
     max_concurrent_jobs: int | None = None,
@@ -100,6 +100,7 @@ def serve(
     max_queue_length: int = 50,
     report_transport: str = "tcp",
 ) -> None:
+    loggingConfig = init_from_cliparam(loggingConfigSer, roleLoggingStr())
     logger.info(f"gateway starting to serve on host {socket.getfqdn()}")
     slurm_install_spec = prepare_slurm_install_spec(shared_path)
     if report_transport == "tcp":
@@ -158,16 +159,3 @@ def roleLoggingStr() -> str:
     # For other roles this matters not -- they are distinguished by jobId in the name, or by #attempt counter
     now = dt.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     return f"gateway.{now}"
-
-
-def main_enp(
-    url: str,
-    loggingConfig: LoggingConfig,
-    max_concurrent_jobs: int | None,
-    max_jobs_history: int = 20,
-    max_queue_length: int = 50,
-    report_transport: str = "tcp",
-) -> None:
-    # use when process is not __main__ but eg forked from another
-    init_from_obj(loggingConfig, roleLoggingStr())
-    serve(url, loggingConfig, None, None, max_concurrent_jobs, max_jobs_history, max_queue_length, report_transport)

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -5,8 +5,9 @@ import pytest
 
 import cascade.gateway.api as api
 import cascade.gateway.client as client
-from cascade.gateway.__main__ import main_cli
+from cascade.deployment.logging import DefaultLoggingConfig
 from cascade.gateway.api import LocalProcesses
+from cascade.gateway.server import serve
 from cascade.low.builders import JobBuilder
 from cascade.low.core import DatasetId, JobInstanceRich, TaskDefinition, TaskId, TaskInstance
 from cascade.ygg.transport import destroy_context
@@ -70,10 +71,12 @@ def spawn_gateway(
     max_queue_length: int = 50,
 ) -> tuple[str, Process]:
     url = "tcp://localhost:12355"
+    logging_config_ser = DefaultLoggingConfig.ser_cliparam()
     p = Process(
-        target=main_cli,
+        target=serve,
         args=(url,),
         kwargs={
+            "loggingConfigSer": logging_config_ser,
             "max_concurrent_jobs": max_concurrent_jobs,
             "max_jobs_history": max_jobs_history,
             "max_queue_length": max_queue_length,


### PR DESCRIPTION
Unifies the main_enp and main_cli methods for gateway -- they diverged and did not expose the same set of args. This fixes it