### PR TITLE
[cascade] fixing bugs: shm unregister, runpy warn

### DIFF
--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -26,7 +26,7 @@ from cascade.executor.msg import (
     Syn,
 )
 from cascade.executor.serde import des_message, ser_message
-from cascade.low.core import HostId
+from cascade.low.core import HostId, WorkerId
 from cascade.low.exceptions import CascadeInfrastructureError, CascadeInternalError
 
 logger = logging.getLogger(__name__)
@@ -265,3 +265,7 @@ class ReliableSender:
                         raise CascadeInfrastructureError(f"message {idx} ({record.clazz}) retried too many times")
                 else:
                     logger.warning(f"{record.host=} not present, cannot retry message {idx=}. Presumably we are at shutdown")
+
+
+def worker_address(workerId: WorkerId, workerAttemptCnt: int) -> BackboneAddress:
+    return f"ipc:///tmp/{repr(workerId)}.{workerAttemptCnt}.socket"

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -29,7 +29,7 @@ import cascade.executor.runner.setup as runner_setup
 import cascade.shm.api as shm_api
 import cascade.shm.client as shm_client
 from cascade.deployment.logging import LoggingConfig, as_dict_config, process_log_paths
-from cascade.executor.comms import GraceWatcher, Listener, ReliableSender, callback
+from cascade.executor.comms import GraceWatcher, Listener, ReliableSender, callback, worker_address
 from cascade.executor.comms import default_message_resend_ms as resend_grace_ms
 from cascade.executor.comms import default_timeout_ms as comms_default_timeout_ms
 from cascade.executor.config import logging_config, logging_config_filehandler
@@ -56,7 +56,6 @@ from cascade.executor.msg import (
     WorkerReady,
     WorkerShutdown,
 )
-from cascade.executor.runner.entrypoint import worker_address
 from cascade.executor.runner.setup import RunnerContext, WorkerProcessHandle
 from cascade.low.core import DatasetId, HostId, JobInstance, TaskId, WorkerId
 from cascade.low.exceptions import CascadeError, CascadeInfrastructureError, CascadeInternalError, CascadeUserError, ser
@@ -203,8 +202,8 @@ class Executor:
                 logger.warning(f"gotten {repr(e)} when shutting down old worker {proc.pid}")
         if hasattr(self, "runner_ctx_shm") and self.runner_ctx_shm is not None:
             try:
-                self.runner_ctx_shm.close()
                 self.runner_ctx_shm.unlink()
+                self.runner_ctx_shm.close()
             except Exception as e:
                 logger.warning(f"failed to free runner ctx shm: {repr(e)}")
         if hasattr(self, "shm_process") and self.shm_process is not None and self.shm_process.is_alive():

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -18,7 +18,7 @@ from packaging.version import Version
 import cascade.executor.platform as platform
 import cascade.executor.serde as serde
 from cascade.deployment.logging import init_from_obj
-from cascade.executor.comms import callback
+from cascade.executor.comms import callback, worker_address
 from cascade.executor.msg import (
     BackboneAddress,
     DatasetPublished,
@@ -93,10 +93,6 @@ class Config:
     # decide dynamically based on memory pressure -- but neither is easy.
     posttask_flush = False  # after task is done, drop all outputs from memory
     pretask_flush = True  # when we receive a task, we drop those in memory that wont be needed
-
-
-def worker_address(workerId: WorkerId, workerAttemptCnt: int) -> BackboneAddress:
-    return f"ipc:///tmp/{repr(workerId)}.{workerAttemptCnt}.socket"
 
 
 def execute_sequence(

--- a/src/cascade/executor/runner/setup.py
+++ b/src/cascade/executor/runner/setup.py
@@ -59,16 +59,6 @@ venv_root = os.environ.get("CASCADE_VENV_ROOT", None)
 
 _python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 
-# Shared memory unregistering pattern: Python's resource tracker automatically unlinks
-# shared memory it created, which is wrong for memory we share across processes.
-# On 3.13+ we can disable tracking at creation time; on older versions we unregister manually.
-if (sys.version_info.major, sys.version_info.minor) >= (3, 13):
-    _is_unregister = False
-    _shm_kwargs: dict[str, Any] = {"track": False}
-else:
-    _is_unregister = True
-    _shm_kwargs = {}
-
 
 class WorkerProcessHandle(ABC):
     @property
@@ -205,6 +195,14 @@ class RunnerContext:
         )
 
 
+# NOTE about shared memory: unlike in the `cascade.shm` module, we dont
+# unregister or provide track=False, because the shared memory lifecycle
+# is that executor process creates, then workers open and close, and then
+# executor unlinks. This is compatible with python default behaviour.
+# On the `cascade.shm`, however, the creator and destroyer of the memory
+# are potentially different processes, thus we need to unregister/untrack.
+
+
 def save_runner_ctx_to_shm(ctx: RunnerContext, key: str) -> SharedMemory:
     """Cloudpickle ctx and store it in a new POSIX shared memory block named key.
 
@@ -214,18 +212,17 @@ def save_runner_ctx_to_shm(ctx: RunnerContext, key: str) -> SharedMemory:
     data = cloudpickle.dumps(ctx)
     size = len(data)
     try:
-        shm = SharedMemory(key, create=True, size=size, **_shm_kwargs)
+        logger.debug(f"saving runner ctx to shm with {key=}")
+        shm = SharedMemory(key, create=True, size=size)
     except FileExistsError:
         # this should not happen thanks to uuid, but if it does we handle gracefully
         logger.error(f"runner ctx shm {key!r} already existed; deleting and recreating")
-        _old = SharedMemory(key, create=False, **_shm_kwargs)
-        _old.close()
+        _old = SharedMemory(key, create=False)
         _old.unlink()
+        _old.close()
         if sys.platform == "darwin":
             time.sleep(1)  # on mac, create right after unlink leads to not found
-        shm = SharedMemory(key, create=True, size=size, **_shm_kwargs)
-    if _is_unregister:
-        resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
+        shm = SharedMemory(key, create=True, size=size)
     assert shm.buf is not None
     shm.buf[:size] = data
     return shm
@@ -236,9 +233,7 @@ def load_runner_ctx_from_shm(key: str) -> RunnerContext:
 
     The worker calls this once during init; the memory stays alive until the executor frees it.
     """
-    shm = SharedMemory(key, create=False, **_shm_kwargs)
-    if _is_unregister:
-        resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
+    shm = SharedMemory(key, create=False)
     assert shm.buf is not None
     data = bytes(shm.buf[: shm.size])
     shm.close()
@@ -325,6 +320,14 @@ def _launch_worker_module(
 ) -> None:
     _redirect_standard_streams(stdout_path, stderr_path)
     _activate_worker_venv(venv_dir, envvars)
+    if module in sys.modules:
+        # NOTE we log because runpy itself gives a warning which is hard to
+        # track down. Its *probably* not a problem, it just denotes that
+        # post-init state changes may have affected the module *but* it is
+        # not visible to the runpy's initializiation. We dont do such changes
+        # anyway so we would not be observably affected, but runpy is careful.
+        # So we better *not* import it, for less warnings and confusion.
+        logger.error(f"the {module=} imported prior to runpy call!")
     runpy.run_module(module, run_name="__main__", alter_sys=True)
 
 


### PR DESCRIPTION
We had a shared memory error logged at the end of each workflow, due to double unregister of executor context. This was because we explicitly unregister ourselves similarly to how we do in shm -- but whereas there it is justified by the shm lifecycle, in the executor context there is actually one holder for the whole lifecycle, hence it can't properly close at the end. By removing the unregister/untrack call, the warning goes away.

We also had a runpy warning logged, because the module has already been imported by the time it was being freezed by runpy. It *probably* had no adverse effect, but still it is proper for runpy to freeze only unimported modules, hence we restructure the code and imports accordingly, and add an easier-to-locate logger call in case it goes wrong again in the future.
