### PR TITLE
[cascade.controller] increase report timeouts

### DIFF
--- a/src/cascade/controller/report.py
+++ b/src/cascade/controller/report.py
@@ -90,8 +90,9 @@ class ReporterChannel:
         self._ygg.retry_outstanding()
 
     def close(self) -> None:
-        # NOTE we really want to get these acked from gw, otherwise completion is never reported
-        self._ygg.close(timeout_ms=1000, wait_for_all_acks=True)
+        # NOTE we really want to get these acked from gw, otherwise completion is never reported,
+        # we go with 3.1s so that 6 retries with 500ms each fit in, +100ms for some slack
+        self._ygg.close(timeout_ms=3100, wait_for_all_acks=True)
 
 
 class Reporter:

--- a/src/cascade/ygg/types.py
+++ b/src/cascade/ygg/types.py
@@ -28,7 +28,7 @@ class RetryPolicy:
 
 @dataclass(frozen=True)
 class YggConfig:
-    control: RetryPolicy = RetryPolicy(retry_interval_ms=800, max_retries=20)
+    control: RetryPolicy = RetryPolicy(retry_interval_ms=500, max_retries=20)
     bulk: RetryPolicy = RetryPolicy(retry_interval_ms=4_000, max_retries=10)
     control_delivery: Delivery = "reliable"
     bulk_delivery: Delivery = "reliable"


### PR DESCRIPTION
Just increasing ygg timeouts a tiny bit to fit more than one retry at the shutdown time