### PR TITLE
[ekw.graph] Move node metadata from `fluent.Node` to `graph.nodes.Node`

### DIFF
--- a/src/earthkit/workflows/fluent.py
+++ b/src/earthkit/workflows/fluent.py
@@ -228,9 +228,9 @@ class Node(BaseNode):
             name,
             outputs=node_outputs,
             payload=task,
+            metadata=metadata,
             **node_inputs,
         )
-        self.metadata: NodeMetadata = metadata
 
     def __str__(self) -> str:
         return f"Node {self.name}, inputs: {[x.parent.name for x in self.inputs.values()]}, payload: {self.payload}"

--- a/src/earthkit/workflows/graph/expand.py
+++ b/src/earthkit/workflows/graph/expand.py
@@ -157,7 +157,7 @@ class Splicer(Transformer):
         Node
             Replacement for the sink
         """
-        return Node(name, outputs=None, payload=s.payload, **inputs)
+        return Node(name, outputs=None, payload=s.payload, metadata=s.metadata, **inputs)
 
 
 ExpanderType = Callable[[Node], Graph | tuple[Graph, dict[str, str] | None, dict[str, str | None]] | None]

--- a/src/earthkit/workflows/graph/export.py
+++ b/src/earthkit/workflows/graph/export.py
@@ -10,6 +10,8 @@ import graphlib
 import json
 from typing import Any, Protocol
 
+from earthkit.workflows.metadata import NodeMetadata
+
 from .graph import Graph
 from .nodes import Node, Output
 
@@ -19,12 +21,12 @@ class NodeFactory(Protocol):
         pass
 
 
-def default_node_factory(name: str, outputs: list[str], payload: Any, **inputs: Output) -> Node:
+def default_node_factory(name: str, outputs: list[str], payload: Any, metadata: NodeMetadata | None = None, **inputs: Output) -> Node:
     # NOTE this logic is rather fragile; necessary due to the existence of default output. Remove it and simplify here
     if not outputs:
-        return Node(name, payload=payload, outputs=[], **inputs)
+        return Node(name, payload=payload, outputs=[], metadata=metadata, **inputs)
     else:
-        return Node(name, outputs, payload, **inputs)
+        return Node(name, outputs, payload, metadata=metadata, **inputs)
 
 
 def _deserialise_node(

--- a/src/earthkit/workflows/graph/nodes.py
+++ b/src/earthkit/workflows/graph/nodes.py
@@ -11,6 +11,7 @@ from typing import Any
 from typing_extensions import Self
 
 from earthkit.workflows.adapters import DefaultNodeOutput
+from earthkit.workflows.metadata import NodeMetadata
 
 
 class Output:
@@ -63,6 +64,8 @@ class Node:
         default output
     payload: Any
         Node payload
+    metadata: NodeMetadata | None
+        Node metadata, by default None
     **inputs: Node | Output
         Node outputs to use as inputs. If a `Node` object is passed, the input
         will be connected to its default output.
@@ -74,17 +77,20 @@ class Node:
     inputs: dict[str, Output]
     outputs: list[str]
     payload: Any
+    metadata: NodeMetadata
 
     def __init__(
         self,
         name: str,
         outputs: list[str] | None = None,
         payload: Any = None,
+        metadata: NodeMetadata | None = None,
         **kwargs: "Node | Output",  # NOTE can't declare Self due to children. Fix hiearchy instead
     ):
         self.name = name
         self.outputs = [Node.DEFAULT_OUTPUT] if outputs is None else outputs
         self.payload = payload
+        self.metadata = metadata or NodeMetadata()
         self.inputs = {iname: (inp if isinstance(inp, Output) else inp.get_output()) for iname, inp in kwargs.items()}
 
     def __getattr__(self, name: str) -> Output:
@@ -142,4 +148,4 @@ class Node:
 
     def copy(self) -> Self:
         """Shallow copy of the node (the payload is not copied)"""
-        return self.__class__(self.name, self.outputs.copy(), self.payload, **self.inputs)
+        return self.__class__(self.name, self.outputs.copy(), self.payload, metadata=self.metadata, **self.inputs)

--- a/src/earthkit/workflows/graph/samplegraphs.py
+++ b/src/earthkit/workflows/graph/samplegraphs.py
@@ -59,7 +59,7 @@ def simple(nread: int = 5, nproc: int = 3) -> Graph:
     ws = []
     for i in range(nproc):
         pi = {f"input{j}": r for j, r in enumerate(rs)}
-        p = Node(f"process-{i}", outputs=None, payload=None, **pi)
+        p = Node(f"process-{i}", outputs=None, payload=None, metadata=None, **pi)
         ps.append(p)
         ws.append(Node(f"writer-{i}", outputs=[], input=p))
     return Graph(ws)
@@ -80,7 +80,7 @@ def multi(nread: int = 5, nout1: int = 3, nout2: int = 2) -> Graph:
     assert nout1 >= 3
     rs = [Node(f"reader-{i}") for i in range(nread)]
     p0i = {f"input{i}": r for i, r in enumerate(rs)}
-    p0 = Node("process-0", outputs=[f"output{i}" for i in range(nout1)], **p0i)
+    p0 = Node("process-0", outputs=[f"output{i}" for i in range(nout1)], metadata=None, **p0i)
     p1s = []
     for i in range(2, nout1):
         p = Node(f"process-{i - 1}", input1=p0.output0, input2=p0.get_output(f"output{i}"))

--- a/src/earthkit/workflows/taskgraph.py
+++ b/src/earthkit/workflows/taskgraph.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Iterator, cast
 from typing_extensions import Self
 
 from .graph import Graph, Node, Output
+from .metadata import NodeMetadata
 from .utility import predecessors
 
 
@@ -36,10 +37,11 @@ class Task(Node):
         name: str,
         outputs: list[str] | None = None,
         payload: Any = None,
+        metadata: NodeMetadata | None = None,
         resources: Resources | None = None,
         **kwargs: Self | Output,
     ):
-        super().__init__(name, outputs, payload, **kwargs)
+        super().__init__(name, outputs, payload, metadata=metadata, **kwargs)
         if resources is None:
             resources = Resources()
         self.resources = resources
@@ -70,7 +72,7 @@ class Task(Node):
         self.resources.cpu_cycles = value
 
     def copy(self) -> "Task":
-        newnode = Task(self.name, self.outputs.copy(), self.payload, self.resources, **self.inputs)
+        newnode = Task(self.name, self.outputs.copy(), self.payload, self.metadata, self.resources, **self.inputs)
         return newnode
 
 

--- a/tests/earthkit_workflows/graph/test_fuse.py
+++ b/tests/earthkit_workflows/graph/test_fuse.py
@@ -32,7 +32,7 @@ def fuse_linear(parent: Node, pout: str, child: Node, cin: str) -> Node | None:
         payload.extend(parent.payload)
     payload.append(child.name)
     print(f"Fuse {parent.name} ({parent.payload}) with {child.name} -> {payload}")
-    return Node(f"{parent.name}+{child.name}", child.outputs, payload=payload, **parent.inputs)
+    return Node(f"{parent.name}+{child.name}", child.outputs, payload=payload, metadata=None, **parent.inputs)
 
 
 def test_fuse_linear():

--- a/tests/earthkit_workflows/graph/test_graph.py
+++ b/tests/earthkit_workflows/graph/test_graph.py
@@ -77,6 +77,7 @@ class NameMangler(Transformer):
         return Node(
             self.mangle_name(processor.name),
             [self.mangle_output(out) for out in processor.outputs],
+            metadata=processor.metadata,
             **{self.mangle_input(iname): isrc for iname, isrc in inputs.items()},
         )
 
@@ -84,6 +85,7 @@ class NameMangler(Transformer):
         return Node(
             self.mangle_name(sink.name),
             outputs=[],
+            metadata=sink.metadata,
             **{self.mangle_input(iname): isrc for iname, isrc in inputs.items()},
         )
 


### PR DESCRIPTION
### Description
Move node metadata (capturing execution requirements and graph construction metadata) down to underlying `ekw.graph.nodes.Node` so that metadata is available in `ekw.graph.Graph`.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
