### PR TITLE
Feat/monitor fds

### DIFF
--- a/integration_tests/harness.py
+++ b/integration_tests/harness.py
@@ -24,7 +24,7 @@ from cascade.gateway.api import LocalProcesses, SlurmCluster, SshCluster
 from cascade.gateway.server import serve
 from cascade.low.core import DatasetId, JobInstanceRich
 from cascade.main import run_locally
-from cascade.ygg.transport import destroy_context
+from cascade.ygg.transport import ensure_clean_zmq_state
 
 logger = logging.getLogger("cascade.main.client")
 
@@ -191,9 +191,7 @@ def wait_for_gateway(url: str, retries: int = 20) -> None:
 def build_job_spec(job_mod: ModuleType, deployment_kind: DeploymentKind) -> api.JobSpec:
     job = job_mod.job()
     spc = job_mod.spc()
-    envvars = {
-        "CASCADE_DEBUG_PERF": "1",
-    }
+    envvars = {}
     if deployment_kind == "plain_cluster":
         job = job.model_copy(update={"custom_pip_indices": (REMOTE_WHEELS_DIR,)})
         infra = SshCluster(
@@ -228,7 +226,7 @@ def collect_outputs(job_id: JobId, datasets: list[DatasetId], job: JobInstanceRi
 
 
 def run_cluster(job_mod: ModuleType, deployment_kind: DeploymentKind) -> None:
-    destroy_context()
+    ensure_clean_zmq_state()
     gw: Process | subprocess.Popen[bytes]
 
     # Slurm requires shared_path for srun scripts; SSH tests the per-node scp path

--- a/integration_tests/harness.py
+++ b/integration_tests/harness.py
@@ -1,6 +1,7 @@
 import argparse
 import importlib
 import logging
+import os
 import subprocess
 import sys
 import tempfile
@@ -190,6 +191,9 @@ def wait_for_gateway(url: str, retries: int = 20) -> None:
 def build_job_spec(job_mod: ModuleType, deployment_kind: DeploymentKind) -> api.JobSpec:
     job = job_mod.job()
     spc = job_mod.spc()
+    envvars = {
+        "CASCADE_DEBUG_PERF": "1",
+    }
     if deployment_kind == "plain_cluster":
         job = job.model_copy(update={"custom_pip_indices": (REMOTE_WHEELS_DIR,)})
         infra = SshCluster(
@@ -197,16 +201,16 @@ def build_job_spec(job_mod: ModuleType, deployment_kind: DeploymentKind) -> api.
             worker_urls=[f"root@worker{i}" for i in range(1, spc.hosts + 1)],
             workers_per_host=spc.workers,
         )
-        return api.JobSpec(job_instance=job, envvars={}, infra_spec=infra)
+        return api.JobSpec(job_instance=job, envvars=envvars, infra_spec=infra)
     elif deployment_kind == "slurm_cluster":
         job = job.model_copy(update={"custom_pip_indices": (REMOTE_WHEELS_DIR,)})
         infra = SlurmCluster(
             workers_per_host=spc.workers,
             hosts=spc.hosts,
         )
-        return api.JobSpec(job_instance=job, envvars={}, infra_spec=infra)
+        return api.JobSpec(job_instance=job, envvars=envvars, infra_spec=infra)
     elif deployment_kind == "local":
-        return api.JobSpec(job_instance=job, envvars={}, infra_spec=LocalProcesses(workers_per_host=spc.workers, hosts=spc.hosts))
+        return api.JobSpec(job_instance=job, envvars=envvars, infra_spec=LocalProcesses(workers_per_host=spc.workers, hosts=spc.hosts))
     else:
         raise ValueError(f"unsupported deployment kind for cluster submission: {deployment_kind}")
 
@@ -298,11 +302,10 @@ def run_cluster(job_mod: ModuleType, deployment_kind: DeploymentKind) -> None:
 
 def run_local(job_mod: ModuleType) -> None:
     spec = build_job_spec(job_mod, "local")
+    for k, v in spec.envvars.items():
+        os.environ[k] = v
     if not isinstance(spec.infra_spec, api.LocalProcesses):
         raise TypeError
-    # NOTE actually not needed, the editable install survives
-    # if "noRuntime" not in job_mod.__name__:
-    #   add_environment(spec, f"-e {RUNTIME_WHEEL_SRC}")
     outputs = run_locally(job=spec.job_instance, hosts=spec.infra_spec.hosts, workers=spec.infra_spec.workers_per_host)
     job_mod.outputOk(outputs)
     logger.info("Local integration test passed with outputs: %s", list(outputs.keys()))

--- a/integration_tests/integration_tests_base/job_ekdGribWriting.py
+++ b/integration_tests/integration_tests_base/job_ekdGribWriting.py
@@ -1,0 +1,38 @@
+"""
+A line of writing grib outputs
+"""
+
+# TODO support distributed in the outputOk
+
+from collections.abc import Mapping
+
+import numpy
+
+from cascade.low.builders import JobBuilder, TaskBuilder
+from cascade.low.core import DatasetId, DefaultTaskOutput, JobInstanceRich, TaskId
+from integration_tests_base.base import JobSpec
+
+
+def job() -> JobInstanceRich:
+    b = JobBuilder()
+    ekdType = "earthkit.data.readers.grib.file.GRIBReader"
+    deps = []
+    b = b.with_node("t0", TaskBuilder.from_entrypoint("integration_tests_runtime.source_ekd", {}, ekdType, deps))
+    N = 100
+    for i in range(N):
+        b = b.with_node(
+            f"t{i + 1}",
+            TaskBuilder.from_entrypoint("integration_tests_runtime.write_grib", {"a": ekdType, "i": "int"}, ekdType, deps).with_values(i=i),
+        ).with_edge(f"t{i}", f"t{i + 1}", "a")
+    ji = b.build().get_or_raise()
+    ji.ext_outputs = [DatasetId(task=TaskId(f"t{N}"), output=DefaultTaskOutput)]
+    return JobInstanceRich(jobInstance=ji, checkpointSpec=None)
+
+
+def spc() -> JobSpec:
+    return JobSpec(workers=1, hosts=1)
+
+
+def outputOk(outputs: Mapping[object, object]) -> None:
+    pass
+    # TODO check that the files exist

--- a/integration_tests/integration_tests_runtime/src/integration_tests_runtime/__init__.py
+++ b/integration_tests/integration_tests_runtime/src/integration_tests_runtime/__init__.py
@@ -50,5 +50,21 @@ def source_numpy() -> "numpy.ndarray":  # ty: ignore
     return numpy.array([1])
 
 
+ekdType = "earthkit.data.readers.grib.file.GRIBReader"
+
+
+def source_ekd() -> ekdType:  # ty: ignore
+    import earthkit.data as ekd
+
+    return ekd.from_source("sample", "test.grib")
+
+
+def write_grib(a: ekdType, i: int) -> ekdType:  # ty: ignore
+    pth = f"/tmp/file{i}.grib"
+    # TODO delete pth
+    a.to_target("file", pth)
+    return a
+
+
 def transform_numpy(a: "numpy.ndarray") -> "numpy.ndarray":  # ty: ignore
     return a + 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,17 +24,19 @@ dependencies = [
     "cloudpickle",
     "numpy",
     "xarray",
-    "networkx",
     "array-api-compat",
     "sortedcontainers",
-    "pyvis",
-    "dill",
     "pyrsistent",
     "pydantic",
     "pyzmq",
     "fire",
     "orjson",
     "qubed>=0.3.0",
+]
+# NOTE optional dependencies are not needed for runtime and would only slow down new worker spin ups etc
+optional-dependencies.vizualize = [
+    "networkx",
+    "pyvis",
 ]
 optional-dependencies.dask = [
     "dask[distributed]>=2026.1.2",

--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -75,15 +75,6 @@ def get_context() -> zmq.Context:
     return cascade.ygg.transport.get_context()
 
 
-def get_socket(address: BackboneAddress) -> zmq.Socket:
-    socket = get_context().socket(zmq.PUSH)
-    # NOTE we set the linger in case the executor dies before consuming a message sent
-    # by the child -- otherwise the child process would hang indefinitely
-    socket.set(zmq.LINGER, 1000)
-    socket.connect(address)
-    return socket
-
-
 def callback(address: BackboneAddress, msg: Message):
     # NOTE should be used for local comms only, as does not prepend with Syn message
     # TODO enforce that -- but needs a refactor for executor to open more sockets & poll correctly
@@ -237,7 +228,13 @@ class ReliableSender:
     def add_host(self, host: HostId, address: BackboneAddress) -> None:
         if host in self.hosts:
             self.hosts[host][0].close()
-        self.hosts[host] = (get_socket(address), address)
+
+        socket = get_context().socket(zmq.PUSH)
+        # NOTE we set the linger in case the executor dies before consuming a message sent
+        # by the child -- otherwise the child process would hang indefinitely
+        socket.set(zmq.LINGER, 1000)
+        socket.connect(address)
+        self.hosts[host] = (socket, address)
 
     def send(self, host: HostId, m: Message) -> None:
         raw = ser_message(m)

--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -87,25 +87,23 @@ def get_socket(address: BackboneAddress) -> zmq.Socket:
 def callback(address: BackboneAddress, msg: Message):
     # NOTE should be used for local comms only, as does not prepend with Syn message
     # TODO enforce that -- but needs a refactor for executor to open more sockets & poll correctly
-    socket = get_socket(address)
-    try:
-        byt = ser_message(msg)
-        socket.send(byt)
-    finally:
-        # NOTE must close explicitly: relying on GC causes sockets to accumulate, exhausting fd limits
-        socket.close()
+    #
+    # NOTE use a cached socket per address. Creating a new socket per call and closing it
+    # immediately doesn't work because ZMQ's IO thread keeps the underlying transport fd alive
+    # for the full LINGER period (1000ms), causing hundreds of fds to accumulate when
+    # callback() is called frequently. One persistent socket per destination avoids this.
+    socket = cascade.ygg.transport.get_callback_socket(address, linger_ms=1000)
+    byt = ser_message(msg)
+    socket.send(byt)
 
 
 def send_data(address: BackboneAddress, data: DatasetTransmitPayload, syn: Syn) -> zmq.MessageTracker:
-    socket = get_socket(address)
-    try:
-        byt = (ser_message(syn), pickle.dumps(data.header), data.value)
-        tracker = socket.send_multipart(byt, copy=False, track=True)
-    finally:
-        # NOTE must close explicitly; LINGER ensures delivery before the OS fd is freed.
-        # The returned tracker remains valid after close — it tracks the message buffer lifecycle,
-        # not the socket lifecycle.
-        socket.close()
+    # NOTE same caching rationale as callback() above.
+    # The returned MessageTracker tracks the message buffer lifecycle independently of the socket,
+    # so keeping the socket open after send is safe.
+    socket = cascade.ygg.transport.get_callback_socket(address, linger_ms=1000)
+    byt = (ser_message(syn), pickle.dumps(data.header), data.value)
+    tracker = socket.send_multipart(byt, copy=False, track=True)
     return tracker
 
 
@@ -237,6 +235,8 @@ class ReliableSender:
         self.address = address
 
     def add_host(self, host: HostId, address: BackboneAddress) -> None:
+        if host in self.hosts:
+            self.hosts[host][0].close()
         self.hosts[host] = (get_socket(address), address)
 
     def send(self, host: HostId, m: Message) -> None:

--- a/src/cascade/executor/comms.py
+++ b/src/cascade/executor/comms.py
@@ -88,14 +88,24 @@ def callback(address: BackboneAddress, msg: Message):
     # NOTE should be used for local comms only, as does not prepend with Syn message
     # TODO enforce that -- but needs a refactor for executor to open more sockets & poll correctly
     socket = get_socket(address)
-    byt = ser_message(msg)
-    socket.send(byt)
+    try:
+        byt = ser_message(msg)
+        socket.send(byt)
+    finally:
+        # NOTE must close explicitly: relying on GC causes sockets to accumulate, exhausting fd limits
+        socket.close()
 
 
 def send_data(address: BackboneAddress, data: DatasetTransmitPayload, syn: Syn) -> zmq.MessageTracker:
     socket = get_socket(address)
-    byt = (ser_message(syn), pickle.dumps(data.header), data.value)
-    tracker = socket.send_multipart(byt, copy=False, track=True)
+    try:
+        byt = (ser_message(syn), pickle.dumps(data.header), data.value)
+        tracker = socket.send_multipart(byt, copy=False, track=True)
+    finally:
+        # NOTE must close explicitly; LINGER ensures delivery before the OS fd is freed.
+        # The returned tracker remains valid after close — it tracks the message buffer lifecycle,
+        # not the socket lifecycle.
+        socket.close()
     return tracker
 
 

--- a/src/cascade/executor/data_server.py
+++ b/src/cascade/executor/data_server.py
@@ -47,7 +47,7 @@ from cascade.low.core import DatasetId, HostId
 from cascade.low.exceptions import CascadeError, CascadeInfrastructureError, CascadeInternalError, ser
 from cascade.low.func import assert_never
 from cascade.low.tracing import TransmitLifecycle, label, mark
-from cascade.ygg.transport import destroy_context
+from cascade.ygg.transport import ensure_clean_zmq_state
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class DataServer:
         logging_config: dict,
     ):
         logging.config.dictConfig(logging_config)
-        destroy_context()
+        ensure_clean_zmq_state()
 
         self.host = host
         label("host", self.host)

--- a/src/cascade/executor/executor.py
+++ b/src/cascade/executor/executor.py
@@ -204,6 +204,8 @@ class Executor:
                 logger.warning(f"gotten {repr(e)} when shutting down old worker {proc.pid}")
         if hasattr(self, "runner_ctx_shm") and self.runner_ctx_shm is not None:
             try:
+                if self.runner_ctx_shm.buf is not None:
+                    self.runner_ctx_shm.buf.release()
                 self.runner_ctx_shm.unlink()
                 self.runner_ctx_shm.close()
             except Exception as e:

--- a/src/cascade/executor/platform.py
+++ b/src/cascade/executor/platform.py
@@ -12,6 +12,7 @@ import fcntl
 import multiprocessing as mp
 import os
 import socket
+import subprocess
 import sys
 import typing
 
@@ -103,3 +104,29 @@ else:
             os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_WILLNEED)
         except OSError:
             pass
+
+
+if sys.platform == "darwin":
+
+    def get_fdcount() -> int:
+        try:
+            # -p targets only this process ID
+            # -F f tells lsof to output file descriptor lines prefixed with 'f'
+            cmd = ["lsof", "-p", str(os.getpid()), "-F", "f"]
+            out = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode()
+
+            # Strip the 'f' prefix to examine the raw FD value
+            # If it's purely digits (like '3' or '12'), it is a real numerical FD
+            # This safely ignores 'cwd', 'txt', 'rtd', and shared memory 'mem' tags
+            fd_count = sum(1 for line in out.splitlines() if line.startswith("f") and line[1:].isdigit())
+            return fd_count
+        except Exception:
+            return -1
+else:
+
+    def get_fdcount() -> int:
+        try:
+            # -1 because the listdir call itself opens an fd
+            return len(os.listdir("/proc/self/fd")) - 1
+        except FileNotFoundError:
+            return -1

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -36,7 +36,7 @@ from cascade.executor.runner.setup import RunnerContext, WorkerSetup, load_runne
 from cascade.low.core import DatasetId, TaskId, WorkerId, type_dec
 from cascade.low.exceptions import CascadeError, CascadeInfrastructureError, CascadeInternalError, CascadeUserError, ser
 from cascade.low.tracing import label
-from cascade.ygg.transport import destroy_context, get_context
+from cascade.ygg.transport import ensure_clean_zmq_state, get_context
 
 logger = logging.getLogger(__name__ if __name__ != "__main__" else "cascade.executor.runner.entrypoint")
 
@@ -149,7 +149,7 @@ def execute_sequence(
 def entrypoint(workerSetup: WorkerSetup, runnerContext: RunnerContext) -> None:
     """Main runner loop for a worker process."""
     init_from_obj(runnerContext.loggingConfig, f"worker_{workerSetup.workerId.worker}")
-    destroy_context()
+    ensure_clean_zmq_state()
     ctx = get_context()
     socket = ctx.socket(zmq.PULL)
     address = worker_address(workerSetup.workerId, workerSetup.workerAttemptCnt)

--- a/src/cascade/executor/runner/entrypoint.py
+++ b/src/cascade/executor/runner/entrypoint.py
@@ -157,6 +157,7 @@ def entrypoint(workerSetup: WorkerSetup, runnerContext: RunnerContext) -> None:
     socket.bind(address)
     callback(runnerContext.callback, WorkerReady(workerSetup.workerId))
     logger.debug(f"worker {workerSetup.workerId} sent WorkerReady")
+
     with (
         Memory(runnerContext.callback, workerSetup.workerId) as memory,
         PackagesEnv({k: Version(v) for k, v in workerSetup.initial_installed.items()}, runnerContext.pip_indices) as pckg,
@@ -222,4 +223,5 @@ if __name__ == "__main__":
     _setup_str = os.environ[WORKER_SETUP_ENVVAR]
     _worker_setup = WorkerSetup.from_str(_setup_str)
     _runner_ctx = load_runner_ctx_from_shm(_worker_setup.shm_key)
+
     entrypoint(_worker_setup, _runner_ctx)

--- a/src/cascade/executor/runner/runner.py
+++ b/src/cascade/executor/runner/runner.py
@@ -41,19 +41,12 @@ class ExecutionContext:
     publish: set[DatasetId]
 
 
-# NOTE we guard this because on macos the get_fdcount can take time
-# (TODO actually measure it... on linux its negligible)
-is_debug_perf = os.environ.get("CASCADE_DEBUG_PERF") == "1"
-
-
 def run(taskId: TaskId, executionContext: ExecutionContext, memory: Memory) -> None:
     label("task", taskId)
     start = perf_counter_ns()
     task = executionContext.tasks[taskId]
     mark({"task": taskId, "action": TaskLifecycle.started})
     logger.debug(f"starting {taskId}")
-    if is_debug_perf:
-        logger.debug(f"before executing {taskId=}, we have {get_fdcount()=}")
 
     # prepare func & inputs
     func: Callable
@@ -144,5 +137,3 @@ def run(taskId: TaskId, executionContext: ExecutionContext, memory: Memory) -> N
     trace(Microtrace.wrk_publish, end - run_end)
     logger.debug(f"post elapsed {(end - run_end) / 1e9: .5f} s in {taskId}")
     clear_label("task")
-    if is_debug_perf:
-        logger.debug(f"after executing {taskId=}, we have {get_fdcount()=}")

--- a/src/cascade/executor/runner/runner.py
+++ b/src/cascade/executor/runner/runner.py
@@ -12,12 +12,14 @@ Just io handling (ie, using Memory api), tracing and callable invocation
 """
 
 import logging
+import os
 from collections.abc import Generator
 from dataclasses import dataclass
 from time import perf_counter_ns
 from typing import Any, Callable
 
 from cascade.executor.msg import BackboneAddress
+from cascade.executor.platform import get_fdcount
 from cascade.executor.runner.memory import Memory
 from cascade.low.core import DatasetId, TaskDefinition, TaskId, TaskInstance
 from cascade.low.exceptions import CascadeError, CascadeInternalError, CascadeUserError
@@ -39,12 +41,19 @@ class ExecutionContext:
     publish: set[DatasetId]
 
 
+# NOTE we guard this because on macos the get_fdcount can take time
+# (TODO actually measure it... on linux its negligible)
+is_debug_perf = os.environ.get("CASCADE_DEBUG_PERF") == "1"
+
+
 def run(taskId: TaskId, executionContext: ExecutionContext, memory: Memory) -> None:
     label("task", taskId)
     start = perf_counter_ns()
     task = executionContext.tasks[taskId]
     mark({"task": taskId, "action": TaskLifecycle.started})
     logger.debug(f"starting {taskId}")
+    if is_debug_perf:
+        logger.debug(f"before executing {taskId=}, we have {get_fdcount()=}")
 
     # prepare func & inputs
     func: Callable
@@ -135,3 +144,5 @@ def run(taskId: TaskId, executionContext: ExecutionContext, memory: Memory) -> N
     trace(Microtrace.wrk_publish, end - run_end)
     logger.debug(f"post elapsed {(end - run_end) / 1e9: .5f} s in {taskId}")
     clear_label("task")
+    if is_debug_perf:
+        logger.debug(f"after executing {taskId=}, we have {get_fdcount()=}")

--- a/src/cascade/executor/runner/setup.py
+++ b/src/cascade/executor/runner/setup.py
@@ -219,6 +219,8 @@ def save_runner_ctx_to_shm(ctx: RunnerContext, key: str) -> SharedMemory:
         # this should not happen thanks to uuid, but if it does we handle gracefully
         logger.error(f"runner ctx shm {key!r} already existed; deleting and recreating")
         _old = SharedMemory(key, create=False)
+        if _old.buf is not None:
+            _old.buf.release()
         _old.unlink()
         _old.close()
         if sys.platform == "darwin":
@@ -237,8 +239,10 @@ def load_runner_ctx_from_shm(key: str) -> RunnerContext:
     shm = SharedMemory(key, create=False)
     assert shm.buf is not None
     data = bytes(shm.buf[: shm.size])
+    loaded = cloudpickle.loads(data)
+    shm.buf.release()
     shm.close()
-    return cloudpickle.loads(data)
+    return loaded
 
 
 def create_venv(pip_indices: Iterable[str]) -> tuple[tempfile.TemporaryDirectory[str], dict[str, str]]:

--- a/src/cascade/shm/client.py
+++ b/src/cascade/shm/client.py
@@ -70,6 +70,8 @@ class AllocatedBuffer:
 
     def close(self) -> None:
         if hasattr(self, "shm") and self.shm is not None:
+            if self.shm.buf is not None:
+                self.shm.buf.release()
             self.shm.close()
             if self.close_callback:
                 self.close_callback()

--- a/src/cascade/shm/client.py
+++ b/src/cascade/shm/client.py
@@ -97,11 +97,13 @@ def _send_command(comm: api.Comm, resp_class: Type[T], timeout_sec: float = 60.0
     # eventually this busy-waits will go away as we switch to event driven behaviour
     while timeout_sec > 0:
         sock = api.get_client_socket()
-        logger.debug(f"sending message {comm}")
-        sock.send(api.ser(comm))
-        # TODO rewrite to poller with timeout
-        response_raw = sock.recv(1024)  # TODO or recv(4) + recv(int.from_bytes)?
-        sock.close()
+        try:
+            logger.debug(f"sending message {comm}")
+            sock.send(api.ser(comm))
+            # TODO rewrite to poller with timeout
+            response_raw = sock.recv(1024)  # TODO or recv(4) + recv(int.from_bytes)?
+        finally:
+            sock.close()
         response_com = api.deser(response_raw)
         logger.debug(f"received response {response_com}")
         # NOTE we first check for presence of error, and only then for Type,

--- a/src/cascade/shm/disk.py
+++ b/src/cascade/shm/disk.py
@@ -38,6 +38,7 @@ class Disk:
                         break
                     shm.buf[i : i + l] = b
                     i += l
+            shm.buf.release()
             shm.close()
             # TODO eleminate in favour of track=False, once we are on python 3.13+
             multiprocessing.resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore # _name
@@ -56,6 +57,7 @@ class Disk:
             assert shm.buf is not None
             with open(f"{self.root.name}/{shmid}", "wb") as f:
                 f.write(shm.buf[:])
+            shm.buf.release()
             shm.unlink()
             shm.close()
         except Exception:

--- a/src/cascade/shm/server.py
+++ b/src/cascade/shm/server.py
@@ -107,6 +107,10 @@ class LocalServer:
                 response = api.OkResponse(error=repr(e))
             logger.debug(f"sending {response=} to {client}")
             self.respond(response, client)
+            # NOTE close accepted socket after responding; for SOCK_STREAM each accept()
+            # creates a new fd that must be explicitly closed or it leaks on the server side
+            if isinstance(client, socket.socket):
+                client.close()
 
 
 def entrypoint(

--- a/src/cascade/ygg/transport.py
+++ b/src/cascade/ygg/transport.py
@@ -31,9 +31,34 @@ def destroy_context() -> None:
     a remnant of parent's zmq context, therefore it is imperative to
     destoy it. Additionally, in tests the context may be left in
     an unpractical state, requiring a delete at the start"""
+    # Close cached callback sockets before destroying the context they belong to
+    if hasattr(_local, "callback_sockets"):
+        for sock in _local.callback_sockets.values():
+            sock.close(linger=0)
+        del _local.callback_sockets
     if hasattr(_local, "context"):
         _local.context.destroy(linger=0)
         del _local.context
+
+
+def get_callback_socket(address: str, linger_ms: int) -> zmq.Socket:
+    """Return a cached thread-local PUSH socket for the given address.
+
+    Using a persistent socket per destination avoids the open/LINGER/close cycle
+    that would accumulate OS file descriptors when sending many short messages.
+    ZMQ's IO thread holds the underlying transport fd alive for ``linger_ms`` after
+    each close(), so creating a new socket per callback() call leads to hundreds of
+    lingering fds at any given time.
+    """
+    if not hasattr(_local, "callback_sockets"):
+        _local.callback_sockets = {}
+    sock: zmq.Socket | None = _local.callback_sockets.get(address)
+    if sock is None or sock.closed:
+        sock = get_context().socket(zmq.PUSH)
+        sock.set(zmq.LINGER, linger_ms)
+        sock.connect(address)
+        _local.callback_sockets[address] = sock
+    return sock
 
 
 class OutboundTransport:

--- a/src/cascade/ygg/transport.py
+++ b/src/cascade/ygg/transport.py
@@ -26,11 +26,14 @@ def get_context() -> zmq.Context:
     return _local.context
 
 
-def destroy_context() -> None:
+def ensure_clean_zmq_state() -> None:
     """When a process has potentially started via a fork, there may be
     a remnant of parent's zmq context, therefore it is imperative to
     destoy it. Additionally, in tests the context may be left in
     an unpractical state, requiring a delete at the start"""
+    # NOTE this is not intended as a general purpose teardown method, rather,
+    # its a startup method. Teardown via atexit register would be at odds
+    # with the storage being thread local
     # Close cached callback sockets before destroying the context they belong to
     if hasattr(_local, "callback_sockets"):
         for sock in _local.callback_sockets.values():
@@ -50,6 +53,12 @@ def get_callback_socket(address: str, linger_ms: int) -> zmq.Socket:
     each close(), so creating a new socket per callback() call leads to hundreds of
     lingering fds at any given time.
     """
+    # NOTE this has a slight downside that we never close the sockets until
+    # the program finishes. We expect the number of sockets to be bound,
+    # as the hosts are static. If this ever ceases to be true, introduce some
+    # ttl and eviction here
+    # NOTE ideally, this whole method gets refactored into OutboundTransport,
+    # to have a unified persistent socket management
     if not hasattr(_local, "callback_sockets"):
         _local.callback_sockets = {}
     sock: zmq.Socket | None = _local.callback_sockets.get(address)

--- a/src/earthkit/workflows/__init__.py
+++ b/src/earthkit/workflows/__init__.py
@@ -8,8 +8,6 @@
 
 import pkgutil
 
-import dill
-
 __path__ = pkgutil.extend_path(__path__, __name__)
 
 try:
@@ -33,17 +31,6 @@ class Cascade:
         for action in actions:
             graph += action.graph()
         return cls(deduplicate_nodes(graph))
-
-    @classmethod
-    def from_serialised(cls, filename: str):
-        with open(filename, "rb") as f:
-            data = dill.load(f)
-            return cls(deserialise(data))
-
-    def serialise(self, filename: str):
-        data = serialise(self._graph)
-        with open(filename, "wb") as f:
-            dill.dump(data, f)
 
     def visualise(self, *args, **kwargs):
         return _visualise_fn(self._graph, *args, **kwargs)

--- a/tests/cascade/controller/test_run.py
+++ b/tests/cascade/controller/test_run.py
@@ -33,7 +33,7 @@ from cascade.low.builders import JobBuilder, TaskBuilder
 from cascade.low.core import CheckpointSpec, DatasetId, HostId, JobInstance, JobInstanceRich, StorageId, TaskId
 from cascade.scheduler.core import Preschedule
 from cascade.scheduler.precompute import precompute
-from cascade.ygg.transport import destroy_context
+from cascade.ygg.transport import ensure_clean_zmq_state
 
 # see the comment above
 run_all_tests = int(os.environ.get("RUN_ALL_TESTS", "0")) == 1
@@ -75,7 +75,7 @@ def run_cluster(
     # TODO rework the port assignemnt in this whole file -- we waste a lot. Note if there
     # is a port overlap, it causes *very unpleasant* interference, even when the tests
     # are executed sequentially
-    destroy_context()
+    ensure_clean_zmq_state()
     if not preschedule:
         preschedule = precompute(job.jobInstance)
     c = f"tcp://localhost:{portBase}"

--- a/tests/cascade/executor/test_executor.py
+++ b/tests/cascade/executor/test_executor.py
@@ -49,14 +49,14 @@ from cascade.low.core import (
     TaskInstance,
     WorkerId,
 )
-from cascade.ygg.transport import destroy_context
+from cascade.ygg.transport import ensure_clean_zmq_state
 
 logger = logging.getLogger(__name__)
 
 
 def launch_executor(job_instance: JobInstance, controller_address: BackboneAddress, portBase: int, test_name: str):
     dictConfig(logging_config)
-    destroy_context()
+    ensure_clean_zmq_state()
     executor = Executor(
         JobInstanceRich(jobInstance=job_instance, checkpointSpec=None),
         controller_address,

--- a/tests/cascade/gateway/test_run.py
+++ b/tests/cascade/gateway/test_run.py
@@ -10,7 +10,7 @@ from cascade.gateway.api import LocalProcesses
 from cascade.gateway.server import serve
 from cascade.low.builders import JobBuilder
 from cascade.low.core import DatasetId, JobInstanceRich, TaskDefinition, TaskId, TaskInstance
-from cascade.ygg.transport import destroy_context
+from cascade.ygg.transport import ensure_clean_zmq_state
 
 init_value = 10
 job_func = lambda i: i * 2
@@ -89,7 +89,7 @@ def spawn_gateway(
 
 @pytest.mark.concurrency_filelock("conflictInExecutorHostname")
 def test_job():
-    destroy_context()
+    ensure_clean_zmq_state()
     url, gw = spawn_gateway(1, max_jobs_history=2)
     try:
         # succ job

--- a/tests/cascade/ygg/test_api.py
+++ b/tests/cascade/ygg/test_api.py
@@ -4,12 +4,12 @@ import pytest
 
 from cascade.low.exceptions import CascadeInternalError
 from cascade.ygg.api import YggNode
-from cascade.ygg.transport import destroy_context
+from cascade.ygg.transport import ensure_clean_zmq_state
 from cascade.ygg.types import HostEndpoints, RetryPolicy, YggConfig
 
 
 def test_control_send_receive_ack() -> None:
-    destroy_context()
+    ensure_clean_zmq_state()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -35,7 +35,7 @@ def test_control_send_receive_ack() -> None:
 
 
 def test_bulk_send_receive() -> None:
-    destroy_context()
+    ensure_clean_zmq_state()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -62,7 +62,7 @@ def test_bulk_send_receive() -> None:
 
 
 def test_control_best_effort_no_syn_ack() -> None:
-    destroy_context()
+    ensure_clean_zmq_state()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -88,7 +88,7 @@ def test_control_best_effort_no_syn_ack() -> None:
 
 
 def test_control_default_delivery_from_config_best_effort() -> None:
-    destroy_context()
+    ensure_clean_zmq_state()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -113,7 +113,7 @@ def test_control_default_delivery_from_config_best_effort() -> None:
 
 
 def test_deduplicates_retries_for_same_syn() -> None:
-    destroy_context()
+    ensure_clean_zmq_state()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=5, max_retries=4),
         bulk=RetryPolicy(retry_interval_ms=5, max_retries=2),
@@ -142,7 +142,7 @@ def test_deduplicates_retries_for_same_syn() -> None:
 
 def test_forget_sender_clears_dedup_cache() -> None:
     """Test that forget_sender removes dedup entries for a specific address."""
-    destroy_context()
+    ensure_clean_zmq_state()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -162,7 +162,7 @@ def test_forget_sender_clears_dedup_cache() -> None:
 
 def test_unregister_host_purges_dedup_for_both_lanes() -> None:
     """Test that unregister_host clears dedup entries for both endpoints."""
-    destroy_context()
+    ensure_clean_zmq_state()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -197,7 +197,7 @@ def test_unregister_host_purges_dedup_for_both_lanes() -> None:
 
 
 def test_close_waits_for_pending_ack() -> None:
-    destroy_context()
+    ensure_clean_zmq_state()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -220,7 +220,7 @@ def test_close_waits_for_pending_ack() -> None:
 
 
 def test_close_logs_remaining_inflight_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
-    destroy_context()
+    ensure_clean_zmq_state()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=10, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=10, max_retries=3),
@@ -246,7 +246,7 @@ def test_close_logs_remaining_inflight_on_timeout(monkeypatch: pytest.MonkeyPatc
 
 
 def test_close_polls_then_retries_until_inflight_clears(monkeypatch: pytest.MonkeyPatch) -> None:
-    destroy_context()
+    ensure_clean_zmq_state()
     config = YggConfig(
         control=RetryPolicy(retry_interval_ms=25, max_retries=3),
         bulk=RetryPolicy(retry_interval_ms=25, max_retries=3),

--- a/tests/earthkit_workflows/test_fluent.py
+++ b/tests/earthkit_workflows/test_fluent.py
@@ -8,7 +8,6 @@
 
 import functools
 
-import dill
 import numpy as np
 import pytest
 
@@ -230,19 +229,6 @@ def test_attributes():
     # Set attributes global to all nodes
     action.add_attributes({"expver": "0001"})
     assert action.nodes.attrs["expver"] == "0001"
-
-
-@pytest.mark.skip("Serialisation not supported due to sinks with outputs")
-def test_serialisation(tmpdir, task_graph):
-    assert len(task_graph.sinks) > 0
-    data = serialise(task_graph)
-    with open(f"{tmpdir}/graph.dill", "wb") as f:
-        dill.dump(data, f)
-
-    with open(f"{tmpdir}/graph.dill", "rb") as f:
-        read_data = dill.load(f)
-    new_graph = deserialise(read_data)
-    assert len(task_graph.sinks) == len(new_graph.sinks)
 
 
 def test_invalid_registration():

--- a/uv.lock
+++ b/uv.lock
@@ -432,11 +432,11 @@ distributed = [
 
 [[package]]
 name = "decorator"
-version = "5.2.1"
+version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
 ]
 
 [[package]]
@@ -449,15 +449,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
-]
-
-[[package]]
-name = "dill"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
 ]
 
 [[package]]
@@ -547,15 +538,12 @@ source = { editable = "." }
 dependencies = [
     { name = "array-api-compat" },
     { name = "cloudpickle" },
-    { name = "dill" },
     { name = "earthkit-data" },
     { name = "fire" },
-    { name = "networkx" },
     { name = "numpy" },
     { name = "orjson" },
     { name = "pydantic" },
     { name = "pyrsistent" },
-    { name = "pyvis" },
     { name = "pyzmq" },
     { name = "qubed" },
     { name = "sortedcontainers" },
@@ -565,6 +553,10 @@ dependencies = [
 [package.optional-dependencies]
 dask = [
     { name = "dask", extra = ["distributed"] },
+]
+vizualize = [
+    { name = "networkx" },
+    { name = "pyvis" },
 ]
 
 [package.dev-dependencies]
@@ -582,21 +574,20 @@ requires-dist = [
     { name = "array-api-compat" },
     { name = "cloudpickle" },
     { name = "dask", extras = ["distributed"], marker = "extra == 'dask'", specifier = ">=2026.1.2" },
-    { name = "dill" },
     { name = "earthkit-data" },
     { name = "fire" },
-    { name = "networkx" },
+    { name = "networkx", marker = "extra == 'vizualize'" },
     { name = "numpy" },
     { name = "orjson" },
     { name = "pydantic" },
     { name = "pyrsistent" },
-    { name = "pyvis" },
+    { name = "pyvis", marker = "extra == 'vizualize'" },
     { name = "pyzmq" },
     { name = "qubed", specifier = ">=0.3.0" },
     { name = "sortedcontainers" },
     { name = "xarray" },
 ]
-provides-extras = ["dask"]
+provides-extras = ["vizualize", "dask"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -766,7 +757,7 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "9.10.0"
+version = "9.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -776,14 +767,15 @@ dependencies = [
     { name = "matplotlib-inline" },
     { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
     { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'emscripten'" },
     { name = "pygments" },
     { name = "stack-data" },
     { name = "traitlets" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/aa/898dec789a05731cd5a9f50605b7b44a72bd198fd0d4528e11fc610177cc/ipython-9.10.0-py3-none-any.whl", hash = "sha256:c6ab68cc23bba8c7e18e9b932797014cc61ea7fd6f19de180ab9ba73e65ee58d", size = 622774, upload-time = "2026-02-02T10:00:31.503Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/22/58818a63eaf8982b67632b1bc20585c811611b15a8da19d6012323dc76a5/ipython-9.14.1-py3-none-any.whl", hash = "sha256:5d4a9ecaa3b10e6e5f269dd0948bdb58ca9cb851899cd23e07c320d3eb11613c", size = 627770, upload-time = "2026-06-05T08:12:33.045Z" },
 ]
 
 [[package]]
@@ -800,14 +792,14 @@ wheels = [
 
 [[package]]
 name = "jedi"
-version = "0.19.2"
+version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "parso" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
 ]
 
 [[package]]
@@ -824,11 +816,11 @@ wheels = [
 
 [[package]]
 name = "jsonpickle"
-version = "4.1.1"
+version = "4.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/a6/d07afcfdef402900229bcca795f80506b207af13a838d4d99ad45abf530c/jsonpickle-4.1.1.tar.gz", hash = "sha256:f86e18f13e2b96c1c1eede0b7b90095bbb61d99fedc14813c44dc2f361dbbae1", size = 316885, upload-time = "2025-06-02T20:36:11.57Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/c0/dde9b4b42cc415b9579573f967f12efbb034e427a2a37e93ad5139891d87/jsonpickle-4.1.2.tar.gz", hash = "sha256:8afed18aa189fd81e2e833b426bb4af485594921f0b1d36c2001fc5637a2f210", size = 319120, upload-time = "2026-05-28T03:50:11.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/73/04df8a6fa66d43a9fd45c30f283cc4afff17da671886e451d52af60bdc7e/jsonpickle-4.1.1-py3-none-any.whl", hash = "sha256:bb141da6057898aa2438ff268362b126826c812a1721e31cf08a6e142910dc91", size = 47125, upload-time = "2025-06-02T20:36:08.647Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/7b/fd3c7a09649aea9da1d3587aea624d8f9b29963dfd84a1bdb2aa93b36dac/jsonpickle-4.1.2-py3-none-any.whl", hash = "sha256:7ffe34426bc797684dbf1dc84185558bd864cd25b1ff5fb01b7405e392d0a937", size = 47203, upload-time = "2026-05-28T03:50:10.605Z" },
 ]
 
 [[package]]
@@ -1028,14 +1020,14 @@ wheels = [
 
 [[package]]
 name = "matplotlib-inline"
-version = "0.2.1"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
 ]
 
 [[package]]
@@ -1380,11 +1372,11 @@ wheels = [
 
 [[package]]
 name = "parso"
-version = "0.8.6"
+version = "0.8.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
 ]
 
 [[package]]
@@ -2304,11 +2296,11 @@ wheels = [
 
 [[package]]
 name = "traitlets"
-version = "5.14.3"
+version = "5.15.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/a9/a2584b8313b89f94869ddb3c4074617a691de1812a614d2d50e32ca5a7a6/traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722", size = 163344, upload-time = "2026-06-03T12:26:06.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+    { url = "https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92", size = 85858, upload-time = "2026-06-03T12:26:04.395Z" },
 ]
 
 [[package]]
@@ -2377,11 +2369,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.6.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
1/ Adds a new integration test which runs a lot of grib writing
2/ Fixes a bug where jobSpec's envvars were not propagated in local runs
3/ Adds explicit `.release()` calls to shm buffers -- intended as an assertion that there is no leaking memory pointer
4/ Caches sockets used in executor callbacks and data sends, to prevent fd leakage
5/ fixes missing socket close in shm server
6/ Removes dill code and dependency -- not needed
7/ Moves pyvis and networkx dependencies to optional -- not needed at runtime, and they create a lot of files during install, putting a pressure on io